### PR TITLE
fix(llm-client): harden URL validation against zone IDs, trailing dots, CGNAT

### DIFF
--- a/packages/llm-client/src/__tests__/url-validation.test.ts
+++ b/packages/llm-client/src/__tests__/url-validation.test.ts
@@ -167,4 +167,57 @@ describe('validateBaseUrl', () => {
       expect(() => validateBaseUrl('http://[fd12::1]:11434', 'ollama')).toThrow('only loopback addresses are allowed');
     });
   });
+
+  describe('hostname normalization (hardening)', () => {
+    it('blocks trailing-dot localhost ("localhost.")', () => {
+      expect(() => validateBaseUrl('http://localhost./api', 'openai')).toThrow('Private/internal URL not allowed');
+    });
+
+    it('blocks trailing-dot 127.0.0.1 ("127.0.0.1.")', () => {
+      expect(() => validateBaseUrl('http://127.0.0.1./api', 'openai')).toThrow('Private/internal URL not allowed');
+    });
+
+    it('blocks IPv6 zone id ([fe80::1%eth0])', () => {
+      // Node's URL parser rejects bracketed IPv6 with a zone id outright as
+      // an invalid URL. That's defense-in-depth — either an "Invalid base
+      // URL" or "Private/internal URL not allowed" is acceptable; the URL
+      // must NOT pass through.
+      expect(() => validateBaseUrl('http://[fe80::1%25eth0]:8080', 'openai'))
+        .toThrow(/Invalid base URL|Private\/internal URL not allowed/);
+    });
+
+    it('blocks bracketed link-local without zone id ([fe80::1])', () => {
+      // The non-zone form parses fine and must be caught by isPrivateHost.
+      expect(() => validateBaseUrl('http://[fe80::1]:8080', 'openai'))
+        .toThrow('Private/internal URL not allowed');
+    });
+
+    it('blocks uppercase LOCALHOST', () => {
+      expect(() => validateBaseUrl('http://LOCALHOST:8080', 'openai')).toThrow('Private/internal URL not allowed');
+    });
+
+    it('blocks the IPv6 unspecified address [::]', () => {
+      expect(() => validateBaseUrl('http://[::]:8080', 'openai')).toThrow('Private/internal URL not allowed');
+    });
+
+    it('blocks long-form IPv6 unspecified [0:0:0:0:0:0:0:0]', () => {
+      // Node URL parser may collapse this to [::], either way it should block
+      expect(() => validateBaseUrl('http://[0:0:0:0:0:0:0:0]:8080', 'openai')).toThrow('Private/internal URL not allowed');
+    });
+  });
+
+  describe('CGNAT (RFC 6598) blocking', () => {
+    it('blocks 100.64.0.0/10 (CGNAT range start)', () => {
+      expect(() => validateBaseUrl('http://100.64.0.1', 'openai')).toThrow('Private/internal URL not allowed');
+    });
+
+    it('blocks 100.127.255.254 (CGNAT range end)', () => {
+      expect(() => validateBaseUrl('http://100.127.255.254', 'openai')).toThrow('Private/internal URL not allowed');
+    });
+
+    it('allows 100.63.x.x and 100.128.x.x (outside CGNAT)', () => {
+      expect(() => validateBaseUrl('http://100.63.0.1', 'openai')).not.toThrow();
+      expect(() => validateBaseUrl('http://100.128.0.1', 'openai')).not.toThrow();
+    });
+  });
 });

--- a/packages/llm-client/src/url-validation.ts
+++ b/packages/llm-client/src/url-validation.ts
@@ -21,8 +21,7 @@ export function validateBaseUrl(baseUrl: string, provider: string): void {
     throw new Error(`Unsupported protocol for ${provider}: ${parsed.protocol}`);
   }
 
-  // URL parser keeps brackets around IPv6: [::1] → strip them for matching
-  const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  const hostname = normalizeHostname(parsed.hostname);
 
   // Block cloud metadata endpoints (all providers, including Ollama)
   if (hostname === '169.254.169.254' || hostname === 'metadata.google.internal') {
@@ -53,7 +52,7 @@ export async function validateBaseUrlWithDns(baseUrl: string, provider: string):
   validateBaseUrl(baseUrl, provider);
 
   const { lookup } = await import('node:dns/promises');
-  const hostname = new URL(baseUrl).hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  const hostname = normalizeHostname(new URL(baseUrl).hostname);
 
   // Skip literal IPs and localhost — already validated above
   if (hostname === 'localhost' || /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname) || hostname.includes(':')) {
@@ -80,9 +79,34 @@ export async function validateBaseUrlWithDns(baseUrl: string, provider: string):
   }
 }
 
+/**
+ * Normalize a hostname for safe matching:
+ * - lowercase
+ * - strip surrounding [] (URL parser leaves brackets on IPv6)
+ * - strip trailing dot (DNS root marker — `localhost.` should match `localhost`)
+ * - strip IPv6 zone id (`fe80::1%eth0` → `fe80::1`)
+ *
+ * Bypasses we are guarding against:
+ * - `LOCALHOST` (case): caught by lowercase
+ * - `localhost.` (trailing dot): caught by dot strip
+ * - `[fe80::1%eth0]` (IPv6 link-local with zone): caught by zone strip + bracket strip
+ */
+function normalizeHostname(raw: string): string {
+  let h = raw.toLowerCase().replace(/^\[|\]$/g, '');
+  if (h.endsWith('.')) h = h.slice(0, -1);
+  const zoneIdx = h.indexOf('%');
+  if (zoneIdx >= 0) h = h.slice(0, zoneIdx);
+  return h;
+}
+
 function isPrivateHost(hostname: string): boolean {
   // Loopback
   if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') {
+    return true;
+  }
+
+  // IPv6 unspecified — equivalent to 0.0.0.0
+  if (hostname === '::' || hostname === '0:0:0:0:0:0:0:0') {
     return true;
   }
 
@@ -113,6 +137,9 @@ function isPrivateHost(hostname: string): boolean {
       if (nums[0] === 127) return true;
       // 0.0.0.0/8
       if (nums[0] === 0) return true;
+      // 100.64.0.0/10 (Carrier-Grade NAT, RFC 6598) — provider-internal,
+      // shouldn't be a target for outbound LLM calls.
+      if (nums[0] === 100 && nums[1]! >= 64 && nums[1]! <= 127) return true;
     }
   }
 


### PR DESCRIPTION
## Summary
SSRF defense in \`@skytwin/llm-client\` was solid for common cases (RFC 1918, link-local, cloud metadata, octal/hex encodings, IPv6 mapped IPv4). The session-start audit flagged three gaps; this PR closes them.

**1. Centralized hostname normalization.** New \`normalizeHostname()\` is the single source of truth for hostname matching. Strips brackets, lowercases, drops trailing dot, drops IPv6 zone id. Both \`validateBaseUrl\` and \`validateBaseUrlWithDns\` route through it so bypasses like \`localhost.\` (DNS root marker) and \`[fe80::1%eth0]\` (link-local with zone) can't slip past.

**2. IPv6 unspecified address.** Both \`[::]\` and the long form \`[0:0:0:0:0:0:0:0]\` now block as private (equivalent to \`0.0.0.0\`).

**3. CGNAT (RFC 6598).** 100.64.0.0/10 — provider-internal carrier NAT range — now blocks. No legitimate LLM endpoint lives there. Boundary-correct: 100.63.x.x and 100.128.x.x still pass.

## Test plan
- [x] \`pnpm --filter @skytwin/llm-client test\` — 78/78 (was 68, +10 hardening tests)
- [x] \`pnpm --filter @skytwin/llm-client lint\` — clean
- [x] \`pnpm test\` — 38/38 turbo tasks
- [x] \`pnpm lint\` — 30/30 turbo tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)