### PR TITLE
fix(web): pluralize twin badges and surface Undo button affordance

### DIFF
--- a/apps/web/public/js/pages/decisions.js
+++ b/apps/web/public/js/pages/decisions.js
@@ -112,7 +112,7 @@ export async function renderDecisions(container, userId) {
                         : '<span class="badge badge-muted" title="Decision pending">Pending</span>'
                     }</td>
                     <td>
-                      <button class="btn btn-sm btn-ghost undo-btn" data-decision-id="${escapeHtml(d.id)}"
+                      <button class="btn btn-sm btn-outline undo-btn" data-decision-id="${escapeHtml(d.id)}"
                               onclick="event.stopPropagation(); showUndoModal('${escapeHtml(d.id)}')">
                         Undo
                       </button>

--- a/apps/web/public/js/pages/twin.js
+++ b/apps/web/public/js/pages/twin.js
@@ -47,7 +47,7 @@ export async function renderTwin(container, userId) {
     <div class="card">
       <div class="card-header">
         <span class="card-title">What I've learned about you</span>
-        <span class="badge badge-info">${preferences.length + inferences.length} things</span>
+        <span class="badge badge-info">${preferences.length + inferences.length} ${preferences.length + inferences.length === 1 ? 'thing' : 'things'}</span>
       </div>
       <div class="card-subtitle">
         Here's everything I think I know about how you like things done.
@@ -130,7 +130,7 @@ function renderDomainGroup(domain, group, userId) {
     <div class="card">
       <div class="card-header">
         <span class="card-title">${domainName}</span>
-        <span class="badge badge-accent">${group.preferences.length} prefs, ${group.inferences.length} inferences</span>
+        <span class="badge badge-accent">${group.preferences.length} ${group.preferences.length === 1 ? 'pref' : 'prefs'}, ${group.inferences.length} ${group.inferences.length === 1 ? 'inference' : 'inferences'}</span>
       </div>
       ${allItems.map(item => renderInsightItem(item, userId)).join('')}
     </div>


### PR DESCRIPTION
## Summary
Two quick-win polish fixes from #53:

- **Twin page badges**: \"1 things\" / \"1 prefs\" / \"1 inferences\" now pluralize correctly. Pattern: \`\${n} \${n === 1 ? 'thing' : 'things'}\`.
- **Decisions table Undo button**: was using \`.btn-ghost\` (transparent border, muted text) so it was indistinguishable from a label. Switched to \`.btn-outline\` for visible affordance.

Addresses two of the smaller items in #53 (P2 grammar bug, P3 unstyled Undo). The larger items (approvals pagination, decisions readability, home page polish) remain open for follow-up.

## Test plan
- [x] Eyeballed the badge templates — \`thing\`/\`things\`, \`pref\`/\`prefs\`, \`inference\`/\`inferences\` all conditional on count
- [x] \`.btn-outline\` exists in styles.css with hover state — undo button now has a visible border

🤖 Generated with [Claude Code](https://claude.com/claude-code)