### PR TITLE
fix: RN 0.85 compat — remove absoluteFillObject, update test expectations

### DIFF
--- a/apps/desktop/src/__tests__/integration-live.test.ts
+++ b/apps/desktop/src/__tests__/integration-live.test.ts
@@ -142,15 +142,15 @@ describe.runIf(serverAvailable)('mDNS advertisement (mobile discovery)', () => {
 });
 
 describe.runIf(serverAvailable)('approval endpoints (mobile approve/reject flow)', () => {
-  it('GET /api/approvals/:userId/pending returns list (may need DB)', async () => {
+  it('GET /api/approvals/:userId/pending returns list (may need DB or auth)', async () => {
     const res = await fetch(`${API_BASE}/api/approvals/test-user-1/pending`);
     if (res.ok) {
       const body = await res.json() as Record<string, unknown>;
       expect(body).toHaveProperty('approvals');
       expect(Array.isArray((body as { approvals: unknown[] }).approvals)).toBe(true);
     } else {
-      // DB not available — verify it's a server error
-      expect(res.status).toBeGreaterThanOrEqual(500);
+      // 401 (auth required), 403 (ownership), or 500+ (DB not available)
+      expect(res.status).toBeGreaterThanOrEqual(400);
     }
   });
 
@@ -176,13 +176,14 @@ describe.runIf(serverAvailable)('approval endpoints (mobile approve/reject flow)
 });
 
 describe.runIf(serverAvailable)('decision history (mobile dashboard)', () => {
-  it('GET /api/decisions/:userId returns list (may need DB)', async () => {
+  it('GET /api/decisions/:userId returns list (may need DB or auth)', async () => {
     const res = await fetch(`${API_BASE}/api/decisions/test-user-1`);
     if (res.ok) {
       const body = await res.json() as Record<string, unknown>;
       expect(body).toHaveProperty('decisions');
     } else {
-      expect(res.status).toBeGreaterThanOrEqual(500);
+      // 401 (auth required), 403 (ownership), or 500+ (DB not available)
+      expect(res.status).toBeGreaterThanOrEqual(400);
     }
   });
 
@@ -199,29 +200,31 @@ describe.runIf(serverAvailable)('decision history (mobile dashboard)', () => {
 });
 
 describe.runIf(serverAvailable)('twin profile (mobile dashboard)', () => {
-  it('GET /api/twin/:userId returns profile (may need DB)', async () => {
+  it('GET /api/twin/:userId returns profile (may need DB or auth)', async () => {
     const res = await fetch(`${API_BASE}/api/twin/test-user-1`);
     if (res.ok) {
       const body = await res.json() as Record<string, unknown>;
       expect(body).toHaveProperty('profile');
     } else {
+      // 401 (auth required), 403 (ownership), or 500+ (DB not available)
       expect(res.status).toBeGreaterThanOrEqual(400);
     }
   });
 });
 
 describe.runIf(serverAvailable)('policies endpoint (engine gaps feature)', () => {
-  it('GET /api/policies/:userId responds (may need DB)', async () => {
+  it('GET /api/policies/:userId responds (may need DB or auth)', async () => {
     const res = await fetch(`${API_BASE}/api/policies/test-user-1`);
-    // 200 (with data), 500 (DB not available) — route exists either way
-    expect([200, 500, 502, 503]).toContain(res.status);
+    // 200 (with data), 401/403 (auth/ownership), 500+ (DB not available)
+    expect([200, 401, 403, 500, 502, 503]).toContain(res.status);
   });
 });
 
 describe.runIf(serverAvailable)('audit endpoint (dashboard feature)', () => {
-  it('GET /api/audit/:userId responds (may need DB)', async () => {
+  it('GET /api/audit/:userId responds (may need DB or auth)', async () => {
     const res = await fetch(`${API_BASE}/api/audit/test-user-1`);
-    expect([200, 500, 502, 503]).toContain(res.status);
+    // 200 (with data), 401/403 (auth/ownership), 500+ (DB not available)
+    expect([200, 401, 403, 500, 502, 503]).toContain(res.status);
   });
 });
 

--- a/apps/mobile/src/screens/ApprovalsScreen.tsx
+++ b/apps/mobile/src/screens/ApprovalsScreen.tsx
@@ -476,7 +476,11 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   swipeBackground: {
-    ...StyleSheet.absoluteFillObject,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',

--- a/apps/mobile/src/screens/PairingScreen.tsx
+++ b/apps/mobile/src/screens/PairingScreen.tsx
@@ -369,7 +369,11 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scanOverlay: {
-    ...StyleSheet.absoluteFillObject,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
     alignItems: 'center',
     justifyContent: 'center',
   },


### PR DESCRIPTION
## Summary

Prepares the codebase for merging #48 (React Native 0.83.4 → 0.85.0).

- **Remove `StyleSheet.absoluteFillObject`** (removed in RN 0.85) — replaced with explicit `position: 'absolute', top: 0, left: 0, right: 0, bottom: 0` in `PairingScreen` and `ApprovalsScreen`
- **Update desktop integration-live tests** to accept 401/403 responses now that session auth + ownership enforcement are active from #56

## Files changed

| File | Change |
|------|--------|
| `apps/mobile/src/screens/PairingScreen.tsx` | Replace `absoluteFillObject` spread |
| `apps/mobile/src/screens/ApprovalsScreen.tsx` | Replace `absoluteFillObject` spread |
| `apps/desktop/src/__tests__/integration-live.test.ts` | Accept 401/403 in status expectations |

## Test plan

- [x] `pnpm lint` — 30/30 pass
- [x] `pnpm test` — 38/38 pass
- [ ] After merge, merge #48 (RN 0.85 bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)