### PR TITLE
fix(decision-engine): record per-candidate policy verdicts; close partial-block leak

### DIFF
--- a/packages/decision-engine/src/__tests__/decision-maker.test.ts
+++ b/packages/decision-engine/src/__tests__/decision-maker.test.ts
@@ -1178,5 +1178,147 @@ describe('DecisionMaker', () => {
       expect(outcome.requiresApproval).toBe(true);
       expect(outcome.reasoning).toContain('blocked by policies');
     });
+
+    it('records every candidate verdict on outcome.policyVerdicts', async () => {
+      const twinService = createMockTwinService();
+      const policyEvaluator = createMockPolicyEvaluator({
+        allowed: false,
+        reason: 'Blocked.',
+      });
+      const decisionRepo = createMockDecisionRepository();
+      const dm = new DecisionMaker(
+        twinService as never,
+        policyEvaluator as never,
+        decisionRepo as never,
+      );
+
+      const context = createContext(TrustTier.HIGH_AUTONOMY);
+      const outcome = await dm.evaluate(context);
+
+      expect(outcome.policyVerdicts).toBeDefined();
+      const verdicts = outcome.policyVerdicts!;
+      const ids = outcome.allCandidates.map((c) => c.id);
+      // Every candidate has a recorded verdict
+      for (const id of ids) {
+        expect(verdicts[id]).toBe('denied');
+      }
+      expect(Object.keys(verdicts)).toHaveLength(ids.length);
+    });
+  });
+
+  // ── Partial-block: some candidates allowed, some denied ──────────
+  // Issue #80: whatWouldIDo must not leak denied candidates as alternatives.
+
+  describe('Mixed verdicts (partial-block)', () => {
+    it('whatWouldIDo filters denied candidates out of alternativeActions', async () => {
+      const twinService = createMockTwinService();
+      // Policy evaluator returns 'denied' for the first candidate evaluated
+      // and 'allowed' for everything after — simulates a real policy where
+      // some action types are blocked and others pass.
+      let callCount = 0;
+      const policyEvaluator = {
+        evaluate: vi.fn().mockImplementation(async () => {
+          callCount += 1;
+          if (callCount === 1) {
+            return { allowed: false, requiresApproval: false, reason: 'First blocked.' };
+          }
+          return { allowed: true, requiresApproval: false, reason: 'OK.' };
+        }),
+        loadPolicies: vi.fn().mockResolvedValue([]),
+        checkSpendLimit: vi.fn().mockReturnValue(true),
+        checkReversibility: vi.fn().mockReturnValue(true),
+        checkDomainAllowlist: vi.fn().mockReturnValue(true),
+      };
+      const decisionRepo = createMockDecisionRepository();
+      const dm = new DecisionMaker(
+        twinService as never,
+        policyEvaluator as never,
+        decisionRepo as never,
+      );
+
+      const mockTwinServiceForQuery = {
+        getOrCreateProfile: vi.fn().mockResolvedValue({
+          id: 'twin_test',
+          userId: 'user_test',
+          version: 1,
+          preferences: [],
+          inferences: [],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+        getRelevantPreferences: vi.fn().mockResolvedValue([]),
+        getPatterns: vi.fn().mockResolvedValue([]),
+        getTraits: vi.fn().mockResolvedValue([]),
+        getTemporalProfile: vi.fn().mockResolvedValue({
+          userId: 'user_test',
+          activeHours: { start: 8, end: 22 },
+          peakResponseTimes: {},
+          weekdayPatterns: {},
+          urgencyThresholds: {},
+        }),
+      };
+
+      const response = await dm.whatWouldIDo(
+        'user_test',
+        { situation: 'Calendar conflict at 3pm', domain: 'calendar' },
+        mockTwinServiceForQuery,
+        TrustTier.HIGH_AUTONOMY,
+      );
+
+      // A winner exists (one of the allowed ones)
+      expect(response.predictedAction).not.toBeNull();
+      // The blocked candidate must NOT appear in alternativeActions
+      // (calendar generates 3 candidates: accept/decline/propose; one was denied)
+      const allReturnedIds = [
+        response.predictedAction?.id,
+        ...response.alternativeActions.map((a) => a.id),
+      ].filter(Boolean) as string[];
+      // We had 3 candidates total, 1 was denied → 2 should surface
+      expect(allReturnedIds).toHaveLength(2);
+    });
+
+    it('whatWouldIDo with a legacy outcome (no policyVerdicts) drops alternatives conservatively', async () => {
+      // Simulates an outcome from a code path that didn't populate verdicts
+      // (e.g. an older serialized outcome). The filter falls back to dropping
+      // candidates whose verdict is unknown — better to under-suggest than
+      // leak something the user might not be allowed to take.
+      const twinService = createMockTwinService();
+      const policyEvaluator = createMockPolicyEvaluator({ allowed: true, requiresApproval: false });
+      const decisionRepo = createMockDecisionRepository();
+      const dm = new DecisionMaker(
+        twinService as never,
+        policyEvaluator as never,
+        decisionRepo as never,
+      );
+
+      // Override evaluate to return an outcome with policyVerdicts deleted
+      // (simulates a stale / legacy code path).
+      const realEvaluate = dm.evaluate.bind(dm);
+      vi.spyOn(dm, 'evaluate').mockImplementation(async (ctx) => {
+        const outcome = await realEvaluate(ctx);
+        return { ...outcome, policyVerdicts: undefined };
+      });
+
+      const mockTwinServiceForQuery = {
+        getOrCreateProfile: vi.fn().mockResolvedValue({
+          id: 'twin_test', userId: 'user_test', version: 1,
+          preferences: [], inferences: [], createdAt: new Date(), updatedAt: new Date(),
+        }),
+        getRelevantPreferences: vi.fn().mockResolvedValue([]),
+        getPatterns: vi.fn().mockResolvedValue([]),
+        getTraits: vi.fn().mockResolvedValue([]),
+        getTemporalProfile: vi.fn().mockResolvedValue({}),
+      };
+
+      const response = await dm.whatWouldIDo(
+        'user_test',
+        { situation: 'Test', domain: 'calendar' },
+        mockTwinServiceForQuery,
+        TrustTier.HIGH_AUTONOMY,
+      );
+
+      // Conservative fallback: alternatives empty when verdicts unavailable
+      expect(response.alternativeActions).toEqual([]);
+    });
   });
 });

--- a/packages/decision-engine/src/decision-maker.ts
+++ b/packages/decision-engine/src/decision-maker.ts
@@ -5,6 +5,7 @@ import type {
   CandidateAction,
   RiskAssessment,
   ActionPolicy,
+  PolicyVerdict,
   TwinProfile,
   Preference,
   WhatWouldIDoRequest,
@@ -129,12 +130,16 @@ export class DecisionMaker {
       }))
       .sort((a, b) => b.score - a.score);
 
-    // Step 7: Find the best action that passes policy checks
+    // Step 7: Evaluate every candidate against policy. We record a verdict for
+    // each so downstream consumers (e.g. whatWouldIDo) can distinguish blocked
+    // candidates from un-evaluated ones. Safety Invariant #1.
+    const policyVerdicts: Record<string, PolicyVerdict> = {};
     let selectedAction: CandidateAction | null = null;
     let selectedAssessment: RiskAssessment | null = null;
     let autoExecute = false;
     let requiresApproval = true;
     let reasoning = '';
+    let lastBlockedReason = '';
 
     for (const { candidate, assessment } of scoredCandidates) {
       const policyDecision = await this.policyEvaluator.evaluate(
@@ -144,7 +149,21 @@ export class DecisionMaker {
         assessment,
       );
 
-      if (policyDecision.allowed) {
+      const verdict: PolicyVerdict = !policyDecision.allowed
+        ? 'denied'
+        : policyDecision.requiresApproval
+          ? 'requires-approval'
+          : 'allowed';
+      policyVerdicts[candidate.id] = verdict;
+
+      if (verdict === 'denied') {
+        lastBlockedReason = `Candidate "${candidate.description}" blocked: ${policyDecision.reason}`;
+        continue;
+      }
+
+      // First non-denied candidate wins. Lower-scored candidates still get
+      // evaluated so verdicts are complete, but we don't switch winners.
+      if (selectedAction === null) {
         selectedAction = candidate;
         selectedAssessment = assessment;
         requiresApproval = policyDecision.requiresApproval;
@@ -155,14 +174,11 @@ export class DecisionMaker {
           : policyDecision.requiresApproval
             ? `Selected "${candidate.description}" but requires approval. ${policyDecision.reason}`
             : `Selected "${candidate.description}". ${policyDecision.reason}`;
-        break;
-      } else {
-        reasoning = `Candidate "${candidate.description}" blocked: ${policyDecision.reason}`;
       }
     }
 
     if (!selectedAction) {
-      reasoning = `All ${candidates.length} candidate(s) were blocked by policies. ` + reasoning;
+      reasoning = `All ${candidates.length} candidate(s) were blocked by policies. ` + lastBlockedReason;
     }
 
     const outcome: DecisionOutcome = {
@@ -175,6 +191,7 @@ export class DecisionMaker {
       requiresApproval: selectedAction ? requiresApproval : true,
       reasoning,
       decidedAt: new Date(),
+      policyVerdicts,
     };
 
     await this.decisionRepository.saveCandidates(candidates);
@@ -237,12 +254,18 @@ export class DecisionMaker {
     const outcome = await this.evaluate(context);
 
     // Step 4: Build WhatWouldIDoResponse.
-    // When no candidate was allowed by policy (selectedAction is null), do not
-    // surface the blocked candidates as "alternatives" — that leaks options the
-    // user would not actually be permitted to take. Safety Invariant #1.
-    const alternativeActions = outcome.selectedAction
-      ? outcome.allCandidates.filter((c) => c !== outcome.selectedAction)
-      : [];
+    // Filter alternatives to candidates that policy actually allowed (or
+    // permitted under approval). Blocked candidates must NOT surface as
+    // options — they would mislead the user about what their twin can do.
+    // Safety Invariant #1.
+    const verdicts = outcome.policyVerdicts ?? {};
+    const alternativeActions = outcome.allCandidates.filter((c) => {
+      if (c === outcome.selectedAction) return false;
+      const verdict = verdicts[c.id];
+      // Conservative default: if no verdict was recorded, drop the candidate.
+      // Better to under-suggest than to leak a blocked one.
+      return verdict === 'allowed' || verdict === 'requires-approval';
+    });
     const policyNotes = outcome.requiresApproval || !outcome.selectedAction
       ? outcome.reasoning
       : undefined;

--- a/packages/explanations/src/__tests__/explanation-generator.test.ts
+++ b/packages/explanations/src/__tests__/explanation-generator.test.ts
@@ -67,6 +67,25 @@ describe('ExplanationGenerator.generate', () => {
     expect(record.actionRationale).toContain('All candidates blocked by policy.');
   });
 
+  it('persists escalationRationale for blocked-by-policy outcomes (Safety Invariant #2)', async () => {
+    const repo = new InMemoryExplanationRepo();
+    const gen = new ExplanationGenerator(repo);
+
+    const decision = makeDecision();
+    const outcome = makeOutcome({
+      selectedAction: null,
+      allCandidates: [],
+      riskAssessment: null,
+      requiresApproval: false,
+      autoExecute: false,
+      reasoning: 'All 3 candidates blocked by policy "no-spending".',
+    });
+
+    const record = await gen.generate(decision, outcome, makeContext({ decision }));
+
+    expect(record.escalationRationale).toBe('All 3 candidates blocked by policy "no-spending".');
+  });
+
   it('persists the record exactly once and returns the saved object', async () => {
     const repo = new InMemoryExplanationRepo();
     const gen = new ExplanationGenerator(repo);
@@ -395,6 +414,40 @@ describe('ExplanationGenerator.formatForUser', () => {
     );
     const out = gen.formatForUser(record);
     expect(out).not.toContain('Why approval was needed:');
+  });
+
+  it('uses "Why no action was taken" label for blocked-by-policy records', async () => {
+    const record = await gen.generate(
+      makeDecision(),
+      makeOutcome({
+        selectedAction: null,
+        allCandidates: [],
+        riskAssessment: null,
+        autoExecute: false,
+        requiresApproval: false,
+        reasoning: 'All candidates blocked by spending policy.',
+      }),
+      makeContext(),
+    );
+    const out = gen.formatForUser(record);
+    expect(out).toContain('Why no action was taken:');
+    expect(out).toContain('blocked by spending policy');
+    expect(out).not.toContain('Why approval was needed:');
+  });
+
+  it('uses "Why approval was needed" label for requires-approval records', async () => {
+    const record = await gen.generate(
+      makeDecision(),
+      makeOutcome({
+        requiresApproval: true,
+        autoExecute: false,
+        reasoning: 'High-risk action requires user approval.',
+      }),
+      makeContext(),
+    );
+    const out = gen.formatForUser(record);
+    expect(out).toContain('Why approval was needed:');
+    expect(out).not.toContain('Why no action was taken:');
   });
 });
 

--- a/packages/explanations/src/explanation-generator.ts
+++ b/packages/explanations/src/explanation-generator.ts
@@ -59,7 +59,11 @@ export class ExplanationGenerator {
     const preferencesInvoked = this.gatherPreferenceReferences(context);
     const confidenceReasoning = this.buildConfidenceReasoning(outcome, context);
     const actionRationale = this.buildActionRationale(outcome);
-    const escalationRationale = outcome.requiresApproval
+    // Capture the non-execution reason for both the requires-approval path AND
+    // the no-action / all-blocked-by-policy path. Without this, blocked
+    // decisions would persist with `escalationRationale: undefined` and the
+    // audit log would lose the policy-block reason. Safety Invariant #2.
+    const escalationRationale = outcome.requiresApproval || !outcome.selectedAction
       ? this.buildEscalationRationale(outcome)
       : undefined;
     const correctionGuidance = this.buildCorrectionGuidance(outcome);
@@ -117,9 +121,13 @@ export class ExplanationGenerator {
     lines.push(`Risk level: ${record.riskTier}`);
     lines.push('');
 
-    // Escalation
+    // Escalation / blocked-by-policy. Label depends on whether SkyTwin
+    // selected an action that needs approval, or could not select any action
+    // at all because policy blocked every candidate.
     if (record.escalationRationale) {
-      lines.push(`Why approval was needed: ${record.escalationRationale}`);
+      const blocked = record.actionRationale.startsWith('No action was selected');
+      const label = blocked ? 'Why no action was taken' : 'Why approval was needed';
+      lines.push(`${label}: ${record.escalationRationale}`);
       lines.push('');
     }
 

--- a/packages/shared-types/src/decision.ts
+++ b/packages/shared-types/src/decision.ts
@@ -90,4 +90,16 @@ export interface DecisionOutcome {
   requiresApproval: boolean;
   reasoning: string;
   decidedAt: Date;
+  /**
+   * Per-candidate policy verdicts, keyed by candidate id. Populated by the
+   * decision engine; not persisted. Consumers (e.g. `whatWouldIDo`) use this
+   * to filter alternatives so blocked candidates are not surfaced as options
+   * the user could take. Safety Invariant #1.
+   */
+  policyVerdicts?: Record<string, PolicyVerdict>;
 }
+
+/**
+ * Per-candidate policy verdict produced during decision evaluation.
+ */
+export type PolicyVerdict = 'allowed' | 'requires-approval' | 'denied';

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -37,6 +37,7 @@ export type {
   RiskAssessment,
   DimensionAssessment,
   DecisionOutcome,
+  PolicyVerdict,
 } from './decision.js';
 
 export type {


### PR DESCRIPTION
## Summary
Closes 2/3 of #80 (items 2 and 3). E2E coverage (item 1) deferred to a follow-up PR.

**Item 2 — Partial-block leak in \`whatWouldIDo\`** (the bigger fix)
- \`DecisionOutcome\` gains an optional \`policyVerdicts: Record<actionId, 'allowed' | 'requires-approval' | 'denied'>\`. Populated by \`evaluate()\`, not persisted (DB layer ignores unknown fields).
- \`evaluate()\` now evaluates **every** candidate against policy instead of breaking at the first allowed one. Selection is unchanged (first non-denied still wins), but lower-scored candidates now have verdicts so consumers can filter accurately. K-1 extra in-memory policy checks per decision in the worst case — acceptable given policy evaluation is cheap and decisions typically have <10 candidates.
- \`whatWouldIDo\` filters \`alternativeActions\` using verdicts. Blocked candidates no longer leak as suggestions. Conservative fallback: when verdicts are unavailable (legacy or stale outcome), alternatives default to empty.

**Item 3 — Blocked-by-policy explanation persistence**
- \`ExplanationGenerator\` now sets \`escalationRationale\` for the no-action case. Previously the audit log silently dropped the policy-block reason — Safety Invariant #2 violation.
- \`formatForUser\` uses a context-aware label: \"Why no action was taken\" for blocked records, \"Why approval was needed\" for requires-approval records.

## Test plan
- [x] \`pnpm --filter @skytwin/decision-engine test\` — 82/82 (was 79, +3)
- [x] \`pnpm --filter @skytwin/explanations test\` — 33/33 (was 30, +3)
- [x] \`pnpm test\` — 38/38 turbo tasks
- [x] \`pnpm lint\` — 30/30 turbo tasks
- [x] \`pnpm build\` — 19/19 packages

Refs #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)