### PR TITLE
test: cover null-action guard and isolate explanation test fixtures

### DIFF
--- a/packages/execution-router/src/__tests__/execution-router.test.ts
+++ b/packages/execution-router/src/__tests__/execution-router.test.ts
@@ -388,6 +388,13 @@ describe('ExecutionRouter', () => {
       ).rejects.toBeInstanceOf(InvariantViolationError);
     });
 
+    it('throws InvariantViolationError when executeWithRouting is called without a CandidateAction', async () => {
+      const assessment = makeRiskAssessment();
+      await expect(
+        router.executeWithRouting(null as unknown as CandidateAction, assessment, 'user-1'),
+      ).rejects.toThrow(/without a CandidateAction/);
+    });
+
     it('throws InvariantViolationError when executeWithRouting is given a mismatched assessment', async () => {
       const action = makeAction({ id: 'action-A' });
       const assessment = makeRiskAssessment({ actionId: 'action-B' });

--- a/packages/explanations/src/__tests__/explanation-generator.test.ts
+++ b/packages/explanations/src/__tests__/explanation-generator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { ConfidenceLevel, RiskTier } from '@skytwin/shared-types';
 import { ExplanationGenerator } from '../explanation-generator.js';
 import {
@@ -99,8 +99,13 @@ describe('ExplanationGenerator.generate', () => {
 });
 
 describe('ExplanationGenerator buildSummary branches', () => {
-  const repo = new InMemoryExplanationRepo();
-  const gen = new ExplanationGenerator(repo);
+  let repo: InMemoryExplanationRepo;
+  let gen: ExplanationGenerator;
+
+  beforeEach(() => {
+    repo = new InMemoryExplanationRepo();
+    gen = new ExplanationGenerator(repo);
+  });
 
   it('escalation summary when no action selected', async () => {
     const record = await gen.generate(
@@ -141,8 +146,13 @@ describe('ExplanationGenerator buildSummary branches', () => {
 });
 
 describe('ExplanationGenerator buildConfidenceReasoning branches', () => {
-  const repo = new InMemoryExplanationRepo();
-  const gen = new ExplanationGenerator(repo);
+  let repo: InMemoryExplanationRepo;
+  let gen: ExplanationGenerator;
+
+  beforeEach(() => {
+    repo = new InMemoryExplanationRepo();
+    gen = new ExplanationGenerator(repo);
+  });
 
   it('notes when no preferences are available', async () => {
     const record = await gen.generate(
@@ -182,8 +192,13 @@ describe('ExplanationGenerator buildConfidenceReasoning branches', () => {
 });
 
 describe('ExplanationGenerator buildActionRationale branches', () => {
-  const repo = new InMemoryExplanationRepo();
-  const gen = new ExplanationGenerator(repo);
+  let repo: InMemoryExplanationRepo;
+  let gen: ExplanationGenerator;
+
+  beforeEach(() => {
+    repo = new InMemoryExplanationRepo();
+    gen = new ExplanationGenerator(repo);
+  });
 
   it('starts with "No action was selected" when no action chosen', async () => {
     const record = await gen.generate(
@@ -215,8 +230,13 @@ describe('ExplanationGenerator buildActionRationale branches', () => {
 });
 
 describe('ExplanationGenerator buildCorrectionGuidance branches', () => {
-  const repo = new InMemoryExplanationRepo();
-  const gen = new ExplanationGenerator(repo);
+  let repo: InMemoryExplanationRepo;
+  let gen: ExplanationGenerator;
+
+  beforeEach(() => {
+    repo = new InMemoryExplanationRepo();
+    gen = new ExplanationGenerator(repo);
+  });
 
   it('offers undo for auto-executed reversible actions', async () => {
     const action = makeAction({ reversible: true });
@@ -256,8 +276,13 @@ describe('ExplanationGenerator buildCorrectionGuidance branches', () => {
 });
 
 describe('ExplanationGenerator gatherEvidenceReferences', () => {
-  const repo = new InMemoryExplanationRepo();
-  const gen = new ExplanationGenerator(repo);
+  let repo: InMemoryExplanationRepo;
+  let gen: ExplanationGenerator;
+
+  beforeEach(() => {
+    repo = new InMemoryExplanationRepo();
+    gen = new ExplanationGenerator(repo);
+  });
 
   it('includes a raw-data reference when decision.rawData.source is present', async () => {
     const decision = makeDecision({ rawData: { source: 'gmail', subject: 'X' } });
@@ -291,8 +316,13 @@ describe('ExplanationGenerator gatherEvidenceReferences', () => {
 });
 
 describe('ExplanationGenerator gatherPreferenceReferences', () => {
-  const repo = new InMemoryExplanationRepo();
-  const gen = new ExplanationGenerator(repo);
+  let repo: InMemoryExplanationRepo;
+  let gen: ExplanationGenerator;
+
+  beforeEach(() => {
+    repo = new InMemoryExplanationRepo();
+    gen = new ExplanationGenerator(repo);
+  });
 
   it('returns an empty array when no preferences are present', async () => {
     const record = await gen.generate(
@@ -322,8 +352,13 @@ describe('ExplanationGenerator gatherPreferenceReferences', () => {
 });
 
 describe('ExplanationGenerator.formatForUser', () => {
-  const repo = new InMemoryExplanationRepo();
-  const gen = new ExplanationGenerator(repo);
+  let repo: InMemoryExplanationRepo;
+  let gen: ExplanationGenerator;
+
+  beforeEach(() => {
+    repo = new InMemoryExplanationRepo();
+    gen = new ExplanationGenerator(repo);
+  });
 
   it('contains all required sections in order for an approval outcome', async () => {
     const record = await gen.generate(
@@ -364,8 +399,13 @@ describe('ExplanationGenerator.formatForUser', () => {
 });
 
 describe('ExplanationGenerator.formatForAudit', () => {
-  const repo = new InMemoryExplanationRepo();
-  const gen = new ExplanationGenerator(repo);
+  let repo: InMemoryExplanationRepo;
+  let gen: ExplanationGenerator;
+
+  beforeEach(() => {
+    repo = new InMemoryExplanationRepo();
+    gen = new ExplanationGenerator(repo);
+  });
 
   it('reports autoExecuted=false when escalationRationale is set', async () => {
     const record = await gen.generate(


### PR DESCRIPTION
## Summary
Two follow-ups surfaced during the post-merge review of #78:

- **Cover the unreachable \`!action\` guard.** \`assertValidExecutionInputs(null, ...)\` was added in #78 but had no test (TypeScript guarantees the branch is unreachable in practice). Defensive code on a safety boundary deserves a test so future refactors can't silently delete it.
- **Isolate explanation test fixtures.** Seven describe blocks in \`explanation-generator.test.ts\` shared a single \`InMemoryExplanationRepo\` declared at \`describe\` scope. \`repo.saved\` accumulated across \`it()\` calls. No current assertion notices, but a future \"save called once\" test would inherit cross-contamination. Converted to per-test \`beforeEach\`.

The larger gaps from #78 (e2e tests, partial-block leak in \`whatWouldIDo\`, blocked-by-policy ExplanationRecord persistence) are tracked separately in #80.

## Test plan
- [x] \`pnpm --filter @skytwin/execution-router test\` — 67/67 (was 66, +1)
- [x] \`pnpm --filter @skytwin/explanations test\` — 30/30 (same count, now isolated)
- [x] \`pnpm test\` (full repo) — all turbo tasks succeed
- [x] \`pnpm lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)