### PR TITLE
fix(web,api): P3 polish — preferences metric, fallback description, dollar inputs

### DIFF
--- a/apps/api/src/routes/evals.ts
+++ b/apps/api/src/routes/evals.ts
@@ -124,18 +124,34 @@ export function createEvalsRouter(): Router {
       const { userId } = req.params;
       const profile = await twinService.getOrCreateProfile(userId);
 
-      const domainConfidence = new Map<string, { total: number; confirmed: number; high: number; moderate: number; low: number; speculative: number }>();
-
-      for (const inf of profile.inferences) {
-        const stats = domainConfidence.get(inf.domain) ?? { total: 0, confirmed: 0, high: 0, moderate: 0, low: 0, speculative: 0 };
+      // "How well I know you" should reflect both explicit preferences and
+      // auto-detected inferences — the user has no concept of the distinction
+      // and was seeing 0% with 5 preferences learned (#53). Combine them and
+      // weight explicit preferences as 'confirmed' (the user told us directly).
+      type ConfStats = { total: number; confirmed: number; high: number; moderate: number; low: number; speculative: number };
+      const empty = (): ConfStats => ({ total: 0, confirmed: 0, high: 0, moderate: 0, low: 0, speculative: 0 });
+      const domainConfidence = new Map<string, ConfStats>();
+      const bump = (domain: string, level: string) => {
+        const stats = domainConfidence.get(domain) ?? empty();
         stats.total++;
-        const level = normalizeConfidence(inf.confidence);
         if (level === 'confirmed') stats.confirmed++;
         else if (level === 'high') stats.high++;
         else if (level === 'moderate') stats.moderate++;
         else if (level === 'low') stats.low++;
         else stats.speculative++;
-        domainConfidence.set(inf.domain, stats);
+        domainConfidence.set(domain, stats);
+      };
+
+      for (const inf of profile.inferences) {
+        bump(inf.domain, normalizeConfidence(inf.confidence));
+      }
+      // Explicit preferences from the user count as the highest confidence —
+      // they told us directly. Inferred preferences carry their own level.
+      for (const pref of profile.preferences) {
+        const level = pref.source === 'explicit' || pref.source === 'corrected'
+          ? 'confirmed'
+          : normalizeConfidence(pref.confidence);
+        bump(pref.domain, level);
       }
 
       // Calculate overall confidence per domain (weighted score)
@@ -146,19 +162,27 @@ export function createEvalsRouter(): Router {
         domains[domain] = Math.round(weighted);
       }
 
-      // Overall confidence
-      const allInferences = profile.inferences.length;
-      const totalWeighted = profile.inferences.reduce((sum, inf) => {
+      // Overall confidence — mean of preferences + inferences combined.
+      const totalSignals = profile.inferences.length + profile.preferences.length;
+      const totalWeighted = [
+        ...profile.inferences.map((inf) => normalizeConfidence(inf.confidence)),
+        ...profile.preferences.map((pref) =>
+          pref.source === 'explicit' || pref.source === 'corrected'
+            ? 'confirmed'
+            : normalizeConfidence(pref.confidence),
+        ),
+      ].reduce((sum, level) => {
         const weights: Record<string, number> = { confirmed: 4, high: 3, moderate: 2, low: 1, speculative: 0 };
-        return sum + (weights[normalizeConfidence(inf.confidence)] ?? 0);
+        return sum + (weights[level] ?? 0);
       }, 0);
-      const overallConfidence = allInferences > 0 ? Math.round((totalWeighted / (allInferences * 4)) * 100) : 0;
+      const overallConfidence = totalSignals > 0 ? Math.round((totalWeighted / (totalSignals * 4)) * 100) : 0;
 
       res.json({
         userId,
         overallConfidence,
         domains,
-        totalInferences: allInferences,
+        totalInferences: profile.inferences.length,
+        totalPreferences: profile.preferences.length,
       });
     } catch (error) {
       next(error);

--- a/apps/api/src/routes/twin.ts
+++ b/apps/api/src/routes/twin.ts
@@ -310,12 +310,21 @@ function describePreference(domain: string, key: string, value: unknown): string
     return domainDescs[key](value);
   }
 
-  // Generic fallback
+  // Generic fallback. Goal: produce something a user would write themselves,
+  // not a debug dump. Boolean prefs read as "enabled/disabled". Free-form
+  // string preferences read as "{Domain}: {their words}". Numeric and
+  // structured values include the key for context.
+  const humanKey = key.replace(/_/g, ' ');
   if (typeof value === 'boolean') {
-    return `${domainLabel}: ${key.replace(/_/g, ' ')} is ${value ? 'enabled' : 'disabled'}`;
+    return `${domainLabel}: ${humanKey} is ${value ? 'enabled' : 'disabled'}`;
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    // The string IS the preference — surface it directly so it doesn't read
+    // like a config file ("find_travel_deals = i love travel deals").
+    return `${domainLabel}: ${value.trim()}`;
   }
   if (value !== null && value !== undefined) {
-    return `${domainLabel}: ${key.replace(/_/g, ' ')} = ${String(value)}`;
+    return `${domainLabel}: ${humanKey} — ${String(value)}`;
   }
   return null;
 }

--- a/apps/web/public/js/pages/settings.js
+++ b/apps/web/public/js/pages/settings.js
@@ -200,14 +200,18 @@ export async function renderSettings(container, userId) {
         Put a cap on how much your assistant can spend without asking you first.
       </div>
       <div class="form-group">
-        <label>Most I can spend at once (in cents)</label>
-        <input class="form-input" type="number" id="max-per-action" value="${autonomy.maxSpendPerActionCents ?? 10000}" min="0">
-        <div style="font-size: 0.75rem; color: var(--text-dim); margin-top: 0.25rem;">e.g. 10000 = $100.00</div>
+        <label>Most I can spend at once</label>
+        <div style="position: relative;">
+          <span style="position: absolute; left: 0.6rem; top: 50%; transform: translateY(-50%); color: var(--text-dim);">$</span>
+          <input class="form-input" type="number" id="max-per-action" value="${((autonomy.maxSpendPerActionCents ?? 10000) / 100).toFixed(2)}" min="0" step="0.01" style="padding-left: 1.4rem;">
+        </div>
       </div>
       <div class="form-group">
-        <label>Most I can spend in one day (in cents)</label>
-        <input class="form-input" type="number" id="max-daily" value="${autonomy.maxDailySpendCents ?? 50000}" min="0">
-        <div style="font-size: 0.75rem; color: var(--text-dim); margin-top: 0.25rem;">e.g. 50000 = $500.00</div>
+        <label>Most I can spend in one day</label>
+        <div style="position: relative;">
+          <span style="position: absolute; left: 0.6rem; top: 50%; transform: translateY(-50%); color: var(--text-dim);">$</span>
+          <input class="form-input" type="number" id="max-daily" value="${((autonomy.maxDailySpendCents ?? 50000) / 100).toFixed(2)}" min="0" step="0.01" style="padding-left: 1.4rem;">
+        </div>
       </div>
       <div class="form-group">
         <label>
@@ -233,7 +237,7 @@ export async function renderSettings(container, userId) {
               <div>
                 <span style="font-weight: 600;">${escapeHtml(p.domain)}</span>
                 <span style="color: var(--text-muted); margin-left: 0.5rem;">${escapeHtml(p.trustTier)}</span>
-                ${p.maxSpendPerActionCents != null ? `<span style="color: var(--text-muted); margin-left: 0.5rem;">(max ${p.maxSpendPerActionCents}c/action)</span>` : ''}
+                ${p.maxSpendPerActionCents != null ? `<span style="color: var(--text-muted); margin-left: 0.5rem;">(max $${(p.maxSpendPerActionCents / 100).toFixed(2)}/action)</span>` : ''}
               </div>
               <button class="btn btn-outline btn-sm" onclick="removeDomainPolicy('${escapeHtml(userId)}', '${escapeHtml(p.domain)}')">Remove</button>
             </div>
@@ -431,9 +435,12 @@ window.pauseTwin = async function(userId) {
 
 window.saveSpendLimits = async function(userId) {
   try {
+    // Inputs are dollars; convert to cents for the API. Round to avoid
+    // float drift (e.g. 100.10 → 10010, not 10009.999...).
+    const dollarsToCents = (id) => Math.round(parseFloat(document.getElementById(id).value) * 100);
     await updateAutonomySettings(userId, {
-      maxSpendPerActionCents: parseInt(document.getElementById('max-per-action').value, 10),
-      maxDailySpendCents: parseInt(document.getElementById('max-daily').value, 10),
+      maxSpendPerActionCents: dollarsToCents('max-per-action'),
+      maxDailySpendCents: dollarsToCents('max-daily'),
       requireApprovalForIrreversible: document.getElementById('irreversible-approval').checked,
     });
     const { renderSettings } = await import('./settings.js');


### PR DESCRIPTION
## Summary
Three small P3 polish items from #53. All independent, bundled because they're each ~5-15 lines.

**1. \"How well I know you\" now counts preferences, not just inferences.** A user with 5 explicit preferences and 0 inferences was seeing 0% even though the twin clearly had real knowledge. The \`/confidence\` endpoint now combines both signals, and explicit/corrected preferences weight as \`'confirmed'\` (the user told us directly).

**2. Generic preference description no longer reads like a config dump.** Was: \"Travel: find_travel_deals = i love travel deals\". Now: \"Travel: i love travel deals\" — string values surface as the preference itself. Booleans and numerics still include the key for context.

**3. Spending guardrails accept dollars, not cents.** Inputs now show a \"$\" prefix and decimal step. Pre-fills as dollars, saves by rounding dollars*100 back to cents (avoids float drift). The domain-policy badge also shows \"max \$X/action\" instead of \"Yc/action\".

## Test plan
- [x] \`node --check apps/web/public/js/pages/settings.js\` — clean
- [x] \`pnpm test\` — 38/38 turbo tasks
- [x] \`pnpm lint\` — 30/30 turbo tasks
- [x] \`pnpm build\` (implicit via lint) — clean

Refs #53 (P3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)