### PR TITLE
feat(mobile): add 3-step Welcome / getting-started tour after first pairing

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -6,7 +6,9 @@ import { StatusBar } from 'expo-status-bar';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { getSession } from './services/session-store';
 import { registerForPushNotifications } from './services/notifications';
+import { hasSeenWelcome } from './services/welcome-store';
 import { PairingScreen } from './screens/PairingScreen';
+import { WelcomeScreen } from './screens/WelcomeScreen';
 import { ApprovalsScreen } from './screens/ApprovalsScreen';
 import { DashboardScreen } from './screens/DashboardScreen';
 import { SettingsScreen } from './screens/SettingsScreen';
@@ -95,15 +97,19 @@ function TabButton({
 export default function App(): React.JSX.Element {
   const [initializing, setInitializing] = useState(true);
   const [hasSession, setHasSession] = useState(false);
+  const [welcomeSeen, setWelcomeSeen] = useState(true);
 
   useEffect(() => {
     const init = async (): Promise<void> => {
       try {
-        // Check for existing session
         const session = await getSession();
         setHasSession(session !== null);
 
-        // Register for notifications (non-blocking)
+        // Welcome state is read here so it's already known by the time the
+        // user finishes pairing — no flash of MainWithTabs first.
+        const seen = await hasSeenWelcome();
+        setWelcomeSeen(seen);
+
         registerForPushNotifications().catch((err: unknown) => {
           console.warn('[app] Failed to register notifications:', err);
         });
@@ -122,6 +128,10 @@ export default function App(): React.JSX.Element {
     setHasSession(true);
   }, []);
 
+  const handleWelcomeDone = useCallback(() => {
+    setWelcomeSeen(true);
+  }, []);
+
   const handleDisconnect = useCallback(() => {
     setHasSession(false);
   }, []);
@@ -138,18 +148,25 @@ export default function App(): React.JSX.Element {
     );
   }
 
+  let content: React.JSX.Element;
+  if (!hasSession) {
+    content = (
+      <RootStack.Navigator screenOptions={{ headerShown: false }}>
+        <RootStack.Screen name="Pairing">
+          {() => <PairingScreen onPaired={handlePaired} />}
+        </RootStack.Screen>
+      </RootStack.Navigator>
+    );
+  } else if (!welcomeSeen) {
+    content = <WelcomeScreen onDone={handleWelcomeDone} />;
+  } else {
+    content = <MainWithTabs onDisconnect={handleDisconnect} />;
+  }
+
   return (
     <SafeAreaProvider>
       <NavigationContainer theme={SkyTwinTheme}>
-        {hasSession ? (
-          <MainWithTabs onDisconnect={handleDisconnect} />
-        ) : (
-          <RootStack.Navigator screenOptions={{ headerShown: false }}>
-            <RootStack.Screen name="Pairing">
-              {() => <PairingScreen onPaired={handlePaired} />}
-            </RootStack.Screen>
-          </RootStack.Navigator>
-        )}
+        {content}
       </NavigationContainer>
       <StatusBar style="light" />
     </SafeAreaProvider>

--- a/apps/mobile/src/__tests__/welcome-store.test.ts
+++ b/apps/mobile/src/__tests__/welcome-store.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const store = new Map<string, string>();
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: async (k: string) => store.get(k) ?? null,
+  setItemAsync: async (k: string, v: string) => {
+    store.set(k, v);
+  },
+  deleteItemAsync: async (k: string) => {
+    store.delete(k);
+  },
+}));
+
+import { hasSeenWelcome, markWelcomeSeen, resetWelcome } from '../services/welcome-store.js';
+
+describe('welcome-store', () => {
+  beforeEach(() => {
+    store.clear();
+  });
+
+  it('hasSeenWelcome returns false on first launch (key missing)', async () => {
+    expect(await hasSeenWelcome()).toBe(false);
+  });
+
+  it('returns true after markWelcomeSeen', async () => {
+    await markWelcomeSeen();
+    expect(await hasSeenWelcome()).toBe(true);
+  });
+
+  it('resetWelcome clears the flag (debug helper)', async () => {
+    await markWelcomeSeen();
+    await resetWelcome();
+    expect(await hasSeenWelcome()).toBe(false);
+  });
+
+  it('treats unrelated stored values as not-seen (only "1" counts)', async () => {
+    store.set('skytwin_welcome_seen', '0');
+    expect(await hasSeenWelcome()).toBe(false);
+    store.set('skytwin_welcome_seen', 'true');
+    expect(await hasSeenWelcome()).toBe(false);
+  });
+});

--- a/apps/mobile/src/screens/WelcomeScreen.tsx
+++ b/apps/mobile/src/screens/WelcomeScreen.tsx
@@ -1,0 +1,187 @@
+import React, { useState, useCallback } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
+import { markWelcomeSeen } from '../services/welcome-store';
+
+interface WelcomeScreenProps {
+  onDone: () => void;
+}
+
+interface TourStep {
+  emoji: string;
+  title: string;
+  body: string;
+}
+
+const STEPS: TourStep[] = [
+  {
+    emoji: '✓',
+    title: 'You approve. Your twin learns.',
+    body:
+      'When SkyTwin sees a new email or calendar invite, it suggests an action. ' +
+      'Tap Approve or Reject and your twin gets smarter about what you actually want.',
+  },
+  {
+    emoji: '⏰',
+    title: 'Heads-up notifications.',
+    body:
+      'You\'ll get a push when something needs your call. Tap it to jump straight ' +
+      'to the approval. No badge polling, no missed signals.',
+  },
+  {
+    emoji: '⚙︎',
+    title: 'You stay in charge.',
+    body:
+      'Settings → Trust tier controls what your twin can do without asking. ' +
+      'Start at Observer (asks for everything) and earn higher autonomy as you ' +
+      'approve consistently.',
+  },
+];
+
+export function WelcomeScreen({ onDone }: WelcomeScreenProps): React.JSX.Element {
+  const [step, setStep] = useState(0);
+
+  const handleNext = useCallback(() => {
+    if (step < STEPS.length - 1) {
+      setStep(step + 1);
+      return;
+    }
+    void (async () => {
+      try {
+        await markWelcomeSeen();
+      } finally {
+        onDone();
+      }
+    })();
+  }, [step, onDone]);
+
+  const handleSkip = useCallback(() => {
+    void (async () => {
+      try {
+        await markWelcomeSeen();
+      } finally {
+        onDone();
+      }
+    })();
+  }, [onDone]);
+
+  const current = STEPS[step]!;
+  const isLast = step === STEPS.length - 1;
+
+  return (
+    <View style={styles.root}>
+      <View style={styles.skipRow}>
+        <TouchableOpacity onPress={handleSkip} accessibilityRole="button">
+          <Text style={styles.skipText}>Skip</Text>
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView
+        contentContainerStyle={styles.cardWrap}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.card}>
+          <Text style={styles.emoji}>{current.emoji}</Text>
+          <Text style={styles.title}>{current.title}</Text>
+          <Text style={styles.body}>{current.body}</Text>
+        </View>
+      </ScrollView>
+
+      <View style={styles.dotsRow}>
+        {STEPS.map((_, i) => (
+          <View
+            key={i}
+            style={[styles.dot, i === step ? styles.dotActive : null]}
+          />
+        ))}
+      </View>
+
+      <TouchableOpacity
+        style={styles.nextButton}
+        onPress={handleNext}
+        accessibilityRole="button"
+      >
+        <Text style={styles.nextText}>{isLast ? "Let's go" : 'Next'}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+    paddingHorizontal: 24,
+    paddingTop: 60,
+    paddingBottom: 32,
+  },
+  skipRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginBottom: 24,
+  },
+  skipText: {
+    color: '#a0a0b8',
+    fontSize: 14,
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+  },
+  cardWrap: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  card: {
+    width: '100%',
+    backgroundColor: '#16162a',
+    borderRadius: 16,
+    padding: 28,
+    alignItems: 'center',
+  },
+  emoji: {
+    fontSize: 48,
+    marginBottom: 16,
+    color: '#4a90d9',
+    fontWeight: '700',
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#e0e0f0',
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  body: {
+    fontSize: 15,
+    color: '#a0a0b8',
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  dotsRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginVertical: 24,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#3a3a54',
+    marginHorizontal: 4,
+  },
+  dotActive: {
+    backgroundColor: '#4a90d9',
+    width: 20,
+  },
+  nextButton: {
+    backgroundColor: '#4a90d9',
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  nextText: {
+    color: '#1a1a2e',
+    fontSize: 16,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+  },
+});

--- a/apps/mobile/src/services/welcome-store.ts
+++ b/apps/mobile/src/services/welcome-store.ts
@@ -1,0 +1,23 @@
+import * as SecureStore from 'expo-secure-store';
+
+const KEY_WELCOME_SEEN = 'skytwin_welcome_seen';
+
+/**
+ * Has the user dismissed the welcome / getting-started tour?
+ *
+ * Lives in the secure store so it survives app reinstalls on the same
+ * device fingerprint without exposing anything sensitive.
+ */
+export async function hasSeenWelcome(): Promise<boolean> {
+  const v = await SecureStore.getItemAsync(KEY_WELCOME_SEEN);
+  return v === '1';
+}
+
+export async function markWelcomeSeen(): Promise<void> {
+  await SecureStore.setItemAsync(KEY_WELCOME_SEEN, '1');
+}
+
+/** Test/debug only — reset the flag so the welcome shows again next launch. */
+export async function resetWelcome(): Promise<void> {
+  await SecureStore.deleteItemAsync(KEY_WELCOME_SEEN);
+}


### PR DESCRIPTION
## Summary
The mobile app dropped users straight into the Approvals tab the moment pairing succeeded — no orientation to what the app does, what the three tabs are for, or how trust tiers control autonomy. The web dashboard had a 5-step wizard (\`apps/web/public/js/pages/onboarding.js\`); mobile had nothing.

This closes the mobile gap from the v0.4 \"first-run experience\" line item.

**Adds**
- \`WelcomeScreen.tsx\`: 3-step single-screen tour with progress dots and Skip / Next / \"Let's go\". Cards explain (1) approve → twin learns, (2) push notifications for new approvals, (3) trust tier controls in Settings.
- \`welcome-store.ts\`: SecureStore-backed flag for \"has seen welcome\". Survives app reinstalls on the same device.
- \`App.tsx\`: threads the flag through init so welcome appears once, after first successful pairing, before \`MainWithTabs\`. No flash of the tabs first — the flag is read during initial loading.

**Tests** +4 in \`__tests__/welcome-store.test.ts\` (happy paths + value coercion). Mobile total: 86 → 90.

## Test plan
- [x] \`pnpm --filter @skytwin/mobile test\` — 90/90 (was 86)
- [x] \`pnpm test\` — 38/38 turbo tasks
- [x] \`pnpm lint\` — clean
- [ ] Manual smoke (operator): fresh install → pair → Welcome appears → Skip or step through → MainWithTabs. Reinstall → Welcome should NOT reappear (SecureStore persists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)