### PR TITLE
test(connectors): cover gmail + google-calendar pure-logic methods

### DIFF
--- a/packages/connectors/src/__tests__/gmail-connector.test.ts
+++ b/packages/connectors/src/__tests__/gmail-connector.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import { GmailConnector } from '../gmail-connector.js';
+import type { OAuthTokenStore } from '../oauth/token-store.js';
+
+function makeStubStore(token: { accessToken: string; refreshToken: string; expiresAt: Date } | null): OAuthTokenStore {
+  return {
+    save: async () => undefined,
+    get: async () => token,
+    delete: async () => undefined,
+    refreshIfExpired: async () => {
+      if (!token) {
+        throw new Error('No token stored');
+      }
+      return token;
+    },
+  } as unknown as OAuthTokenStore;
+}
+
+function makeMessage(overrides: {
+  id?: string;
+  from?: string;
+  subject?: string;
+  labelIds?: string[];
+  internalDate?: string;
+  snippet?: string;
+} = {}): unknown {
+  return {
+    id: overrides.id ?? 'm1',
+    threadId: 'thread-1',
+    labelIds: overrides.labelIds ?? [],
+    snippet: overrides.snippet ?? 'preview text',
+    payload: {
+      headers: [
+        { name: 'From', value: overrides.from ?? 'sender@example.com' },
+        { name: 'Subject', value: overrides.subject ?? '' },
+        { name: 'Date', value: 'Mon, 1 Jan 2026 00:00:00 GMT' },
+      ],
+    },
+    internalDate: overrides.internalDate ?? '1735689600000',
+  };
+}
+
+describe('GmailConnector lifecycle', () => {
+  it('connect() throws when no token is available', async () => {
+    const conn = new GmailConnector('user-1', makeStubStore(null));
+    await expect(conn.connect()).rejects.toThrow();
+  });
+
+  it('connect() succeeds when a token is available', async () => {
+    const store = makeStubStore({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const conn = new GmailConnector('user-1', store);
+    await expect(conn.connect()).resolves.toBeUndefined();
+  });
+
+  it('poll() throws if connect() was not called', async () => {
+    const store = makeStubStore({
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const conn = new GmailConnector('user-1', store);
+    await expect(conn.poll()).rejects.toThrow(/not connected/);
+  });
+
+  it('disconnect() clears handler list and connection state', async () => {
+    const store = makeStubStore({
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const conn = new GmailConnector('user-1', store);
+    await conn.connect();
+    conn.onSignal(() => {});
+    await conn.disconnect();
+    // After disconnect, poll should throw "not connected" again
+    await expect(conn.poll()).rejects.toThrow(/not connected/);
+  });
+});
+
+describe('GmailConnector.inferEmailType', () => {
+  // Private method — accessed via cast for test coverage of the classification.
+  function infer(from: string, subject: string, labels: string[] = []): string {
+    const conn = new GmailConnector('u', makeStubStore(null));
+    return (conn as unknown as { inferEmailType: (f: string, s: string, l: string[]) => string })
+      .inferEmailType(from, subject, labels);
+  }
+
+  it('classifies CATEGORY_PROMOTIONS as newsletter', () => {
+    expect(infer('any@x.com', '', ['CATEGORY_PROMOTIONS'])).toBe('newsletter');
+  });
+
+  it('classifies "newsletter" or "digest" subjects as newsletter', () => {
+    expect(infer('a@x.com', 'Weekly Newsletter')).toBe('newsletter');
+    expect(infer('a@x.com', 'Daily Digest')).toBe('newsletter');
+  });
+
+  it('classifies subscription/renewal/billing subjects', () => {
+    expect(infer('a@x.com', 'Your subscription is renewing')).toBe('subscription_renewal');
+    expect(infer('a@x.com', 'Billing notice')).toBe('subscription_renewal');
+  });
+
+  it('classifies meeting subjects as meeting_invite', () => {
+    expect(infer('a@x.com', 'Meeting on Friday')).toBe('meeting_invite');
+    expect(infer('a@x.com', 'Calendar invite')).toBe('meeting_invite');
+  });
+
+  it('classifies grocery/order subjects as grocery_reorder', () => {
+    expect(infer('a@x.com', 'Your order has shipped')).toBe('grocery_reorder');
+    expect(infer('a@x.com', 'Grocery delivery tomorrow')).toBe('grocery_reorder');
+  });
+
+  it('classifies travel-related subjects as travel_alert', () => {
+    expect(infer('a@x.com', 'Flight confirmation')).toBe('travel_alert');
+    expect(infer('a@x.com', 'Hotel booking')).toBe('travel_alert');
+  });
+
+  it('classifies noreply senders as notification', () => {
+    expect(infer('noreply@stripe.com', 'Receipt')).toBe('notification');
+    expect(infer('no-reply@github.com', 'Pull request')).toBe('notification');
+  });
+
+  it('classifies CATEGORY_UPDATES as notification', () => {
+    expect(infer('person@example.com', 'Update', ['CATEGORY_UPDATES'])).toBe('notification');
+  });
+
+  it('falls back to work_email for unmatched mail', () => {
+    expect(infer('client@company.com', 'Quick question about the contract')).toBe('work_email');
+  });
+
+  it('case-insensitive matching on subject and sender', () => {
+    expect(infer('a@x.com', 'NEWSLETTER FROM US')).toBe('newsletter');
+    expect(infer('NoReply@example.com', 'Hi')).toBe('notification');
+  });
+});
+
+describe('GmailConnector.messageToSignal', () => {
+  function toSignal(msg: unknown): unknown {
+    const conn = new GmailConnector('u', makeStubStore(null));
+    return (conn as unknown as { messageToSignal: (m: unknown) => unknown }).messageToSignal(msg);
+  }
+
+  it('produces a stable id prefix and source', () => {
+    const sig = toSignal(makeMessage({ id: 'abc' })) as { id: string; source: string };
+    expect(sig.id).toBe('sig_gmail_abc');
+    expect(sig.source).toBe('gmail');
+  });
+
+  it('extracts From and Subject case-insensitively', () => {
+    const msg = {
+      id: 'm1',
+      threadId: 't1',
+      labelIds: [],
+      snippet: '',
+      payload: {
+        headers: [
+          { name: 'from', value: 'lower@example.com' },
+          { name: 'SUBJECT', value: 'Mixed case header' },
+        ],
+      },
+      internalDate: '1735689600000',
+    };
+    const sig = toSignal(msg) as { data: { from: string; subject: string } };
+    expect(sig.data.from).toBe('lower@example.com');
+    expect(sig.data.subject).toBe('Mixed case header');
+  });
+
+  it('marks work_email and meeting_invite as requiresResponse', () => {
+    const work = toSignal(makeMessage({ subject: 'Quick question' })) as { data: { requiresResponse: boolean } };
+    const meeting = toSignal(makeMessage({ subject: 'Meeting on Friday' })) as { data: { requiresResponse: boolean } };
+    expect(work.data.requiresResponse).toBe(true);
+    expect(meeting.data.requiresResponse).toBe(true);
+  });
+
+  it('does not mark newsletters or notifications as requiresResponse', () => {
+    const news = toSignal(makeMessage({ subject: 'Weekly Newsletter' })) as { data: { requiresResponse: boolean } };
+    const noti = toSignal(makeMessage({ from: 'noreply@x.com', subject: 'Receipt' })) as { data: { requiresResponse: boolean } };
+    expect(news.data.requiresResponse).toBe(false);
+    expect(noti.data.requiresResponse).toBe(false);
+  });
+
+  it('parses internalDate (epoch ms) into ISO timestamp', () => {
+    const sig = toSignal(makeMessage({ internalDate: '1735689600000' })) as {
+      data: { receivedAt: string };
+      timestamp: Date;
+    };
+    expect(sig.data.receivedAt).toBe(new Date(1735689600000).toISOString());
+    expect(sig.timestamp).toBeInstanceOf(Date);
+  });
+
+  it('handles missing headers without throwing', () => {
+    const msg = {
+      id: 'm1',
+      threadId: 't1',
+      labelIds: [],
+      snippet: '',
+      payload: { headers: [] },
+      internalDate: '1735689600000',
+    };
+    const sig = toSignal(msg) as { data: { from: string; subject: string } };
+    expect(sig.data.from).toBe('');
+    expect(sig.data.subject).toBe('');
+  });
+});

--- a/packages/connectors/src/__tests__/google-calendar-connector.test.ts
+++ b/packages/connectors/src/__tests__/google-calendar-connector.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import { GoogleCalendarConnector } from '../google-calendar-connector.js';
+import type { OAuthTokenStore } from '../oauth/token-store.js';
+
+function makeStubStore(token: { accessToken: string; refreshToken: string; expiresAt: Date } | null): OAuthTokenStore {
+  return {
+    save: async () => undefined,
+    get: async () => token,
+    delete: async () => undefined,
+    refreshIfExpired: async () => {
+      if (!token) {
+        throw new Error('No token stored');
+      }
+      return token;
+    },
+  } as unknown as OAuthTokenStore;
+}
+
+interface RawCalendarEvent {
+  id: string;
+  summary: string;
+  description?: string;
+  start: { dateTime?: string; date?: string };
+  end: { dateTime?: string; date?: string };
+  organizer: { email: string; displayName?: string };
+  attendees?: Array<{ email: string; responseStatus: string; self?: boolean }>;
+  status: string;
+  htmlLink: string;
+  created: string;
+  updated: string;
+}
+
+function makeEvent(overrides: Partial<RawCalendarEvent> = {}): RawCalendarEvent {
+  return {
+    id: overrides.id ?? 'evt-1',
+    summary: overrides.summary ?? 'Standup',
+    start: overrides.start ?? { dateTime: '2026-04-27T09:00:00Z' },
+    end: overrides.end ?? { dateTime: '2026-04-27T09:30:00Z' },
+    organizer: overrides.organizer ?? { email: 'host@example.com' },
+    attendees: overrides.attendees,
+    status: overrides.status ?? 'confirmed',
+    htmlLink: overrides.htmlLink ?? 'https://calendar.google.com/event?eid=x',
+    created: overrides.created ?? '2026-04-26T00:00:00Z',
+    updated: overrides.updated ?? '2026-04-26T00:00:00Z',
+    description: overrides.description,
+  };
+}
+
+describe('GoogleCalendarConnector lifecycle', () => {
+  it('connect() throws when no token is available', async () => {
+    const conn = new GoogleCalendarConnector('user-1', makeStubStore(null));
+    await expect(conn.connect()).rejects.toThrow();
+  });
+
+  it('connect() succeeds with a valid token', async () => {
+    const store = makeStubStore({
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const conn = new GoogleCalendarConnector('user-1', store);
+    await expect(conn.connect()).resolves.toBeUndefined();
+  });
+
+  it('poll() throws when not connected', async () => {
+    const store = makeStubStore({
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const conn = new GoogleCalendarConnector('user-1', store);
+    await expect(conn.poll()).rejects.toThrow(/not connected/);
+  });
+
+  it('disconnect() clears state and handlers', async () => {
+    const store = makeStubStore({
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const conn = new GoogleCalendarConnector('user-1', store);
+    await conn.connect();
+    await conn.disconnect();
+    await expect(conn.poll()).rejects.toThrow(/not connected/);
+  });
+});
+
+describe('GoogleCalendarConnector.eventToSignal', () => {
+  function toSignal(event: RawCalendarEvent, hasConflict = false): unknown {
+    const conn = new GoogleCalendarConnector('u', makeStubStore(null));
+    return (conn as unknown as { eventToSignal: (e: RawCalendarEvent, c: boolean) => unknown })
+      .eventToSignal(event, hasConflict);
+  }
+
+  it('produces a stable id derived from event id and updated timestamp', () => {
+    const sig = toSignal(makeEvent({ id: 'abc', updated: '2026-04-26T12:34:56Z' })) as { id: string; source: string };
+    expect(sig.id).toContain('sig_cal_abc');
+    expect(sig.source).toBe('google_calendar');
+  });
+
+  it('marks needsAction self-attendee as meeting_invite + requiresResponse', () => {
+    const event = makeEvent({
+      attendees: [{ email: 'me@x.com', responseStatus: 'needsAction', self: true }],
+    });
+    const sig = toSignal(event) as { type: string; data: { requiresResponse: boolean; responseStatus: string } };
+    expect(sig.type).toBe('meeting_invite');
+    expect(sig.data.requiresResponse).toBe(true);
+    expect(sig.data.responseStatus).toBe('needsAction');
+  });
+
+  it('marks accepted self-attendee as calendar_event (no response needed)', () => {
+    const event = makeEvent({
+      attendees: [{ email: 'me@x.com', responseStatus: 'accepted', self: true }],
+    });
+    const sig = toSignal(event) as { type: string; data: { requiresResponse: boolean } };
+    expect(sig.type).toBe('calendar_event');
+    expect(sig.data.requiresResponse).toBe(false);
+  });
+
+  it('treats events without self attendee as calendar_event', () => {
+    const event = makeEvent({
+      attendees: [{ email: 'someone@x.com', responseStatus: 'accepted' }],
+    });
+    const sig = toSignal(event) as { type: string; data: { responseStatus: string } };
+    expect(sig.type).toBe('calendar_event');
+    expect(sig.data.responseStatus).toBe('unknown');
+  });
+
+  it('surfaces the conflict flag in payload', () => {
+    const sig = toSignal(makeEvent(), true) as { data: { hasConflict: boolean } };
+    expect(sig.data.hasConflict).toBe(true);
+  });
+
+  it('handles all-day events (date instead of dateTime)', () => {
+    const event = makeEvent({
+      start: { date: '2026-04-27' },
+      end: { date: '2026-04-28' },
+    });
+    const sig = toSignal(event) as { data: { startTime: string; endTime: string } };
+    expect(sig.data.startTime).toBe('2026-04-27');
+    expect(sig.data.endTime).toBe('2026-04-28');
+  });
+});
+
+describe('GoogleCalendarConnector.detectConflicts', () => {
+  function detect(events: RawCalendarEvent[]): Set<string> {
+    const conn = new GoogleCalendarConnector('u', makeStubStore(null));
+    return (conn as unknown as { detectConflicts: (e: RawCalendarEvent[]) => Set<string> })
+      .detectConflicts(events);
+  }
+
+  it('returns empty set when no events overlap', () => {
+    const events = [
+      makeEvent({ id: 'a', start: { dateTime: '2026-04-27T09:00:00Z' }, end: { dateTime: '2026-04-27T10:00:00Z' } }),
+      makeEvent({ id: 'b', start: { dateTime: '2026-04-27T10:30:00Z' }, end: { dateTime: '2026-04-27T11:00:00Z' } }),
+    ];
+    expect(detect(events).size).toBe(0);
+  });
+
+  it('flags both events when they overlap', () => {
+    const events = [
+      makeEvent({ id: 'a', start: { dateTime: '2026-04-27T09:00:00Z' }, end: { dateTime: '2026-04-27T10:00:00Z' } }),
+      makeEvent({ id: 'b', start: { dateTime: '2026-04-27T09:30:00Z' }, end: { dateTime: '2026-04-27T10:30:00Z' } }),
+    ];
+    const conflicts = detect(events);
+    expect(conflicts.has('a')).toBe(true);
+    expect(conflicts.has('b')).toBe(true);
+  });
+
+  it('does not flag back-to-back events sharing a boundary', () => {
+    // a ends at 10:00, b starts at 10:00 → not a conflict
+    const events = [
+      makeEvent({ id: 'a', start: { dateTime: '2026-04-27T09:00:00Z' }, end: { dateTime: '2026-04-27T10:00:00Z' } }),
+      makeEvent({ id: 'b', start: { dateTime: '2026-04-27T10:00:00Z' }, end: { dateTime: '2026-04-27T11:00:00Z' } }),
+    ];
+    expect(detect(events).size).toBe(0);
+  });
+
+  it('flags all events in a three-way overlap', () => {
+    const events = [
+      makeEvent({ id: 'a', start: { dateTime: '2026-04-27T09:00:00Z' }, end: { dateTime: '2026-04-27T11:00:00Z' } }),
+      makeEvent({ id: 'b', start: { dateTime: '2026-04-27T10:00:00Z' }, end: { dateTime: '2026-04-27T10:30:00Z' } }),
+      makeEvent({ id: 'c', start: { dateTime: '2026-04-27T10:15:00Z' }, end: { dateTime: '2026-04-27T11:00:00Z' } }),
+    ];
+    const conflicts = detect(events);
+    expect(conflicts.has('a')).toBe(true);
+    expect(conflicts.has('b')).toBe(true);
+    expect(conflicts.has('c')).toBe(true);
+  });
+
+  it('ignores events without dateTime (all-day events)', () => {
+    const events = [
+      makeEvent({ id: 'a', start: { dateTime: '2026-04-27T09:00:00Z' }, end: { dateTime: '2026-04-27T10:00:00Z' } }),
+      makeEvent({ id: 'allday', start: { date: '2026-04-27' }, end: { date: '2026-04-28' } }),
+    ];
+    const conflicts = detect(events);
+    // Only a is dateTime; allday is ignored — no overlap detected
+    expect(conflicts.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the second-largest gap from the session-start audit: \`@skytwin/connectors\` had a single test (db-token-store) despite handling OAuth tokens and normalizing untrusted external data. Connectors feed raw signals into the decision pipeline, so silent bugs cascade.

This PR covers the pure-logic methods that don't need network mocking. Network-bound paths (poll → fetch, retry on 429) remain a follow-up — they need either a recorded fixture suite or a fetch mock layer.

**\`gmail-connector\` — +20 tests**
- Lifecycle: \`connect\` throws on missing token / succeeds with valid token, \`poll\` throws when not connected, \`disconnect\` clears state
- \`inferEmailType\` (9 cases): newsletter (PROMOTIONS label, \"newsletter\"/\"digest\" subjects), subscription_renewal, meeting_invite, grocery_reorder, travel_alert, notification (noreply + UPDATES), case-insensitive matching, work_email fallback
- \`messageToSignal\` (6 cases): id format, case-insensitive header extraction, \`requiresResponse\` derivation per email type, internalDate → ISO timestamp, missing-headers safety

**\`google-calendar-connector\` — +15 tests**
- Lifecycle: same shape as gmail
- \`eventToSignal\`: id format, needsAction → meeting_invite + requiresResponse, accepted-self → calendar_event, no-self-attendee fallback, conflict-flag passthrough, all-day events (\`date\` instead of \`dateTime\`)
- \`detectConflicts\`: empty, two-way overlap, back-to-back boundary (NOT a conflict), three-way overlap, all-day events ignored

**Net coverage:** connectors went 8 → 43 tests.

## Test plan
- [x] \`pnpm --filter @skytwin/connectors test\` — 43/43 (was 8)
- [x] \`pnpm --filter @skytwin/connectors lint\` — clean
- [x] \`pnpm test\` — 38/38 turbo tasks
- [x] \`pnpm lint\` — 30/30 turbo tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)