### PR TITLE
test(config,core): cover env loading, validation, and core helpers

### DIFF
--- a/packages/config/src/__tests__/config.test.ts
+++ b/packages/config/src/__tests__/config.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import { loadConfig, validate, loadValidatedConfig } from '../index.js';
+
+describe('loadConfig', () => {
+  it('applies defaults for an empty environment', () => {
+    const cfg = loadConfig({});
+    expect(cfg.databaseUrl).toContain('postgresql://');
+    expect(cfg.ironclawApiUrl).toBe('http://localhost:4000');
+    expect(cfg.apiPort).toBe(3100);
+    expect(cfg.workerPort).toBe(3101);
+    expect(cfg.nodeEnv).toBe('development');
+    expect(cfg.logLevel).toBe('info');
+    expect(cfg.useMockIronclaw).toBe(false);
+    expect(cfg.desktopMode).toBe(false);
+    expect(cfg.ironclawPreferChat).toBe(false);
+  });
+
+  it('reads values from the provided environment', () => {
+    const cfg = loadConfig({
+      DATABASE_URL: 'postgresql://override',
+      IRONCLAW_API_URL: 'http://ironclaw.test',
+      IRONCLAW_WEBHOOK_SECRET: 's3cret',
+      API_PORT: '4242',
+      LOG_LEVEL: 'debug',
+      NODE_ENV: 'production',
+    });
+    expect(cfg.databaseUrl).toBe('postgresql://override');
+    expect(cfg.ironclawApiUrl).toBe('http://ironclaw.test');
+    expect(cfg.ironclawWebhookSecret).toBe('s3cret');
+    expect(cfg.apiPort).toBe(4242);
+    expect(cfg.logLevel).toBe('debug');
+    expect(cfg.nodeEnv).toBe('production');
+  });
+
+  it('falls back to default for invalid LOG_LEVEL', () => {
+    const cfg = loadConfig({ LOG_LEVEL: 'verbose' });
+    expect(cfg.logLevel).toBe('info');
+  });
+
+  it('falls back to default for invalid NODE_ENV', () => {
+    const cfg = loadConfig({ NODE_ENV: 'staging' });
+    expect(cfg.nodeEnv).toBe('development');
+  });
+
+  it('parses boolean env vars only when value is "true"', () => {
+    expect(loadConfig({ USE_MOCK_IRONCLAW: 'true' }).useMockIronclaw).toBe(true);
+    expect(loadConfig({ USE_MOCK_IRONCLAW: 'TRUE' }).useMockIronclaw).toBe(false);
+    expect(loadConfig({ USE_MOCK_IRONCLAW: '1' }).useMockIronclaw).toBe(false);
+    expect(loadConfig({ USE_MOCK_IRONCLAW: '' }).useMockIronclaw).toBe(false);
+  });
+
+  it('honors GATEWAY_AUTH_TOKEN as a fallback for IRONCLAW_GATEWAY_TOKEN', () => {
+    expect(loadConfig({ GATEWAY_AUTH_TOKEN: 'legacy' }).ironclawGatewayToken).toBe('legacy');
+    expect(loadConfig({
+      GATEWAY_AUTH_TOKEN: 'legacy',
+      IRONCLAW_GATEWAY_TOKEN: 'preferred',
+    }).ironclawGatewayToken).toBe('preferred');
+  });
+
+  it('honors IRONCLAW_CHANNEL as a fallback for IRONCLAW_DEFAULT_CHANNEL', () => {
+    expect(loadConfig({ IRONCLAW_CHANNEL: 'legacy' }).ironclawDefaultChannel).toBe('legacy');
+    expect(loadConfig({
+      IRONCLAW_CHANNEL: 'legacy',
+      IRONCLAW_DEFAULT_CHANNEL: 'preferred',
+    }).ironclawDefaultChannel).toBe('preferred');
+  });
+});
+
+describe('validate', () => {
+  function validCfg() {
+    return loadConfig({
+      DATABASE_URL: 'postgresql://localhost/skytwin',
+      IRONCLAW_API_URL: 'http://localhost:4000',
+      IRONCLAW_WEBHOOK_SECRET: 'secret',
+    });
+  }
+
+  it('returns no errors for a valid config', () => {
+    expect(validate(validCfg())).toEqual([]);
+  });
+
+  it('rejects empty databaseUrl', () => {
+    const cfg = validCfg();
+    cfg.databaseUrl = '';
+    const errs = validate(cfg);
+    expect(errs.find((e) => e.field === 'databaseUrl')).toBeDefined();
+  });
+
+  it('rejects non-postgresql databaseUrl', () => {
+    const cfg = validCfg();
+    cfg.databaseUrl = 'mysql://localhost/skytwin';
+    const errs = validate(cfg);
+    expect(errs.find((e) => e.field === 'databaseUrl')?.message).toContain('valid PostgreSQL');
+  });
+
+  it('accepts both postgres:// and postgresql:// schemes', () => {
+    const cfg = validCfg();
+    cfg.databaseUrl = 'postgres://localhost/skytwin';
+    expect(validate(cfg).find((e) => e.field === 'databaseUrl')).toBeUndefined();
+  });
+
+  it('rejects malformed ironclawApiUrl', () => {
+    const cfg = validCfg();
+    cfg.ironclawApiUrl = 'not a url';
+    expect(validate(cfg).find((e) => e.field === 'ironclawApiUrl')).toBeDefined();
+  });
+
+  it('requires ironclawWebhookSecret unless mock is enabled', () => {
+    const cfg = validCfg();
+    cfg.ironclawWebhookSecret = '';
+    expect(validate(cfg).find((e) => e.field === 'ironclawWebhookSecret')).toBeDefined();
+
+    cfg.useMockIronclaw = true;
+    expect(validate(cfg).find((e) => e.field === 'ironclawWebhookSecret')).toBeUndefined();
+  });
+
+  it('rejects out-of-range apiPort', () => {
+    const cfg = validCfg();
+    cfg.apiPort = 0;
+    expect(validate(cfg).find((e) => e.field === 'apiPort')).toBeDefined();
+
+    cfg.apiPort = 99999;
+    expect(validate(cfg).find((e) => e.field === 'apiPort')).toBeDefined();
+  });
+
+  it('rejects NaN apiPort (e.g. from non-numeric env)', () => {
+    const cfg = validCfg();
+    cfg.apiPort = NaN;
+    expect(validate(cfg).find((e) => e.field === 'apiPort')).toBeDefined();
+  });
+});
+
+describe('loadValidatedConfig', () => {
+  it('returns the config when valid', () => {
+    const cfg = loadValidatedConfig({
+      DATABASE_URL: 'postgresql://localhost/skytwin',
+      IRONCLAW_API_URL: 'http://localhost:4000',
+      IRONCLAW_WEBHOOK_SECRET: 'secret',
+    });
+    expect(cfg.apiPort).toBe(3100);
+  });
+
+  it('throws an aggregated error when validation fails', () => {
+    expect(() =>
+      loadValidatedConfig({
+        DATABASE_URL: 'mysql://bad',
+        IRONCLAW_API_URL: 'not a url',
+      }),
+    ).toThrow(/Invalid configuration/);
+  });
+
+  it('error message lists every failing field', () => {
+    let captured: Error | null = null;
+    try {
+      loadValidatedConfig({
+        DATABASE_URL: 'mysql://bad',
+        IRONCLAW_API_URL: 'not a url',
+      });
+    } catch (err) {
+      captured = err as Error;
+    }
+    expect(captured).not.toBeNull();
+    expect(captured!.message).toContain('databaseUrl');
+    expect(captured!.message).toContain('ironclawApiUrl');
+    expect(captured!.message).toContain('ironclawWebhookSecret');
+  });
+});

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  generateId,
+  createLogger,
+  compareRiskTiers,
+  riskExceeds,
+  trustMeetsOrExceeds,
+  RISK_TIER_ORDER,
+  TRUST_TIER_ORDER,
+  CONFIDENCE_LEVEL_ORDER,
+} from '../index.js';
+
+describe('generateId', () => {
+  it('returns a UUID-shaped string', () => {
+    const id = generateId();
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+  });
+
+  it('returns unique values across calls', () => {
+    const ids = new Set([generateId(), generateId(), generateId()]);
+    expect(ids.size).toBe(3);
+  });
+});
+
+describe('compareRiskTiers', () => {
+  it('returns 0 for equal tiers', () => {
+    expect(compareRiskTiers('low', 'low')).toBe(0);
+    expect(compareRiskTiers('critical', 'critical')).toBe(0);
+  });
+
+  it('returns negative when a < b', () => {
+    expect(compareRiskTiers('low', 'high')).toBeLessThan(0);
+    expect(compareRiskTiers('negligible', 'critical')).toBeLessThan(0);
+  });
+
+  it('returns positive when a > b', () => {
+    expect(compareRiskTiers('high', 'low')).toBeGreaterThan(0);
+    expect(compareRiskTiers('critical', 'negligible')).toBeGreaterThan(0);
+  });
+
+  it('treats unknown tiers as 0 (lowest)', () => {
+    expect(compareRiskTiers('unknown', 'negligible')).toBe(0);
+    expect(compareRiskTiers('unknown', 'low')).toBeLessThan(0);
+  });
+});
+
+describe('riskExceeds', () => {
+  it('returns true when risk is strictly above threshold', () => {
+    expect(riskExceeds('high', 'moderate')).toBe(true);
+    expect(riskExceeds('critical', 'low')).toBe(true);
+  });
+
+  it('returns false when risk equals threshold', () => {
+    expect(riskExceeds('moderate', 'moderate')).toBe(false);
+  });
+
+  it('returns false when risk is below threshold', () => {
+    expect(riskExceeds('low', 'high')).toBe(false);
+  });
+});
+
+describe('trustMeetsOrExceeds', () => {
+  it('returns true when actual >= required', () => {
+    expect(trustMeetsOrExceeds('high_autonomy', 'low_autonomy')).toBe(true);
+    expect(trustMeetsOrExceeds('moderate_autonomy', 'moderate_autonomy')).toBe(true);
+  });
+
+  it('returns false when actual < required', () => {
+    expect(trustMeetsOrExceeds('observer', 'high_autonomy')).toBe(false);
+    expect(trustMeetsOrExceeds('suggest', 'moderate_autonomy')).toBe(false);
+  });
+
+  it('treats unknown tier as observer (0)', () => {
+    expect(trustMeetsOrExceeds('unknown', 'observer')).toBe(true);
+    expect(trustMeetsOrExceeds('unknown', 'suggest')).toBe(false);
+  });
+});
+
+describe('tier ordering tables', () => {
+  it('RISK_TIER_ORDER orders from negligible (0) to critical (4)', () => {
+    const order = ['negligible', 'low', 'moderate', 'high', 'critical'].map(
+      (t) => RISK_TIER_ORDER[t] ?? -1,
+    );
+    expect(order).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('TRUST_TIER_ORDER orders from observer (0) to high_autonomy (4)', () => {
+    expect(TRUST_TIER_ORDER['observer']).toBe(0);
+    expect(TRUST_TIER_ORDER['high_autonomy']).toBe(4);
+  });
+
+  it('CONFIDENCE_LEVEL_ORDER orders from speculative (0) to confirmed (4)', () => {
+    expect(CONFIDENCE_LEVEL_ORDER['speculative']).toBe(0);
+    expect(CONFIDENCE_LEVEL_ORDER['confirmed']).toBe(4);
+  });
+});
+
+describe('createLogger', () => {
+  // Using a permissive helper type because vi.spyOn's generic differs across
+  // versions and we just need .mockRestore + .mock.calls here.
+  type Spy = ReturnType<typeof vi.fn> & { mockRestore: () => void };
+  let debugSpy: Spy;
+  let infoSpy: Spy;
+  let warnSpy: Spy;
+  let errorSpy: Spy;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {}) as unknown as Spy;
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {}) as unknown as Spy;
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {}) as unknown as Spy;
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {}) as unknown as Spy;
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('routes each level to the matching console method', () => {
+    const log = createLogger('test');
+    log.debug('d');
+    log.info('i');
+    log.warn('w');
+    log.error('e');
+    expect(debugSpy).toHaveBeenCalledOnce();
+    expect(infoSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('includes namespace, level, and message in each formatted line', () => {
+    const log = createLogger('decision-engine');
+    log.info('Hello');
+    const line = String(infoSpy.mock.calls[0]?.[0] ?? '');
+    expect(line).toContain('[INFO]');
+    expect(line).toContain('[decision-engine]');
+    expect(line).toContain('Hello');
+  });
+
+  it('serializes meta as JSON when present', () => {
+    const log = createLogger('test');
+    log.warn('something', { userId: 'u1', count: 3 });
+    const line = String(warnSpy.mock.calls[0]?.[0] ?? '');
+    expect(line).toContain('"userId":"u1"');
+    expect(line).toContain('"count":3');
+  });
+
+  it('omits the meta blob when no meta is supplied', () => {
+    const log = createLogger('test');
+    log.info('plain');
+    const line = String(infoSpy.mock.calls[0]?.[0] ?? '');
+    expect(line).not.toContain('{');
+  });
+
+  it('emits an ISO 8601 timestamp', () => {
+    const log = createLogger('test');
+    log.error('boom');
+    const line = String(errorSpy.mock.calls[0]?.[0] ?? '');
+    expect(line).toMatch(/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\]/);
+  });
+});


### PR DESCRIPTION
## Summary
The session-start audit flagged \`@skytwin/config\` and the top-level helpers in \`@skytwin/core\` as having zero test coverage. Both are dependency roots — config gates bootstrap, core hosts comparison helpers used across decision/policy/risk paths. Silent regressions here cascade everywhere.

**\`@skytwin/config\` — 0 → 18 tests**
- \`loadConfig\` defaults, env reads, fallback parsing
- Legacy aliases: \`GATEWAY_AUTH_TOKEN\` → \`IRONCLAW_GATEWAY_TOKEN\`, \`IRONCLAW_CHANNEL\` → \`IRONCLAW_DEFAULT_CHANNEL\`
- \`validate()\` field-by-field rejection: empty/invalid databaseUrl, malformed URL, missing webhook secret (unless mock enabled), port range, NaN
- \`loadValidatedConfig\` success + aggregated error message lists every failing field

**\`@skytwin/core\` — 30 → 50 tests (+20)**
- \`generateId\` UUID shape + uniqueness
- \`compareRiskTiers\` eq/gt/lt/unknown
- \`riskExceeds\` strict-greater behavior
- \`trustMeetsOrExceeds\` gte semantics + unknown handling
- Tier ordering tables (RISK_TIER_ORDER, TRUST_TIER_ORDER, CONFIDENCE_LEVEL_ORDER)
- \`createLogger\` level routing, format (level + namespace + message + ISO timestamp), meta JSON serialization, omit-meta-when-absent

## Test plan
- [x] \`pnpm --filter @skytwin/config test\` — 18/18
- [x] \`pnpm --filter @skytwin/core test\` — 50/50 (was 30)
- [x] \`pnpm --filter @skytwin/config lint\` and \`@skytwin/core lint\` — clean
- [x] \`pnpm test\` — 38/38 turbo tasks
- [x] \`pnpm lint\` — 30/30 turbo tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)