### PR TITLE
test(worker): extract signal dedupe to a testable module + cover eviction

### DIFF
--- a/apps/worker/src/__tests__/signal-dedupe.test.ts
+++ b/apps/worker/src/__tests__/signal-dedupe.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import type { RawSignal } from '@skytwin/connectors';
+import { SignalDeduper, DEFAULT_TTL_MS, DEFAULT_MAX_PER_USER } from '../signal-dedupe.js';
+
+function makeSignal(id: string, source = 'gmail'): RawSignal {
+  return {
+    id,
+    source,
+    type: 'email_received',
+    data: {},
+    timestamp: new Date(),
+  };
+}
+
+describe('SignalDeduper', () => {
+  it('returns false for an unseen signal', () => {
+    const dedup = new SignalDeduper();
+    expect(dedup.has(makeSignal('s1'), 'user1')).toBe(false);
+  });
+
+  it('returns true after a signal is marked', () => {
+    const dedup = new SignalDeduper();
+    const sig = makeSignal('s1');
+    dedup.mark(sig, 'user1');
+    expect(dedup.has(sig, 'user1')).toBe(true);
+  });
+
+  it('isolates dedupe state per user', () => {
+    const dedup = new SignalDeduper();
+    const sig = makeSignal('s1');
+    dedup.mark(sig, 'user1');
+    expect(dedup.has(sig, 'user2')).toBe(false);
+  });
+
+  it('isolates dedupe state by signal source', () => {
+    const dedup = new SignalDeduper();
+    // Same id, different source → different dedupe key
+    const gmailSig = makeSignal('1', 'gmail');
+    const slackSig = makeSignal('1', 'slack');
+    dedup.mark(gmailSig, 'user1');
+    expect(dedup.has(gmailSig, 'user1')).toBe(true);
+    expect(dedup.has(slackSig, 'user1')).toBe(false);
+  });
+
+  it('expires entries past the TTL window', () => {
+    let now = 1_000_000;
+    const dedup = new SignalDeduper({ ttlMs: 1000, now: () => now });
+    const sig = makeSignal('s1');
+
+    dedup.mark(sig, 'user1');
+    expect(dedup.has(sig, 'user1')).toBe(true);
+
+    now += 999; // still within TTL
+    expect(dedup.has(sig, 'user1')).toBe(true);
+
+    now += 2; // past TTL
+    expect(dedup.has(sig, 'user1')).toBe(false);
+  });
+
+  it('mark() is idempotent — calling twice does not double-count', () => {
+    const dedup = new SignalDeduper();
+    const sig = makeSignal('s1');
+    dedup.mark(sig, 'user1');
+    dedup.mark(sig, 'user1');
+    expect(dedup.size('user1')).toBe(1);
+  });
+
+  it('reset() clears a single user without affecting others', () => {
+    const dedup = new SignalDeduper();
+    dedup.mark(makeSignal('s1'), 'user1');
+    dedup.mark(makeSignal('s2'), 'user2');
+    dedup.reset('user1');
+    expect(dedup.size('user1')).toBe(0);
+    expect(dedup.size('user2')).toBe(1);
+  });
+
+  // ── Eviction ─────────────────────────────────────────────────────
+
+  it('drops expired entries first when over capacity', () => {
+    let now = 0;
+    const dedup = new SignalDeduper({ ttlMs: 100, maxPerUser: 5, now: () => now });
+
+    // Insert 5 expired entries
+    for (let i = 0; i < 5; i++) {
+      dedup.mark(makeSignal(`old-${i}`), 'u');
+    }
+    now = 1000; // far past TTL
+
+    // Insert one more — pushes size to 6, triggers eviction
+    dedup.mark(makeSignal('new'), 'u');
+
+    // All 5 expired entries should have been swept; only the fresh one survives
+    expect(dedup.size('u')).toBe(1);
+    expect(dedup.has(makeSignal('new'), 'u')).toBe(true);
+  });
+
+  it('drops oldest insertion-order entries when all are within TTL', () => {
+    let now = 0;
+    const dedup = new SignalDeduper({ ttlMs: 10_000, maxPerUser: 3, now: () => now });
+
+    // Insert 3 entries within TTL
+    for (let i = 0; i < 3; i++) {
+      dedup.mark(makeSignal(`s${i}`), 'u');
+      now += 1; // distinct timestamps for clarity
+    }
+    expect(dedup.size('u')).toBe(3);
+
+    // Insert one more — exceeds cap, no expirations to sweep, oldest is dropped
+    dedup.mark(makeSignal('newest'), 'u');
+
+    // We had s0, s1, s2; insertion of newest pushes size to 4, evict drops s0
+    expect(dedup.size('u')).toBe(3);
+    expect(dedup.has(makeSignal('s0'), 'u')).toBe(false);
+    expect(dedup.has(makeSignal('s1'), 'u')).toBe(true);
+    expect(dedup.has(makeSignal('s2'), 'u')).toBe(true);
+    expect(dedup.has(makeSignal('newest'), 'u')).toBe(true);
+  });
+
+  it('eviction does not run while size is at or below the cap', () => {
+    let now = 0;
+    const dedup = new SignalDeduper({ ttlMs: 1, maxPerUser: 5, now: () => now });
+
+    for (let i = 0; i < 5; i++) dedup.mark(makeSignal(`s${i}`), 'u');
+    now = 10_000; // entries are technically expired
+
+    // Size is at the cap (5), so the eviction sweep does NOT run on insert.
+    // Test the read path: has() still respects the TTL.
+    expect(dedup.has(makeSignal('s0'), 'u')).toBe(false);
+    // But the entries are still in the map until eviction triggers.
+    expect(dedup.size('u')).toBe(5);
+  });
+
+  it('exposes default TTL and capacity constants', () => {
+    expect(DEFAULT_TTL_MS).toBe(24 * 60 * 60 * 1000);
+    expect(DEFAULT_MAX_PER_USER).toBe(5_000);
+  });
+});

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -15,15 +15,14 @@ import {
   serviceCredentialRepository,
 } from '@skytwin/db';
 import { withRetry, RetryableHttpError, CircuitBreaker, createLogger } from '@skytwin/core';
+import { SignalDeduper } from './signal-dedupe.js';
 
 const config = loadConfig();
 const log = createLogger('worker');
 
 /** Per-user circuit breakers to skip users with persistent failures. */
 const userCircuitBreakers = new Map<string, CircuitBreaker>();
-const seenSignalIdsByUser = new Map<string, Map<string, number>>();
-const SIGNAL_DEDUPE_TTL_MS = 24 * 60 * 60 * 1000;
-const SIGNAL_DEDUPE_MAX_PER_USER = 5_000;
+const signalDeduper = new SignalDeduper();
 
 function getCircuitBreaker(userId: string): CircuitBreaker {
   let breaker = userCircuitBreakers.get(userId);
@@ -91,47 +90,12 @@ async function forwardSignalToApi(signal: RawSignal, userId: string): Promise<vo
   log.info(`Forwarded signal ${signal.id} (${signal.source}/${signal.type}) for user ${userId}`);
 }
 
-function getSignalDedupeMap(userId: string): Map<string, number> {
-  const now = Date.now();
-  let seen = seenSignalIdsByUser.get(userId);
-  if (!seen) {
-    seen = new Map();
-    seenSignalIdsByUser.set(userId, seen);
-  }
-
-  // Evict expired entries first, then trim oldest if still over limit
-  if (seen.size > SIGNAL_DEDUPE_MAX_PER_USER) {
-    for (const [key, seenAt] of seen) {
-      if (now - seenAt > SIGNAL_DEDUPE_TTL_MS) {
-        seen.delete(key);
-      }
-    }
-    // If still over limit after expiry sweep, trim oldest entries (Map preserves insertion order)
-    if (seen.size > SIGNAL_DEDUPE_MAX_PER_USER) {
-      const excess = seen.size - SIGNAL_DEDUPE_MAX_PER_USER;
-      let removed = 0;
-      for (const key of seen.keys()) {
-        if (removed >= excess) break;
-        seen.delete(key);
-        removed++;
-      }
-    }
-  }
-
-  return seen;
-}
-
 function hasForwardedSignal(signal: RawSignal, userId: string): boolean {
-  const now = Date.now();
-  const seen = getSignalDedupeMap(userId);
-  const key = `${signal.source}:${signal.id}`;
-  const seenAt = seen.get(key);
-  return Boolean(seenAt && now - seenAt < SIGNAL_DEDUPE_TTL_MS);
+  return signalDeduper.has(signal, userId);
 }
 
 function markSignalForwarded(signal: RawSignal, userId: string): void {
-  const seen = getSignalDedupeMap(userId);
-  seen.set(`${signal.source}:${signal.id}`, Date.now());
+  signalDeduper.mark(signal, userId);
 }
 
 /**
@@ -445,11 +409,7 @@ async function main(): Promise<void> {
             userCircuitBreakers.delete(userId);
           }
         }
-        for (const userId of seenSignalIdsByUser.keys()) {
-          if (!newUserIds.has(userId)) {
-            seenSignalIdsByUser.delete(userId);
-          }
-        }
+        signalDeduper.pruneUsers(newUserIds);
       }
     }
 

--- a/apps/worker/src/signal-dedupe.ts
+++ b/apps/worker/src/signal-dedupe.ts
@@ -1,0 +1,120 @@
+import type { RawSignal } from '@skytwin/connectors';
+
+/**
+ * In-memory deduplication for signals already forwarded to the API.
+ *
+ * Each user has its own Map<signalKey, seenAtMs> with two bounds:
+ * - TTL: entries expire after `ttlMs`
+ * - Capacity: when a user's map exceeds `maxPerUser`, expired entries
+ *   are evicted first; if still over the cap, oldest insertion-order
+ *   entries are dropped (rough LRU)
+ *
+ * Pure module — no globals, no side effects on import. Test it directly
+ * by constructing a SignalDeduper with custom bounds and a clock.
+ */
+
+export interface DeduperOptions {
+  ttlMs?: number;
+  maxPerUser?: number;
+  /** Time source — exposed so tests can advance it deterministically. */
+  now?: () => number;
+}
+
+export const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+export const DEFAULT_MAX_PER_USER = 5_000;
+
+export class SignalDeduper {
+  private readonly ttlMs: number;
+  private readonly maxPerUser: number;
+  private readonly now: () => number;
+  private readonly seenByUser = new Map<string, Map<string, number>>();
+
+  constructor(opts: DeduperOptions = {}) {
+    this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxPerUser = opts.maxPerUser ?? DEFAULT_MAX_PER_USER;
+    this.now = opts.now ?? Date.now;
+  }
+
+  /** True if this signal has been forwarded for this user within the TTL window. */
+  has(signal: RawSignal, userId: string): boolean {
+    const map = this.seenByUser.get(userId);
+    if (!map) return false;
+    const seenAt = map.get(this.key(signal));
+    return Boolean(seenAt && this.now() - seenAt < this.ttlMs);
+  }
+
+  /** Record that a signal was forwarded for this user. */
+  mark(signal: RawSignal, userId: string): void {
+    const map = this.getOrCreate(userId);
+    map.set(this.key(signal), this.now());
+  }
+
+  /** Test/observability helper: how many entries are currently held for a user. */
+  size(userId: string): number {
+    return this.seenByUser.get(userId)?.size ?? 0;
+  }
+
+  /** Test helper: drop a user's map entirely. */
+  reset(userId: string): void {
+    this.seenByUser.delete(userId);
+  }
+
+  /**
+   * Drop dedupe state for any user not in `activeUserIds`. Used by the
+   * worker's user-discovery loop to release memory when a user is no
+   * longer tracked (e.g. their account was disconnected).
+   */
+  pruneUsers(activeUserIds: Set<string>): void {
+    for (const userId of this.seenByUser.keys()) {
+      if (!activeUserIds.has(userId)) {
+        this.seenByUser.delete(userId);
+      }
+    }
+  }
+
+  /**
+   * Compose the unique key for a signal. Source is included so that two
+   * connectors with overlapping numeric ids (e.g. gmail and slack each
+   * starting at "1") do not collide.
+   */
+  private key(signal: RawSignal): string {
+    return `${signal.source}:${signal.id}`;
+  }
+
+  private getOrCreate(userId: string): Map<string, number> {
+    let map = this.seenByUser.get(userId);
+    if (!map) {
+      map = new Map();
+      this.seenByUser.set(userId, map);
+    }
+
+    // Pre-emptively evict when about to exceed the cap. Using >= here means
+    // the cap is a hard ceiling: callers can't push the size above maxPerUser
+    // even by one. Walking the map on every set would be O(n) per signal —
+    // too costly under load — so the sweep only runs when the size is at the
+    // cap and a new entry is about to land.
+    if (map.size >= this.maxPerUser) {
+      this.evict(map);
+    }
+    return map;
+  }
+
+  private evict(map: Map<string, number>): void {
+    const cutoff = this.now() - this.ttlMs;
+
+    // First pass: drop expired entries.
+    for (const [k, seenAt] of map) {
+      if (seenAt < cutoff) {
+        map.delete(k);
+      }
+    }
+
+    // Free at least one slot so the next insert lands within the cap.
+    // Map iteration is insertion-ordered → the first key is the oldest.
+    while (map.size >= this.maxPerUser && map.size > 0) {
+      const oldestKey = map.keys().next().value;
+      if (oldestKey === undefined) break;
+      map.delete(oldestKey);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Closes the worker test gap from the session-start audit. The worker held its dedupe state in module-level Maps with no exported entry points, so TTL expiry and capacity eviction had zero coverage. Both matter for production memory bounds.

**Refactor**
- Extract \`SignalDeduper\` class to \`apps/worker/src/signal-dedupe.ts\` with constructor-injected TTL, capacity, and clock. Pure module — no globals, no side effects on import.
- Replace module-level \`seenSignalIdsByUser\` Map + \`getSignalDedupeMap\` / \`hasForwardedSignal\` / \`markSignalForwarded\` helpers with delegations to a single \`SignalDeduper\` instance.
- Add \`SignalDeduper.pruneUsers(activeUserIds)\` so the worker's user-discovery loop can release dedupe memory for users no longer tracked.

**Behavior tightening**
- Eviction now triggers on \`size >= maxPerUser\` (was strict \`>\`). The cap is now a hard ceiling — callers can't push the size above \`maxPerUser\` even by one. Previous logic allowed +1 overshoot. \`evict()\` drops expired entries first, then falls back to oldest-first removal until \`size < maxPerUser\`.

**Tests** — apps/worker had **zero** tests before this PR. Now has 11.
- Per-user isolation (state, source-namespacing for cross-connector ids)
- TTL expiry boundary
- \`mark()\` idempotency
- \`reset()\` per-user clear
- Eviction: expired-first sweep, then oldest-insertion-order
- Eviction stays inert while size is at or below the cap with no new insert
- Default \`DEFAULT_TTL_MS\` and \`DEFAULT_MAX_PER_USER\` constants exposed

## Test plan
- [x] \`pnpm --filter @skytwin/worker test\` — 11/11 (was 0)
- [x] \`pnpm --filter @skytwin/worker lint\` — clean
- [x] \`pnpm test\` — 38/38 turbo tasks
- [x] \`pnpm lint\` — 30/30 turbo tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)