### PR TITLE
test(safety): lock policy-check-blocks-execution invariant

### DIFF
--- a/apps/api/src/__tests__/events-routes.test.ts
+++ b/apps/api/src/__tests__/events-routes.test.ts
@@ -167,6 +167,39 @@ describe('Events API routes', () => {
     mockExecutionRepository.createResult.mockResolvedValue({});
   });
 
+  it('emits decision:blocked-by-policy when no action was selected (Safety Invariant #1)', async () => {
+    mockEvaluate.mockResolvedValue({
+      autoExecute: false,
+      requiresApproval: false,
+      reasoning: 'All candidates blocked by policy "No travel auto-bookings".',
+      selectedAction: null,
+      allCandidates: [],
+    });
+
+    const res = await request(buildApp(), 'POST', '/api/events/ingest', {
+      userId: 'user-1',
+      source: 'test',
+      type: 'travel_decision',
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockSseManager.emit).toHaveBeenCalledWith(
+      'user-1',
+      'decision:blocked-by-policy',
+      expect.objectContaining({
+        decisionId: 'decision-1',
+        reason: expect.stringContaining('blocked by policy'),
+      }),
+    );
+    // Must not have emitted execution events
+    expect(mockSseManager.emit).not.toHaveBeenCalledWith(
+      'user-1',
+      'decision:executed',
+      expect.anything(),
+    );
+    expect(mockExecutionRepository.createPlan).not.toHaveBeenCalled();
+  });
+
   it('marks the execution plan failed when streaming execution throws before a terminal event', async () => {
     async function* throwingStream() {
       throw new Error('No adapter can handle action type "create_calendar_event"');

--- a/apps/api/src/routes/events.ts
+++ b/apps/api/src/routes/events.ts
@@ -353,6 +353,22 @@ export function createEventsRouter(): Router {
         });
       }
 
+      // Surface "no action taken" outcomes (every candidate blocked, or none
+      // generated) so the user can see why nothing happened. Without this the
+      // event ingest is silent and the policy decision is invisible — Safety
+      // Invariant #1 (every auto-execute path went through a policy check) is
+      // structurally enforced upstream, but the *result* of that check needs
+      // to be observable.
+      if (!outcome.selectedAction && !approvalRequest && !executionResult) {
+        sseManager.emit(userId, 'decision:blocked-by-policy', {
+          decisionId: decision.id,
+          reason: outcome.reasoning,
+          domain: decision.domain,
+          situationType: decision.situationType,
+          urgency: decision.urgency,
+        });
+      }
+
       // 10. Return result
       res.json({
         decision: {

--- a/packages/decision-engine/src/__tests__/decision-maker.test.ts
+++ b/packages/decision-engine/src/__tests__/decision-maker.test.ts
@@ -1098,6 +1098,59 @@ describe('DecisionMaker', () => {
       expect(actionTypes).toContain('create_note');
       expect(actionTypes).toContain('escalate_to_user');
     });
+
+    it('returns no predicted action and no alternatives when policy blocks every candidate', async () => {
+      const twinService = createMockTwinService();
+      const policyEvaluator = createMockPolicyEvaluator({
+        allowed: false,
+        requiresApproval: false,
+        reason: 'All candidates blocked.',
+      });
+      const decisionRepo = createMockDecisionRepository();
+      const dm = new DecisionMaker(
+        twinService as never,
+        policyEvaluator as never,
+        decisionRepo as never,
+      );
+
+      const mockTwinServiceForQuery = {
+        getOrCreateProfile: vi.fn().mockResolvedValue({
+          id: 'twin_test',
+          userId: 'user_test',
+          version: 1,
+          preferences: [],
+          inferences: [],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+        getRelevantPreferences: vi.fn().mockResolvedValue([]),
+        getPatterns: vi.fn().mockResolvedValue([]),
+        getTraits: vi.fn().mockResolvedValue([]),
+        getTemporalProfile: vi.fn().mockResolvedValue({
+          userId: 'user_test',
+          activeHours: { start: 8, end: 22 },
+          peakResponseTimes: {},
+          weekdayPatterns: {},
+          urgencyThresholds: {},
+        }),
+      };
+
+      const response = await dm.whatWouldIDo(
+        'user_test',
+        { situation: 'New email', domain: 'email' },
+        mockTwinServiceForQuery,
+        TrustTier.HIGH_AUTONOMY,
+      );
+
+      // Safety Invariant #1: predict path must not leak blocked candidates
+      expect(response.predictedAction).toBeNull();
+      expect(response.alternativeActions).toEqual([]);
+      expect(response.wouldAutoExecute).toBe(false);
+      expect(response.confidence).toBe(ConfidenceLevel.SPECULATIVE);
+      // policyNotes should surface the blocking reason so the user understands
+      expect(response.policyNotes).toBeDefined();
+      expect(response.policyNotes).toContain('blocked');
+    });
   });
 
   // ── All candidates blocked by policy ──────────────────────────────

--- a/packages/decision-engine/src/decision-maker.ts
+++ b/packages/decision-engine/src/decision-maker.ts
@@ -236,16 +236,24 @@ export class DecisionMaker {
     // Step 3: Evaluate through the standard pipeline
     const outcome = await this.evaluate(context);
 
-    // Step 4: Build WhatWouldIDoResponse
+    // Step 4: Build WhatWouldIDoResponse.
+    // When no candidate was allowed by policy (selectedAction is null), do not
+    // surface the blocked candidates as "alternatives" — that leaks options the
+    // user would not actually be permitted to take. Safety Invariant #1.
+    const alternativeActions = outcome.selectedAction
+      ? outcome.allCandidates.filter((c) => c !== outcome.selectedAction)
+      : [];
+    const policyNotes = outcome.requiresApproval || !outcome.selectedAction
+      ? outcome.reasoning
+      : undefined;
+
     return {
       predictedAction: outcome.selectedAction,
       confidence: outcome.selectedAction?.confidence ?? ConfidenceLevel.SPECULATIVE,
       reasoning: outcome.reasoning,
       wouldAutoExecute: outcome.autoExecute,
-      policyNotes: outcome.requiresApproval ? outcome.reasoning : undefined,
-      alternativeActions: outcome.allCandidates.filter(
-        (c) => c !== outcome.selectedAction,
-      ),
+      policyNotes,
+      alternativeActions,
       predictionId: `pred_${Date.now()}`,
     };
   }

--- a/packages/execution-router/src/__tests__/execution-router.test.ts
+++ b/packages/execution-router/src/__tests__/execution-router.test.ts
@@ -8,7 +8,7 @@ import type {
   RollbackResult,
 } from '@skytwin/shared-types';
 import type { IronClawAdapter } from '@skytwin/ironclaw-adapter';
-import { ExecutionRouter, NoAdapterError } from '../execution-router.js';
+import { ExecutionRouter, NoAdapterError, InvariantViolationError } from '../execution-router.js';
 import {
   AdapterRegistry,
   IRONCLAW_TRUST_PROFILE,
@@ -369,6 +369,56 @@ describe('ExecutionRouter', () => {
       expect(result.status).toBe('failed');
       expect(result.output?.['adapter_used']).toBe('ironclaw');
       expect(result.output?.['fallback_skipped_reason']).toContain('fallback unsafe');
+    });
+  });
+
+  describe('safety invariant guards', () => {
+    let router: ExecutionRouter;
+
+    beforeEach(() => {
+      const registry = new AdapterRegistry();
+      registry.register('ironclaw', createMockAdapter('ironclaw'), IRONCLAW_TRUST_PROFILE);
+      router = new ExecutionRouter(registry);
+    });
+
+    it('throws InvariantViolationError when executeWithRouting is called without a RiskAssessment', async () => {
+      const action = makeAction();
+      await expect(
+        router.executeWithRouting(action, null as unknown as RiskAssessment, 'user-1'),
+      ).rejects.toBeInstanceOf(InvariantViolationError);
+    });
+
+    it('throws InvariantViolationError when executeWithRouting is given a mismatched assessment', async () => {
+      const action = makeAction({ id: 'action-A' });
+      const assessment = makeRiskAssessment({ actionId: 'action-B' });
+      await expect(
+        router.executeWithRouting(action, assessment, 'user-1'),
+      ).rejects.toThrow(/does not match/);
+    });
+
+    it('throws InvariantViolationError from executeWithRoutingStreaming on null assessment', async () => {
+      const action = makeAction();
+      const stream = router.executeWithRoutingStreaming(
+        action,
+        null as unknown as RiskAssessment,
+        'user-1',
+      );
+      await expect((async () => {
+        for await (const _ of stream) {
+          // noop
+        }
+      })()).rejects.toBeInstanceOf(InvariantViolationError);
+    });
+
+    it('throws InvariantViolationError from executeWithRoutingStreaming on mismatched id', async () => {
+      const action = makeAction({ id: 'action-A' });
+      const assessment = makeRiskAssessment({ actionId: 'action-B' });
+      const stream = router.executeWithRoutingStreaming(action, assessment, 'user-1');
+      await expect((async () => {
+        for await (const _ of stream) {
+          // noop
+        }
+      })()).rejects.toThrow(/does not match/);
     });
   });
 });

--- a/packages/execution-router/src/execution-router.ts
+++ b/packages/execution-router/src/execution-router.ts
@@ -34,6 +34,41 @@ export class NoAdapterError extends Error {
 }
 
 /**
+ * Thrown when a caller violates an execution-pipeline invariant — for example,
+ * invoking the router without a `RiskAssessment` (Safety Invariant #7) or with
+ * an action whose id does not match the assessment it was paired with.
+ *
+ * These are programmer errors, not runtime conditions to recover from.
+ */
+export class InvariantViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvariantViolationError';
+  }
+}
+
+function assertValidExecutionInputs(
+  action: CandidateAction,
+  riskAssessment: RiskAssessment,
+): void {
+  if (!riskAssessment) {
+    throw new InvariantViolationError(
+      'ExecutionRouter called without a RiskAssessment. Safety Invariant #7 ' +
+        '("Risk assessment is mandatory") forbids executing actions without one.',
+    );
+  }
+  if (!action) {
+    throw new InvariantViolationError('ExecutionRouter called without a CandidateAction.');
+  }
+  if (action.id !== riskAssessment.actionId) {
+    throw new InvariantViolationError(
+      `RiskAssessment.actionId (${riskAssessment.actionId}) does not match ` +
+        `CandidateAction.id (${action.id}). Refusing to execute with a mismatched assessment.`,
+    );
+  }
+}
+
+/**
  * Execution router that selects the best adapter for a given action,
  * applies adapter-specific risk modifiers, and executes with fallback.
  *
@@ -135,6 +170,7 @@ export class ExecutionRouter {
     riskAssessment: RiskAssessment,
     userId: string,
   ): Promise<ExecutionResult> {
+    assertValidExecutionInputs(action, riskAssessment);
     const routingDecision = await this.route(action, riskAssessment, userId);
 
     const adapterChain = [routingDecision.selectedAdapter, ...routingDecision.fallbackChain];
@@ -210,6 +246,7 @@ export class ExecutionRouter {
     riskAssessment: RiskAssessment,
     userId: string,
   ): AsyncIterable<ExecutionEvent> {
+    assertValidExecutionInputs(action, riskAssessment);
     const routingDecision = await this.route(action, riskAssessment, userId);
     const adapterChain = [routingDecision.selectedAdapter, ...routingDecision.fallbackChain];
     const attemptedAdapters: string[] = [];

--- a/packages/execution-router/src/index.ts
+++ b/packages/execution-router/src/index.ts
@@ -1,4 +1,4 @@
-export { ExecutionRouter, NoAdapterError } from './execution-router.js';
+export { ExecutionRouter, NoAdapterError, InvariantViolationError } from './execution-router.js';
 
 export {
   AdapterRegistry,


### PR DESCRIPTION
## Summary
- \`ExecutionRouter\` now throws \`InvariantViolationError\` when called without a \`RiskAssessment\` or with a mismatched \`actionId\` — pins Safety Invariants #1 and #7 at the boundary so a future caller that skips the decision pipeline cannot silently auto-execute (+4 unit tests)
- \`DecisionMaker.whatWouldIDo\` no longer leaks blocked candidates via \`alternativeActions\` when policy denies every candidate; returns empty alternatives and surfaces the blocking reason via \`policyNotes\` (+1 unit test pinning the no-leak contract)
- \`POST /api/events/ingest\` emits a \`decision:blocked-by-policy\` SSE event when no action was selected and no approval was created, so users can see the policy result instead of silent ingestion (+1 unit test)

Production call sites (\`apps/api/src/routes/events.ts:230\`, \`apps/api/src/routes/approvals.ts:264\`) already build matching \`RiskAssessment\` objects — the new guards are inert for them and active against future orphan callers.

## Test plan
- [x] \`pnpm --filter @skytwin/execution-router test\` — 66/66 (was 62)
- [x] \`pnpm --filter @skytwin/decision-engine test\` — 79/79 (was 78)
- [x] \`pnpm --filter @skytwin/api test\` — 142 passed | 22 skipped (was 141)
- [x] \`pnpm test\` — 38/38 turbo tasks
- [x] \`pnpm lint\` — 30/30 turbo tasks

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)