### PR TITLE
fix(execution-router): validate adapter shape and pass manifest defaultConfig

### DIFF
--- a/packages/execution-router/src/__tests__/adapter-manifest.test.ts
+++ b/packages/execution-router/src/__tests__/adapter-manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateManifest } from '../adapter-manifest.js';
+import { validateManifest, isAdapterShape, REQUIRED_ADAPTER_METHODS } from '../adapter-manifest.js';
 // ── Test helpers ─────────────────────────────────────────────────────
 
 function makeValidManifestInput(): Record<string, unknown> {
@@ -332,5 +332,76 @@ describe('validateManifest', () => {
         expect(result.manifest.trustProfile.riskModifier).toBe(2);
       }
     });
+
+    it('parses defaultConfig when present and a plain object', () => {
+      const input = makeValidManifestInput();
+      input['defaultConfig'] = { apiUrl: 'https://x.example.com', channel: 'main' };
+      const result = validateManifest(input);
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.manifest.defaultConfig).toEqual({ apiUrl: 'https://x.example.com', channel: 'main' });
+      }
+    });
+
+    it('drops defaultConfig when missing', () => {
+      const result = validateManifest(makeValidManifestInput());
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.manifest.defaultConfig).toBeUndefined();
+      }
+    });
+
+    it('drops defaultConfig when not an object (string, array, number)', () => {
+      const inputs = ['hello', [1, 2, 3], 42, true];
+      for (const v of inputs) {
+        const input = makeValidManifestInput();
+        input['defaultConfig'] = v as unknown;
+        const result = validateManifest(input);
+        expect(result.valid).toBe(true);
+        if (result.valid) {
+          expect(result.manifest.defaultConfig).toBeUndefined();
+        }
+      }
+    });
+  });
+});
+
+describe('isAdapterShape', () => {
+  function validShape(): Record<string, unknown> {
+    return {
+      buildPlan: () => ({}),
+      execute: () => ({}),
+      rollback: () => ({}),
+      healthCheck: () => ({ healthy: true, latencyMs: 0 }),
+    };
+  }
+
+  it('accepts a value that has every required method', () => {
+    expect(isAdapterShape(validShape())).toBe(true);
+  });
+
+  it('rejects a value missing any single required method', () => {
+    for (const m of REQUIRED_ADAPTER_METHODS) {
+      const obj = validShape();
+      delete obj[m];
+      expect(isAdapterShape(obj)).toBe(false);
+    }
+  });
+
+  it('rejects a value where a required method is not a function', () => {
+    const obj = validShape();
+    obj['execute'] = 'not a function';
+    expect(isAdapterShape(obj)).toBe(false);
+  });
+
+  it('rejects null and undefined', () => {
+    expect(isAdapterShape(null)).toBe(false);
+    expect(isAdapterShape(undefined)).toBe(false);
+  });
+
+  it('rejects primitives', () => {
+    expect(isAdapterShape('hello')).toBe(false);
+    expect(isAdapterShape(42)).toBe(false);
+    expect(isAdapterShape(true)).toBe(false);
   });
 });

--- a/packages/execution-router/src/adapter-discovery.ts
+++ b/packages/execution-router/src/adapter-discovery.ts
@@ -3,7 +3,7 @@ import { join, resolve, sep, relative } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { IronClawAdapter } from '@skytwin/ironclaw-adapter';
 import type { AdapterTrustProfile } from '@skytwin/shared-types';
-import { validateManifest } from './adapter-manifest.js';
+import { validateManifest, isAdapterShape, REQUIRED_ADAPTER_METHODS } from './adapter-manifest.js';
 import type { AdapterManifest } from './adapter-manifest.js';
 import type { AdapterRegistry } from './adapter-registry.js';
 
@@ -97,7 +97,23 @@ export async function discoverAdapters(
         continue;
       }
 
-      const adapter = factory({});
+      // Pass manifest.defaultConfig if declared so plugins can receive their
+      // bootstrap settings instead of always getting an empty object.
+      let adapter: IronClawAdapter;
+      try {
+        adapter = factory(manifest.defaultConfig ?? {});
+      } catch (err) {
+        console.warn(`[adapter-discovery] ${dirName}: factory threw during construction: ${err instanceof Error ? err.message : String(err)}`);
+        continue;
+      }
+
+      // Validate the adapter implements the contract before registering.
+      // A plugin that returns a malformed object would otherwise surface as a
+      // NoAdapterError under load — fail fast at load time instead.
+      if (!isAdapterShape(adapter)) {
+        console.warn(`[adapter-discovery] ${dirName}: factory result is not a valid adapter (missing one of: ${REQUIRED_ADAPTER_METHODS.join(', ')})`);
+        continue;
+      }
 
       const trustProfile: AdapterTrustProfile = {
         name: manifest.name,

--- a/packages/execution-router/src/adapter-manifest.ts
+++ b/packages/execution-router/src/adapter-manifest.ts
@@ -16,6 +16,13 @@ export interface AdapterManifest {
   };
   skills: string[];
   healthEndpoint?: string;
+  /**
+   * Default config passed to the plugin's factory function. Use this when
+   * the adapter needs configuration to construct correctly (e.g. an API
+   * URL, channel id). Without this, the loader falls back to passing an
+   * empty object and the adapter is responsible for its own defaults.
+   */
+  defaultConfig?: Record<string, unknown>;
 }
 
 /**
@@ -71,7 +78,28 @@ export function validateManifest(raw: unknown): { valid: true; manifest: Adapter
     },
     skills: (obj['skills'] as unknown[]).filter((s) => typeof s === 'string') as string[],
     healthEndpoint: typeof obj['healthEndpoint'] === 'string' ? obj['healthEndpoint'] : undefined,
+    defaultConfig: (obj['defaultConfig'] && typeof obj['defaultConfig'] === 'object' && !Array.isArray(obj['defaultConfig']))
+      ? obj['defaultConfig'] as Record<string, unknown>
+      : undefined,
   };
 
   return { valid: true, manifest };
+}
+
+/**
+ * Required methods on an `IronClawAdapter` instance. The discovery loader
+ * checks for these so plugins that silently return malformed objects fail
+ * fast at load time rather than surfacing as a NoAdapterError under load.
+ */
+export const REQUIRED_ADAPTER_METHODS: readonly string[] = [
+  'buildPlan',
+  'execute',
+  'rollback',
+  'healthCheck',
+] as const;
+
+export function isAdapterShape(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  return REQUIRED_ADAPTER_METHODS.every((m) => typeof obj[m] === 'function');
 }


### PR DESCRIPTION
## Summary
Closes the adapter-discovery hardening item from the session-start audit. The discovery loader called \`factory({})\` with empty config and never validated the returned object — adapters that expected config keys silently failed, and adapters that returned malformed objects surfaced as \`NoAdapterError\` under load instead of failing fast.

**1. Manifest gains optional \`defaultConfig\`.** Plugins declare their bootstrap settings (api URL, channel id, etc.) and the loader passes them to the factory. Falls back to \`{}\` when absent — current plugins keep working. Strings/arrays/numbers/booleans for \`defaultConfig\` are dropped (must be a plain object).

**2. \`isAdapterShape\` shape check after construction.** The loader now validates the returned object implements the four required \`IronClawAdapter\` methods (\`buildPlan\`, \`execute\`, \`rollback\`, \`healthCheck\`) before registering. Plugins returning malformed objects now log \"factory result is not a valid adapter\" at load time instead of bubbling up as \`NoAdapterError\` under load. Also wraps \`factory()\` in try/catch so a throwing constructor doesn't kill discovery for unrelated plugins.

## Test plan
- [x] \`pnpm --filter @skytwin/execution-router test\` — 75/75 (was 67, +8)
- [x] \`pnpm --filter @skytwin/execution-router lint\` — clean
- [x] \`pnpm test\` — 38/38 turbo tasks
- [x] \`pnpm lint\` — 30/30 turbo tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)