### PR TITLE
feat(api): runtime validation at the /api/events/ingest boundary

### DIFF
--- a/apps/api/src/__tests__/event-ingest-validator.test.ts
+++ b/apps/api/src/__tests__/event-ingest-validator.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import { validateEventIngest } from '../validators/event-ingest.js';
+
+describe('validateEventIngest', () => {
+  describe('happy path', () => {
+    it('accepts a minimal valid event (just userId)', () => {
+      const result = validateEventIngest({ userId: 'user_1' });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.userId).toBe('user_1');
+        expect(result.event['userId']).toBe('user_1');
+      }
+    });
+
+    it('accepts a fully-populated event', () => {
+      const result = validateEventIngest({
+        userId: 'user_1',
+        source: 'gmail',
+        type: 'email_received',
+        urgency: 'high',
+        data: { from: 'a@b.com', subject: 'Hi' },
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('accepts every documented urgency value', () => {
+      for (const urgency of ['low', 'medium', 'high', 'critical']) {
+        const result = validateEventIngest({ userId: 'u', urgency });
+        expect(result.ok).toBe(true);
+      }
+    });
+  });
+
+  describe('body shape', () => {
+    it('rejects null body', () => {
+      const result = validateEventIngest(null);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errors[0]?.field).toBe('_body');
+      }
+    });
+
+    it('rejects array body', () => {
+      const result = validateEventIngest([{ userId: 'u' }]);
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects primitive body', () => {
+      expect(validateEventIngest('hello').ok).toBe(false);
+      expect(validateEventIngest(42).ok).toBe(false);
+      expect(validateEventIngest(true).ok).toBe(false);
+    });
+
+    it('rejects undefined body', () => {
+      expect(validateEventIngest(undefined).ok).toBe(false);
+    });
+  });
+
+  describe('userId', () => {
+    it('rejects missing userId', () => {
+      const result = validateEventIngest({});
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errors.find((e) => e.field === 'userId')).toBeDefined();
+      }
+    });
+
+    it('rejects empty-string userId', () => {
+      const result = validateEventIngest({ userId: '' });
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects whitespace-only userId', () => {
+      const result = validateEventIngest({ userId: '   ' });
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects non-string userId', () => {
+      expect(validateEventIngest({ userId: 42 }).ok).toBe(false);
+      expect(validateEventIngest({ userId: null }).ok).toBe(false);
+      expect(validateEventIngest({ userId: { id: 'u' } }).ok).toBe(false);
+    });
+  });
+
+  describe('source and type', () => {
+    it('accepts missing source and type (interpreter has fallbacks)', () => {
+      expect(validateEventIngest({ userId: 'u' }).ok).toBe(true);
+    });
+
+    it('rejects non-string source', () => {
+      const result = validateEventIngest({ userId: 'u', source: 42 });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errors.find((e) => e.field === 'source')).toBeDefined();
+      }
+    });
+
+    it('rejects non-string type', () => {
+      const result = validateEventIngest({ userId: 'u', type: { name: 'email' } });
+      expect(result.ok).toBe(false);
+    });
+
+    it('accepts empty-string source and type (interpreter normalizes)', () => {
+      expect(validateEventIngest({ userId: 'u', source: '', type: '' }).ok).toBe(true);
+    });
+  });
+
+  describe('urgency', () => {
+    it('rejects unknown urgency value', () => {
+      const result = validateEventIngest({ userId: 'u', urgency: 'urgent' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errors.find((e) => e.field === 'urgency')).toBeDefined();
+      }
+    });
+
+    it('rejects non-string urgency', () => {
+      expect(validateEventIngest({ userId: 'u', urgency: 5 }).ok).toBe(false);
+    });
+  });
+
+  describe('data', () => {
+    it('accepts missing data', () => {
+      expect(validateEventIngest({ userId: 'u' }).ok).toBe(true);
+    });
+
+    it('accepts empty data object', () => {
+      expect(validateEventIngest({ userId: 'u', data: {} }).ok).toBe(true);
+    });
+
+    it('rejects array data', () => {
+      const result = validateEventIngest({ userId: 'u', data: [1, 2, 3] });
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects null data', () => {
+      const result = validateEventIngest({ userId: 'u', data: null });
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects primitive data', () => {
+      expect(validateEventIngest({ userId: 'u', data: 'hello' }).ok).toBe(false);
+      expect(validateEventIngest({ userId: 'u', data: 42 }).ok).toBe(false);
+    });
+  });
+
+  describe('trustTier injection prevention', () => {
+    it('rejects caller-supplied trustTier even if value is valid', () => {
+      const result = validateEventIngest({
+        userId: 'u',
+        trustTier: 'high_autonomy',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errors.find((e) => e.field === 'trustTier')?.message)
+          .toContain('cannot be set by the caller');
+      }
+    });
+
+    it('rejects trustTier even when set to undefined explicitly', () => {
+      // The contract is "trustTier is not a caller field" — sneaking it in as
+      // undefined should still trigger the explicit rejection.
+      const result = validateEventIngest({ userId: 'u', trustTier: undefined });
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('error aggregation', () => {
+    it('returns every failing field, not just the first', () => {
+      const result = validateEventIngest({
+        userId: 42,
+        urgency: 'urgent',
+        data: 'not an object',
+        trustTier: 'high_autonomy',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const fields = result.errors.map((e) => e.field).sort();
+        expect(fields).toEqual(['data', 'trustTier', 'urgency', 'userId']);
+      }
+    });
+  });
+});

--- a/apps/api/src/routes/events.ts
+++ b/apps/api/src/routes/events.ts
@@ -36,6 +36,7 @@ import { processTravelDecision } from '../workflows/travel-decision.js';
 import { getExecutionRouter } from '../execution-setup.js';
 import { bindUserIdParamOwnership } from '../middleware/require-ownership.js';
 import { sseManager } from '../sse.js';
+import { validateEventIngest } from '../validators/event-ingest.js';
 
 /**
  * Create the events router for ingesting raw events.
@@ -105,13 +106,20 @@ export function createEventsRouter(): Router {
    */
   router.post('/ingest', async (req, res, next) => {
     try {
-      const rawEvent = req.body as Record<string, unknown>;
-      const userId = rawEvent['userId'] as string | undefined;
-
-      if (!userId) {
-        res.status(400).json({ error: 'Missing userId in event data' });
+      // Validate the request body against the documented event-ingest contract
+      // BEFORE handing it to the interpreter. Catches malformed payloads at
+      // the boundary instead of failing later with a TypeError. Also blocks
+      // caller-supplied trustTier (must come from the user record).
+      const validation = validateEventIngest(req.body);
+      if (!validation.ok) {
+        res.status(400).json({
+          error: 'Invalid event payload',
+          details: validation.errors,
+        });
         return;
       }
+      const rawEvent = validation.event;
+      const userId = validation.userId;
 
       // 0. Build per-user LLM client and strategies (or fall back to rule-based)
       const llmClient = await buildLlmClientForUser(userId);

--- a/apps/api/src/validators/event-ingest.ts
+++ b/apps/api/src/validators/event-ingest.ts
@@ -1,0 +1,75 @@
+/**
+ * Runtime validation for /api/events/ingest payloads.
+ *
+ * Hand-rolled rather than reaching for Zod — the API only has a handful of
+ * boundary endpoints today and adding a runtime dep for one of them would be
+ * premature. The shape here matches what `SituationInterpreter.interpret()`
+ * actually reads, so a payload that passes validation will not crash the
+ * downstream pipeline with a TypeError.
+ */
+
+const VALID_URGENCIES = new Set(['low', 'medium', 'high', 'critical']);
+
+/** Discriminated result type. Errors are field-keyed so the API can echo
+ *  them back to the caller without leaking internal structure. */
+export type EventIngestValidationResult =
+  | { ok: true; event: Record<string, unknown>; userId: string }
+  | { ok: false; errors: Array<{ field: string; message: string }> };
+
+export function validateEventIngest(raw: unknown): EventIngestValidationResult {
+  const errors: Array<{ field: string; message: string }> = [];
+
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, errors: [{ field: '_body', message: 'Request body must be a JSON object' }] };
+  }
+
+  const event = raw as Record<string, unknown>;
+  const userId = event['userId'];
+
+  if (typeof userId !== 'string' || userId.trim().length === 0) {
+    errors.push({ field: 'userId', message: 'userId is required and must be a non-empty string' });
+  }
+
+  // Source and type are not strictly required (the interpreter falls back),
+  // but if present they must be strings — otherwise downstream code crashes
+  // on `.toLowerCase()` against a non-string.
+  if ('source' in event && event['source'] !== undefined && typeof event['source'] !== 'string') {
+    errors.push({ field: 'source', message: 'source must be a string when provided' });
+  }
+  if ('type' in event && event['type'] !== undefined && typeof event['type'] !== 'string') {
+    errors.push({ field: 'type', message: 'type must be a string when provided' });
+  }
+
+  // Urgency is read directly into the DecisionObject. Accept only the four
+  // documented values plus undefined.
+  if (event['urgency'] !== undefined) {
+    if (typeof event['urgency'] !== 'string' || !VALID_URGENCIES.has(event['urgency'])) {
+      errors.push({
+        field: 'urgency',
+        message: 'urgency must be one of: low, medium, high, critical',
+      });
+    }
+  }
+
+  // `data` is optional but must be a plain object when provided.
+  if (event['data'] !== undefined) {
+    if (event['data'] === null || typeof event['data'] !== 'object' || Array.isArray(event['data'])) {
+      errors.push({ field: 'data', message: 'data must be a JSON object when provided' });
+    }
+  }
+
+  // Trust tier MUST NOT come from the caller — the API reads it from the DB.
+  // Reject payloads that try to inject one to make the contract explicit.
+  if ('trustTier' in event) {
+    errors.push({
+      field: 'trustTier',
+      message: 'trustTier cannot be set by the caller; it is sourced from the user record',
+    });
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return { ok: true, event, userId: userId as string };
+}


### PR DESCRIPTION
## Summary
Closes the last item on the session-start audit punch list. The events-ingest endpoint accepted any object with a \`userId\` and trusted the rest to the interpreter — malformed payloads (non-string \`source\`, unknown \`urgency\`, primitive \`data\` field) crashed downstream with TypeError instead of returning 400 at the boundary. Caller-supplied \`trustTier\` was also silently stripped instead of explicitly rejected.

**Validator** (\`apps/api/src/validators/event-ingest.ts\`)
- \`validateEventIngest()\` returns a discriminated result: \`{ ok: true, event, userId } | { ok: false, errors }\`.
- Hand-rolled rather than reaching for Zod — this is the first runtime validator in the API surface and pulling in a runtime dep for one endpoint would be premature. If/when more endpoints need validation, the team can swap in Zod (or io-ts) module-by-module.
- Aggregates errors so a payload with several bad fields gets one 400 with the full list, not a sequence of one-at-a-time corrections.

**Wire-up**
- 400 \`{ error: 'Invalid event payload', details: [{ field, message }] }\` on validation failure.
- Removes the prior single-field check (\`if (!userId) → 400 'Missing userId'\`) — the validator now handles it as one of many checks.

**Safety Invariant #3 enforcement.** The validator explicitly rejects caller-supplied \`trustTier\`. The trust tier MUST come from the user record; a payload trying to inject one is a bug or an attack and should fail loudly, not be silently dropped.

## Test plan
- [x] \`pnpm --filter @skytwin/api test\` — 167/167 (was 142, +25)
- [x] \`pnpm --filter @skytwin/api lint\` — clean
- [x] \`pnpm test\` — 38/38 turbo tasks
- [x] \`pnpm lint\` — 30/30 turbo tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)