### PR TITLE
fix(api,dev): UUID-validate userId at the boundary; register Mock IronClaw in dev

### DIFF
--- a/apps/api/src/__tests__/event-ingest-validator.test.ts
+++ b/apps/api/src/__tests__/event-ingest-validator.test.ts
@@ -1,20 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { validateEventIngest } from '../validators/event-ingest.js';
 
+const VALID_UID = 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e';
+
 describe('validateEventIngest', () => {
   describe('happy path', () => {
     it('accepts a minimal valid event (just userId)', () => {
-      const result = validateEventIngest({ userId: 'user_1' });
+      const result = validateEventIngest({ userId: VALID_UID });
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.userId).toBe('user_1');
-        expect(result.event['userId']).toBe('user_1');
+        expect(result.userId).toBe(VALID_UID);
+        expect(result.event['userId']).toBe(VALID_UID);
       }
     });
 
     it('accepts a fully-populated event', () => {
       const result = validateEventIngest({
-        userId: 'user_1',
+        userId: VALID_UID,
         source: 'gmail',
         type: 'email_received',
         urgency: 'high',
@@ -25,7 +27,7 @@ describe('validateEventIngest', () => {
 
     it('accepts every documented urgency value', () => {
       for (const urgency of ['low', 'medium', 'high', 'critical']) {
-        const result = validateEventIngest({ userId: 'u', urgency });
+        const result = validateEventIngest({ userId: VALID_UID, urgency });
         expect(result.ok).toBe(true);
       }
     });
@@ -41,7 +43,7 @@ describe('validateEventIngest', () => {
     });
 
     it('rejects array body', () => {
-      const result = validateEventIngest([{ userId: 'u' }]);
+      const result = validateEventIngest([{ userId: VALID_UID }]);
       expect(result.ok).toBe(false);
     });
 
@@ -80,15 +82,36 @@ describe('validateEventIngest', () => {
       expect(validateEventIngest({ userId: null }).ok).toBe(false);
       expect(validateEventIngest({ userId: { id: 'u' } }).ok).toBe(false);
     });
+
+    it('rejects non-UUID userId strings (catches typos and stale tokens)', () => {
+      // The DB stores user_id as uuid; any non-uuid string crashes pg-pool
+      // with a 500. Catch it at the boundary so the API returns 400.
+      const r = validateEventIngest({ userId: '501' });
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.errors.find((e) => e.field === 'userId')?.message).toContain('valid UUID');
+      }
+    });
+
+    it('rejects userId that looks UUID-ish but is malformed', () => {
+      expect(validateEventIngest({ userId: 'not-a-uuid' }).ok).toBe(false);
+      expect(validateEventIngest({ userId: '12345678-1234-1234-1234-12345678901' }).ok).toBe(false);
+      expect(validateEventIngest({ userId: 'gggggggg-gggg-gggg-gggg-gggggggggggg' }).ok).toBe(false);
+    });
+
+    it('accepts canonical UUIDs (lowercase and uppercase)', () => {
+      expect(validateEventIngest({ userId: 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e' }).ok).toBe(true);
+      expect(validateEventIngest({ userId: 'B2C3D4E5-F6A7-4B8C-9D0E-1F2A3B4C5D6E' }).ok).toBe(true);
+    });
   });
 
   describe('source and type', () => {
     it('accepts missing source and type (interpreter has fallbacks)', () => {
-      expect(validateEventIngest({ userId: 'u' }).ok).toBe(true);
+      expect(validateEventIngest({ userId: VALID_UID }).ok).toBe(true);
     });
 
     it('rejects non-string source', () => {
-      const result = validateEventIngest({ userId: 'u', source: 42 });
+      const result = validateEventIngest({ userId: VALID_UID, source: 42 });
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.errors.find((e) => e.field === 'source')).toBeDefined();
@@ -96,18 +119,18 @@ describe('validateEventIngest', () => {
     });
 
     it('rejects non-string type', () => {
-      const result = validateEventIngest({ userId: 'u', type: { name: 'email' } });
+      const result = validateEventIngest({ userId: VALID_UID, type: { name: 'email' } });
       expect(result.ok).toBe(false);
     });
 
     it('accepts empty-string source and type (interpreter normalizes)', () => {
-      expect(validateEventIngest({ userId: 'u', source: '', type: '' }).ok).toBe(true);
+      expect(validateEventIngest({ userId: VALID_UID, source: '', type: '' }).ok).toBe(true);
     });
   });
 
   describe('urgency', () => {
     it('rejects unknown urgency value', () => {
-      const result = validateEventIngest({ userId: 'u', urgency: 'urgent' });
+      const result = validateEventIngest({ userId: VALID_UID, urgency: 'urgent' });
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.errors.find((e) => e.field === 'urgency')).toBeDefined();
@@ -115,39 +138,39 @@ describe('validateEventIngest', () => {
     });
 
     it('rejects non-string urgency', () => {
-      expect(validateEventIngest({ userId: 'u', urgency: 5 }).ok).toBe(false);
+      expect(validateEventIngest({ userId: VALID_UID, urgency: 5 }).ok).toBe(false);
     });
   });
 
   describe('data', () => {
     it('accepts missing data', () => {
-      expect(validateEventIngest({ userId: 'u' }).ok).toBe(true);
+      expect(validateEventIngest({ userId: VALID_UID }).ok).toBe(true);
     });
 
     it('accepts empty data object', () => {
-      expect(validateEventIngest({ userId: 'u', data: {} }).ok).toBe(true);
+      expect(validateEventIngest({ userId: VALID_UID, data: {} }).ok).toBe(true);
     });
 
     it('rejects array data', () => {
-      const result = validateEventIngest({ userId: 'u', data: [1, 2, 3] });
+      const result = validateEventIngest({ userId: VALID_UID, data: [1, 2, 3] });
       expect(result.ok).toBe(false);
     });
 
     it('rejects null data', () => {
-      const result = validateEventIngest({ userId: 'u', data: null });
+      const result = validateEventIngest({ userId: VALID_UID, data: null });
       expect(result.ok).toBe(false);
     });
 
     it('rejects primitive data', () => {
-      expect(validateEventIngest({ userId: 'u', data: 'hello' }).ok).toBe(false);
-      expect(validateEventIngest({ userId: 'u', data: 42 }).ok).toBe(false);
+      expect(validateEventIngest({ userId: VALID_UID, data: 'hello' }).ok).toBe(false);
+      expect(validateEventIngest({ userId: VALID_UID, data: 42 }).ok).toBe(false);
     });
   });
 
   describe('trustTier injection prevention', () => {
     it('rejects caller-supplied trustTier even if value is valid', () => {
       const result = validateEventIngest({
-        userId: 'u',
+        userId: VALID_UID,
         trustTier: 'high_autonomy',
       });
       expect(result.ok).toBe(false);
@@ -160,7 +183,7 @@ describe('validateEventIngest', () => {
     it('rejects trustTier even when set to undefined explicitly', () => {
       // The contract is "trustTier is not a caller field" — sneaking it in as
       // undefined should still trigger the explicit rejection.
-      const result = validateEventIngest({ userId: 'u', trustTier: undefined });
+      const result = validateEventIngest({ userId: VALID_UID, trustTier: undefined });
       expect(result.ok).toBe(false);
     });
   });

--- a/apps/api/src/__tests__/events-routes.test.ts
+++ b/apps/api/src/__tests__/events-routes.test.ts
@@ -57,7 +57,7 @@ vi.mock('@skytwin/db', () => ({
   approvalRepository: { create: vi.fn() },
   oauthRepository: { getToken: vi.fn().mockResolvedValue(null) },
   executionRepository: mockExecutionRepository,
-  userRepository: { findById: vi.fn().mockResolvedValue({ id: 'user-1', trust_tier: 'observer', ironclaw_channel: 'skytwin' }) },
+  userRepository: { findById: vi.fn().mockResolvedValue({ id: 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e', trust_tier: 'observer', ironclaw_channel: 'skytwin' }) },
   aiProviderRepository: { getEnabledForUser: vi.fn().mockResolvedValue([]) },
   TwinRepositoryAdapter: vi.fn(),
   PatternRepositoryAdapter: vi.fn(),
@@ -177,14 +177,14 @@ describe('Events API routes', () => {
     });
 
     const res = await request(buildApp(), 'POST', '/api/events/ingest', {
-      userId: 'user-1',
+      userId: 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e',
       source: 'test',
       type: 'travel_decision',
     });
 
     expect(res.status).toBe(200);
     expect(mockSseManager.emit).toHaveBeenCalledWith(
-      'user-1',
+      'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e',
       'decision:blocked-by-policy',
       expect.objectContaining({
         decisionId: 'decision-1',
@@ -193,7 +193,7 @@ describe('Events API routes', () => {
     );
     // Must not have emitted execution events
     expect(mockSseManager.emit).not.toHaveBeenCalledWith(
-      'user-1',
+      'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e',
       'decision:executed',
       expect.anything(),
     );
@@ -209,7 +209,7 @@ describe('Events API routes', () => {
     });
 
     const res = await request(buildApp(), 'POST', '/api/events/ingest', {
-      userId: 'user-1',
+      userId: 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e',
       source: 'test',
       type: 'calendar_event',
     });

--- a/apps/api/src/execution-setup.ts
+++ b/apps/api/src/execution-setup.ts
@@ -1,6 +1,7 @@
 import { loadConfig } from '@skytwin/config';
 import {
   RealIronClawAdapter,
+  MockIronClawAdapter,
   DirectExecutionAdapter,
   ActionHandlerRegistry,
   EmailActionHandler,
@@ -46,8 +47,15 @@ export async function createExecutionRouter(): Promise<ExecutionRouter> {
   const ironclawConfig = await resolveIronClawConfig(config);
   const openclawConfig = await resolveOpenClawConfig(config);
 
-  // IronClaw — highest trust, requires a running IronClaw server
-  if (ironclawConfig.apiUrl && ironclawConfig.webhookSecret) {
+  // IronClaw — highest trust, requires a running IronClaw server.
+  // Mock mode (USE_MOCK_IRONCLAW=true) registers an in-process simulator so
+  // the execution router still has a primary adapter to route through in dev
+  // and tests. Real mode registers the HTTP adapter when URL + secret exist.
+  if (config.useMockIronclaw) {
+    const ironclawAdapter: IronClawAdapter = new MockIronClawAdapter();
+    registry.register('ironclaw', ironclawAdapter, IRONCLAW_TRUST_PROFILE);
+    console.info('[execution] Registered Mock IronClaw adapter (USE_MOCK_IRONCLAW=true)');
+  } else if (ironclawConfig.apiUrl && ironclawConfig.webhookSecret) {
     const ironclawAdapter: IronClawAdapter = new RealIronClawAdapter({
       apiUrl: ironclawConfig.apiUrl,
       webhookSecret: ironclawConfig.webhookSecret,

--- a/apps/api/src/validators/event-ingest.ts
+++ b/apps/api/src/validators/event-ingest.ts
@@ -9,6 +9,11 @@
  */
 
 const VALID_URGENCIES = new Set(['low', 'medium', 'high', 'critical']);
+// User ids in this codebase are PostgreSQL uuids (gen_random_uuid()).
+// Reject anything that is not the canonical 8-4-4-4-12 hex-with-dashes form
+// here at the boundary so the DB layer doesn't crash with a 500 on every
+// typo'd test client or stale session token.
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /** Discriminated result type. Errors are field-keyed so the API can echo
  *  them back to the caller without leaking internal structure. */
@@ -28,6 +33,8 @@ export function validateEventIngest(raw: unknown): EventIngestValidationResult {
 
   if (typeof userId !== 'string' || userId.trim().length === 0) {
     errors.push({ field: 'userId', message: 'userId is required and must be a non-empty string' });
+  } else if (!UUID_REGEX.test(userId)) {
+    errors.push({ field: 'userId', message: 'userId must be a valid UUID' });
   }
 
   // Source and type are not strictly required (the interpreter falls back),

--- a/bin/skytwin-dev
+++ b/bin/skytwin-dev
@@ -58,6 +58,14 @@ fi
 echo -e "${BLUE}=== SkyTwin Development Server ===${NC}"
 echo ""
 
+# Default IronClaw to mock mode in dev unless the operator has wired up real
+# credentials. Without this, the API logs "IronClaw not configured (no URL or
+# secret) — skipping" and the execution router silently runs without it, which
+# looks like a bug in the dashboard.
+if [ -z "${IRONCLAW_API_URL:-}" ] && [ -z "${IRONCLAW_WEBHOOK_SECRET:-}" ]; then
+  export USE_MOCK_IRONCLAW="${USE_MOCK_IRONCLAW:-true}"
+fi
+
 # 1. Check prerequisites
 echo -e "${YELLOW}Checking prerequisites...${NC}"
 


### PR DESCRIPTION
## Summary
Two real bugs surfaced during a live walkthrough of the dashboard.

**1. \`/api/events/ingest\` crashed with 500 on any non-UUID userId.**
The validator I added in #95 only checked \"non-empty string\" so \`userId=\"501\"\` passed validation, then crashed at the DB layer with \`could not parse \"501\" as type uuid\`. Now rejects with a 400 + structured error at the boundary. Catches typos in test clients, stale session tokens, and any caller that hasn't gotten the user ID format right.

**2. IronClaw silently disabled in dev.**
Without \`IRONCLAW_API_URL\` or \`IRONCLAW_WEBHOOK_SECRET\` set, the API logged \"IronClaw not configured (no URL or secret) — skipping\" and the execution router ran without it. The Setup page showed nothing useful for the primary execution engine. Two fixes:
- \`bin/skytwin-dev\` now exports \`USE_MOCK_IRONCLAW=true\` when neither URL nor secret is set, so the dev stack always has a primary adapter to route through.
- \`apps/api/src/execution-setup.ts\` now registers \`MockIronClawAdapter\` when \`config.useMockIronclaw\` is true (was unwired — the import existed but the branch was missing).

Setup page now shows IronClaw **Running** out of the box in dev:
\`\`\`
[execution] Registered Mock IronClaw adapter (USE_MOCK_IRONCLAW=true)
\`\`\`

## Test plan
- [x] \`pnpm --filter @skytwin/api test\` — 170/170 (was 167, +3 new for UUID validation)
- [x] \`pnpm --filter @skytwin/api lint\` — clean
- [x] \`pnpm test\` — 38/38 turbo tasks
- [x] \`pnpm lint\` — 30/30 turbo tasks
- [x] Manual: started dev stack, hit \`POST /api/events/ingest\` with \`userId=\"501\"\`, verified 400 with \`{\"field\":\"userId\",\"message\":\"userId must be a valid UUID\"}\`. Loaded \`/#/setup\` in browser, verified IronClaw shows green dot + \"Running\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)