### PR TITLE
fix(worker): persistent dedupe ledger so restarts don't re-emit signals

### DIFF
--- a/apps/worker/src/__tests__/signal-dedupe.test.ts
+++ b/apps/worker/src/__tests__/signal-dedupe.test.ts
@@ -134,4 +134,75 @@ describe('SignalDeduper', () => {
     expect(DEFAULT_TTL_MS).toBe(24 * 60 * 60 * 1000);
     expect(DEFAULT_MAX_PER_USER).toBe(5_000);
   });
+
+  // ── Persistence ─────────────────────────────────────────────────────────
+
+  describe('persistence', () => {
+    it('mark() write-throughs to the persistence layer', async () => {
+      const persisted: Array<{ userId: string; signalKey: string }> = [];
+      const dedup = new SignalDeduper({
+        persistence: {
+          mark: async (userId, signalKey) => {
+            persisted.push({ userId, signalKey });
+          },
+        },
+      });
+
+      dedup.mark(makeSignal('s1'), 'user1');
+
+      // Persistence is async — wait a tick.
+      await new Promise((r) => setImmediate(r));
+      expect(persisted).toEqual([{ userId: 'user1', signalKey: 'gmail:s1' }]);
+    });
+
+    it('persistence failures are reported but do not throw', async () => {
+      const errors: Array<{ userId: string; signalKey: string }> = [];
+      const dedup = new SignalDeduper({
+        persistence: {
+          mark: async () => {
+            throw new Error('db down');
+          },
+        },
+        onPersistenceError: (_err, userId, signalKey) => {
+          errors.push({ userId, signalKey });
+        },
+      });
+
+      // Should not throw synchronously or via unhandled rejection.
+      dedup.mark(makeSignal('s1'), 'user1');
+
+      // The in-memory entry should still be recorded.
+      expect(dedup.has(makeSignal('s1'), 'user1')).toBe(true);
+
+      await new Promise((r) => setImmediate(r));
+      expect(errors).toEqual([{ userId: 'user1', signalKey: 'gmail:s1' }]);
+    });
+
+    it('hydrate() repopulates the in-memory map from persisted rows', () => {
+      let now = 1_000_000;
+      const dedup = new SignalDeduper({ ttlMs: 60_000, now: () => now });
+
+      dedup.hydrate([
+        { userId: 'user1', signalKey: 'gmail:s1', forwardedAt: new Date(now - 10_000) },
+        { userId: 'user2', signalKey: 'gmail:s2', forwardedAt: new Date(now - 1_000) },
+      ]);
+
+      expect(dedup.has(makeSignal('s1'), 'user1')).toBe(true);
+      expect(dedup.has(makeSignal('s2'), 'user2')).toBe(true);
+      expect(dedup.has(makeSignal('s2'), 'user1')).toBe(false);
+    });
+
+    it('hydrate() skips rows past the TTL', () => {
+      const now = 1_000_000;
+      const dedup = new SignalDeduper({ ttlMs: 5_000, now: () => now });
+
+      dedup.hydrate([
+        { userId: 'user1', signalKey: 'gmail:old', forwardedAt: new Date(now - 60_000) },
+        { userId: 'user1', signalKey: 'gmail:fresh', forwardedAt: new Date(now - 1_000) },
+      ]);
+
+      expect(dedup.has(makeSignal('old'), 'user1')).toBe(false);
+      expect(dedup.has(makeSignal('fresh'), 'user1')).toBe(true);
+    });
+  });
 });

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -9,20 +9,42 @@ import {
   type GoogleOAuthConfig,
 } from '@skytwin/connectors';
 import {
+  forwardedSignalsRepository,
   oauthRepository,
   approvalRepository,
   ironClawToolRepository,
   serviceCredentialRepository,
 } from '@skytwin/db';
 import { withRetry, RetryableHttpError, CircuitBreaker, createLogger } from '@skytwin/core';
-import { SignalDeduper } from './signal-dedupe.js';
+import { SignalDeduper, DEFAULT_TTL_MS } from './signal-dedupe.js';
 
 const config = loadConfig();
 const log = createLogger('worker');
 
 /** Per-user circuit breakers to skip users with persistent failures. */
 const userCircuitBreakers = new Map<string, CircuitBreaker>();
-const signalDeduper = new SignalDeduper();
+
+/**
+ * Dedup state survives restarts via forwarded_signals: the in-memory map
+ * is hydrated at startup from the persistent ledger, and every mark()
+ * write-throughs back to the table. Without this, `tsx watch` reloads
+ * (or any worker crash/restart) cause every still-matching gmail thread
+ * to re-emit and create duplicate approvals downstream — see #102.
+ */
+const signalDeduper = new SignalDeduper({
+  persistence: {
+    async mark(userId: string, signalKey: string): Promise<void> {
+      await forwardedSignalsRepository.mark(userId, signalKey);
+    },
+  },
+  onPersistenceError: (err, userId, signalKey) => {
+    log.warn('Failed to persist signal dedupe entry', {
+      userId,
+      signalKey,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  },
+});
 
 function getCircuitBreaker(userId: string): CircuitBreaker {
   let breaker = userCircuitBreakers.get(userId);
@@ -326,6 +348,30 @@ async function main(): Promise<void> {
   log.info('Starting SkyTwin worker...');
   log.info(`API base URL: ${config.apiBaseUrl}`);
   log.info(`Poll interval: ${config.workerPollIntervalMs}ms`);
+
+  // Hydrate the dedup window from the persistent ledger before we start
+  // polling, so already-forwarded signals are recognised on the very first
+  // poll after a restart. Failures are non-fatal: the worker can still run,
+  // it'll just have its previous behaviour of re-emitting on reload.
+  try {
+    const rows = await forwardedSignalsRepository.listSince(DEFAULT_TTL_MS);
+    signalDeduper.hydrate(
+      rows.map((r) => ({
+        userId: r.user_id,
+        signalKey: r.signal_key,
+        forwardedAt: r.forwarded_at,
+      })),
+    );
+    log.info(`Hydrated dedupe ledger: ${rows.length} entries`);
+
+    // Best-effort GC of expired rows so the table doesn't grow unbounded.
+    const removed = await forwardedSignalsRepository.gcOlderThan(DEFAULT_TTL_MS);
+    if (removed > 0) log.info(`GC'd ${removed} expired forwarded_signals rows`);
+  } catch (error) {
+    log.warn('Could not hydrate dedupe ledger — proceeding with empty state', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   // Detect startup hangs (discoverUsers or connect hanging on a broken DB/network)
   const startupTimer = setTimeout(() => {

--- a/apps/worker/src/signal-dedupe.ts
+++ b/apps/worker/src/signal-dedupe.ts
@@ -13,11 +13,25 @@ import type { RawSignal } from '@skytwin/connectors';
  * by constructing a SignalDeduper with custom bounds and a clock.
  */
 
+/**
+ * Optional persistence layer that lets the deduper survive worker restarts.
+ * Pure interface — the worker wires it to forwardedSignalsRepository, tests
+ * pass a stub, and the deduper itself stays free of DB dependencies.
+ */
+export interface DeduperPersistence {
+  /** Append a (userId, signalKey) pair to durable storage. Best-effort. */
+  mark(userId: string, signalKey: string): Promise<void>;
+}
+
 export interface DeduperOptions {
   ttlMs?: number;
   maxPerUser?: number;
   /** Time source — exposed so tests can advance it deterministically. */
   now?: () => number;
+  /** Persistence layer for write-through and hydration. Optional. */
+  persistence?: DeduperPersistence;
+  /** Logger for failed persistence writes. Optional. */
+  onPersistenceError?: (err: unknown, userId: string, signalKey: string) => void;
 }
 
 export const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
@@ -27,12 +41,32 @@ export class SignalDeduper {
   private readonly ttlMs: number;
   private readonly maxPerUser: number;
   private readonly now: () => number;
+  private readonly persistence: DeduperPersistence | undefined;
+  private readonly onPersistenceError: NonNullable<DeduperOptions['onPersistenceError']> | undefined;
   private readonly seenByUser = new Map<string, Map<string, number>>();
 
   constructor(opts: DeduperOptions = {}) {
     this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
     this.maxPerUser = opts.maxPerUser ?? DEFAULT_MAX_PER_USER;
     this.now = opts.now ?? Date.now;
+    this.persistence = opts.persistence;
+    this.onPersistenceError = opts.onPersistenceError;
+  }
+
+  /**
+   * Replay a batch of `(userId, signalKey, forwardedAt)` tuples into the
+   * in-memory map. Used at startup to hydrate from the persistent ledger
+   * so the worker doesn't re-emit signals it had already forwarded before
+   * the last restart. Skips entries past the TTL.
+   */
+  hydrate(rows: Array<{ userId: string; signalKey: string; forwardedAt: Date }>): void {
+    const cutoff = this.now() - this.ttlMs;
+    for (const row of rows) {
+      const ts = row.forwardedAt.getTime();
+      if (ts < cutoff) continue;
+      const map = this.getOrCreate(row.userId);
+      map.set(row.signalKey, ts);
+    }
   }
 
   /** True if this signal has been forwarded for this user within the TTL window. */
@@ -43,10 +77,23 @@ export class SignalDeduper {
     return Boolean(seenAt && this.now() - seenAt < this.ttlMs);
   }
 
-  /** Record that a signal was forwarded for this user. */
+  /**
+   * Record that a signal was forwarded for this user. Writes through to
+   * the persistence layer (if configured) so the mark survives a restart.
+   * Persistence errors do not throw — they're reported via
+   * `onPersistenceError` and the in-memory entry is still recorded.
+   */
   mark(signal: RawSignal, userId: string): void {
+    const key = this.key(signal);
     const map = this.getOrCreate(userId);
-    map.set(this.key(signal), this.now());
+    map.set(key, this.now());
+
+    if (this.persistence) {
+      const handle = this.onPersistenceError;
+      this.persistence.mark(userId, key).catch((err) => {
+        if (handle) handle(err, userId, key);
+      });
+    }
   }
 
   /** Test/observability helper: how many entries are currently held for a user. */

--- a/apps/worker/src/signal-dedupe.ts
+++ b/apps/worker/src/signal-dedupe.ts
@@ -91,7 +91,15 @@ export class SignalDeduper {
     if (this.persistence) {
       const handle = this.onPersistenceError;
       this.persistence.mark(userId, key).catch((err) => {
-        if (handle) handle(err, userId, key);
+        if (!handle) return;
+        // Defensive: a throwing error handler on a fire-and-forget promise
+        // would surface as an unhandled rejection, which can crash the
+        // worker. Swallow rather than rethrow.
+        try {
+          handle(err, userId, key);
+        } catch {
+          /* swallow */
+        }
       });
     }
   }

--- a/packages/db/src/__tests__/forwarded-signals-repository.test.ts
+++ b/packages/db/src/__tests__/forwarded-signals-repository.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockQuery = vi.fn();
+
+vi.mock('../connection.js', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+const { forwardedSignalsRepository } = await import(
+  '../repositories/forwarded-signals-repository.js'
+);
+
+describe('forwardedSignalsRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('mark() upserts idempotently on (user_id, signal_key)', async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+
+    await forwardedSignalsRepository.mark('user-1', 'gmail:sig_abc');
+
+    const [sql, args] = mockQuery.mock.calls[0]!;
+    expect(sql).toContain('ON CONFLICT (user_id, signal_key) DO NOTHING');
+    expect(args).toEqual(['user-1', 'gmail:sig_abc']);
+  });
+
+  it('markBatch() inserts multiple rows in one query', async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 2 });
+
+    await forwardedSignalsRepository.markBatch([
+      { userId: 'user-1', signalKey: 'gmail:sig_a' },
+      { userId: 'user-2', signalKey: 'gmail:sig_b' },
+    ]);
+
+    const [sql, args] = mockQuery.mock.calls[0]!;
+    expect(sql).toContain('VALUES ($1, $2), ($3, $4)');
+    expect(args).toEqual(['user-1', 'gmail:sig_a', 'user-2', 'gmail:sig_b']);
+  });
+
+  it('markBatch() with empty input is a no-op', async () => {
+    await forwardedSignalsRepository.markBatch([]);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('listSince() filters by an INTERVAL derived from the TTL', async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    await forwardedSignalsRepository.listSince(24 * 60 * 60 * 1000);
+
+    const [, args] = mockQuery.mock.calls[0]!;
+    expect(args).toEqual(['86400 seconds']);
+  });
+
+  it('gcOlderThan() returns the rowCount of removed rows', async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 17 });
+
+    const removed = await forwardedSignalsRepository.gcOlderThan(60_000);
+
+    expect(removed).toBe(17);
+    const [sql, args] = mockQuery.mock.calls[0]!;
+    expect(sql).toContain('DELETE FROM forwarded_signals');
+    expect(args).toEqual(['60 seconds']);
+  });
+
+  it('gcOlderThan() with no matches returns 0', async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: null });
+    const removed = await forwardedSignalsRepository.gcOlderThan(1000);
+    expect(removed).toBe(0);
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -88,7 +88,8 @@ export type {
 
 export { signalRepository, proposalRepository, skillGapRepository, proactiveScanRepository } from './repositories/index.js';
 
-export { trustTierAuditRepository, spendRepository, domainAutonomyRepository, escalationTriggerRepository, preferenceHistoryRepository, sessionRepository, mempalaceRepository, serviceCredentialRepository, credentialRequirementRepository, aiProviderRepository, ironClawToolRepository } from './repositories/index.js';
+export { trustTierAuditRepository, spendRepository, domainAutonomyRepository, escalationTriggerRepository, preferenceHistoryRepository, sessionRepository, mempalaceRepository, serviceCredentialRepository, credentialRequirementRepository, aiProviderRepository, ironClawToolRepository, forwardedSignalsRepository } from './repositories/index.js';
+export type { ForwardedSignalRow } from './repositories/index.js';
 export type { SessionRow } from './repositories/index.js';
 export type { UpsertServiceCredentialInput } from './repositories/index.js';
 export type { RegisterCredentialRequirementInput } from './repositories/index.js';

--- a/packages/db/src/migrations/022-forwarded-signals-ledger.sql
+++ b/packages/db/src/migrations/022-forwarded-signals-ledger.sql
@@ -1,0 +1,23 @@
+-- 022-forwarded-signals-ledger.sql
+-- Persistent ledger of signals already forwarded from the worker to the API.
+--
+-- The worker has always had an in-memory SignalDeduper, but `tsx watch`
+-- restarts (and crashes, and `pnpm dev` reloads) wipe it. After a restart
+-- the worker re-emits everything still matching the connector's "what
+-- counts as new" filter (Gmail's `is:unread` returns the same hundred
+-- threads), each producing a fresh decision + approval downstream.
+--
+-- This table lets the deduper survive restarts: hydrate on startup, write
+-- through on every mark. `forwarded_at` is the truth-of-record for the
+-- 24h TTL — the in-memory map is just a hot cache.
+
+CREATE TABLE IF NOT EXISTS forwarded_signals (
+  user_id      UUID        NOT NULL,
+  signal_key   STRING      NOT NULL,        -- e.g. "gmail:sig_gmail_19dd2..."
+  forwarded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, signal_key)
+);
+
+-- Used by the periodic GC sweep that drops rows past the TTL window.
+CREATE INDEX IF NOT EXISTS forwarded_signals_forwarded_at_idx
+    ON forwarded_signals (forwarded_at);

--- a/packages/db/src/repositories/forwarded-signals-repository.ts
+++ b/packages/db/src/repositories/forwarded-signals-repository.ts
@@ -55,10 +55,15 @@ export const forwardedSignalsRepository = {
    * hydration to repopulate the in-memory deduper.
    */
   async listSince(ttlMs: number): Promise<ForwardedSignalRow[]> {
+    // Ordered oldest-first so the deduper's insertion-order eviction (rough
+    // LRU) treats older rows as evictable when over capacity. Without this,
+    // arbitrary DB order means newer entries could be dropped first on a
+    // user with > maxPerUser rows in the ledger.
     const result = await query<ForwardedSignalRow>(
       `SELECT user_id, signal_key, forwarded_at
          FROM forwarded_signals
-        WHERE forwarded_at > now() - ($1::INTERVAL)`,
+        WHERE forwarded_at > now() - ($1::INTERVAL)
+        ORDER BY forwarded_at ASC, user_id ASC, signal_key ASC`,
       [`${Math.max(1, Math.floor(ttlMs / 1000))} seconds`],
     );
     return result.rows;

--- a/packages/db/src/repositories/forwarded-signals-repository.ts
+++ b/packages/db/src/repositories/forwarded-signals-repository.ts
@@ -1,0 +1,79 @@
+import { query } from '../connection.js';
+
+export interface ForwardedSignalRow {
+  user_id: string;
+  signal_key: string;
+  forwarded_at: Date;
+}
+
+/**
+ * Persistent ledger of `(userId, signalKey)` pairs the worker has already
+ * forwarded to the API. Backs the in-memory SignalDeduper so the dedup
+ * window survives worker restarts.
+ *
+ * `signal_key` is the same key the in-memory deduper composes —
+ * `${signal.source}:${signal.id}` — so the two layers stay in lockstep
+ * without a translation step.
+ */
+export const forwardedSignalsRepository = {
+  /**
+   * Idempotent insert. Many callers go through here on startup hydration
+   * and during per-poll write-through, so collisions are expected.
+   */
+  async mark(userId: string, signalKey: string): Promise<void> {
+    await query(
+      `INSERT INTO forwarded_signals (user_id, signal_key)
+       VALUES ($1, $2)
+       ON CONFLICT (user_id, signal_key) DO NOTHING`,
+      [userId, signalKey],
+    );
+  },
+
+  /**
+   * Bulk version of mark(). Used when hydrating the deduper or writing
+   * a batch of newly forwarded signals.
+   */
+  async markBatch(entries: Array<{ userId: string; signalKey: string }>): Promise<void> {
+    if (entries.length === 0) return;
+    const values: string[] = [];
+    const params: unknown[] = [];
+    let i = 1;
+    for (const entry of entries) {
+      values.push(`($${i++}, $${i++})`);
+      params.push(entry.userId, entry.signalKey);
+    }
+    await query(
+      `INSERT INTO forwarded_signals (user_id, signal_key)
+       VALUES ${values.join(', ')}
+       ON CONFLICT (user_id, signal_key) DO NOTHING`,
+      params,
+    );
+  },
+
+  /**
+   * All rows newer than `now() - ttlMs`. Used by the worker's startup
+   * hydration to repopulate the in-memory deduper.
+   */
+  async listSince(ttlMs: number): Promise<ForwardedSignalRow[]> {
+    const result = await query<ForwardedSignalRow>(
+      `SELECT user_id, signal_key, forwarded_at
+         FROM forwarded_signals
+        WHERE forwarded_at > now() - ($1::INTERVAL)`,
+      [`${Math.max(1, Math.floor(ttlMs / 1000))} seconds`],
+    );
+    return result.rows;
+  },
+
+  /**
+   * Drop rows past the TTL window. Returns the number of rows removed
+   * so the caller can log it.
+   */
+  async gcOlderThan(ttlMs: number): Promise<number> {
+    const result = await query(
+      `DELETE FROM forwarded_signals
+        WHERE forwarded_at <= now() - ($1::INTERVAL)`,
+      [`${Math.max(1, Math.floor(ttlMs / 1000))} seconds`],
+    );
+    return result.rowCount ?? 0;
+  },
+};

--- a/packages/db/src/repositories/index.ts
+++ b/packages/db/src/repositories/index.ts
@@ -84,3 +84,6 @@ export type { UpsertAIProviderInput } from './ai-provider-repository.js';
 
 export { ironClawToolRepository } from './ironclaw-tool-repository.js';
 export type { UpsertIronClawToolInput } from './ironclaw-tool-repository.js';
+
+export { forwardedSignalsRepository } from './forwarded-signals-repository.js';
+export type { ForwardedSignalRow } from './forwarded-signals-repository.js';


### PR DESCRIPTION
Addresses the in-memory layer of #102. The Gmail History API rewrite and the signal_id uniqueness constraint remain follow-ups (see "Not in scope" below).

## Why
Pending approvals grew ~10 every worker reload because `SignalDeduper`'s 24h window lived in process memory. `tsx watch` (and any crash) wiped it, so every still-unread Gmail thread re-emitted, the API created a fresh decision+approval pair for each, and the count creeped.

## What changed
- **New table `forwarded_signals(user_id, signal_key, forwarded_at)`** — PK on `(user_id, signal_key)` so writes are idempotent. The `signal_key` matches the existing in-memory dedupe key (`${signal.source}:${signal.id}`) verbatim, so the two layers stay in lockstep with no translation.
- **`forwardedSignalsRepository`** — `mark`, `markBatch`, `listSince`, `gcOlderThan`.
- **`SignalDeduper`** gained an optional `persistence` hook and a `hydrate` method. `mark()` writes through; failures go to `onPersistenceError` and never throw.
- **Worker startup** hydrates the deduper from `listSince(24h)` and runs one GC pass. Hydration is best-effort — if it fails the worker proceeds with an empty cache rather than refusing to start.

## Not in scope (filed in the issue, will land separately)
- Replace Gmail's `is:unread` poll with the History API + persistent `historyId` cursor. The current connector still pulls all unread mail every poll; this PR makes that idempotent across restarts but doesn't reduce upstream API load.
- Multi-account-aware cursor keying — `(user_id, provider, account_email)` — depends on #103 (the multi-account schema). Adding it now would conflict; cleaner as the next PR.
- DB-level uniqueness on signal_id in `decisions`/`approval_requests` (defense-in-depth so a deduper miss can't ever produce a real duplicate row).

## Test plan
- [x] `pnpm --filter @skytwin/db test` — 131 passed (6 new repo tests).
- [x] `pnpm --filter @skytwin/worker test` — 15 passed (4 new persistence tests: write-through, error containment, hydrate, TTL filter on hydrate).
- [x] `pnpm --filter @skytwin/worker exec tsc --noEmit` — clean.
- [x] `pnpm db:migrate` against dev CRDB — applied. Worker hot-reloaded under `tsx watch`; logs show `Hydrated dedupe ledger: 0 entries`, then `SELECT * FROM forwarded_signals` confirms write-through on each forward.
- [ ] Restart worker after a few minutes of polling → expect zero new approvals from already-seen messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)