### PR TITLE
fix(api): launch-prep auth hardening (SESSION_SECRET, /api/users scope, OAuth rate limit, trust-tier default)

### DIFF
--- a/apps/api/src/__tests__/oauth-rate-limit.test.ts
+++ b/apps/api/src/__tests__/oauth-rate-limit.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  checkNewUserRateLimit,
+  NEW_USER_RATE_LIMIT_MAX,
+  NEW_USER_RATE_LIMIT_WINDOW_MS,
+  _resetNewUserRateLimitForTests,
+} from '../routes/oauth.js';
+
+describe('checkNewUserRateLimit', () => {
+  beforeEach(() => {
+    _resetNewUserRateLimitForTests();
+  });
+
+  it('allows up to MAX requests within the window', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < NEW_USER_RATE_LIMIT_MAX; i++) {
+      const result = checkNewUserRateLimit('1.2.3.4', now);
+      expect(result.allowed).toBe(true);
+    }
+  });
+
+  it('rejects the (MAX+1)th request inside the window', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < NEW_USER_RATE_LIMIT_MAX; i++) {
+      checkNewUserRateLimit('1.2.3.4', now);
+    }
+    const blocked = checkNewUserRateLimit('1.2.3.4', now);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.resetAt).toBe(now + NEW_USER_RATE_LIMIT_WINDOW_MS);
+  });
+
+  it('isolates buckets per IP', () => {
+    const now = 2_000_000;
+    for (let i = 0; i < NEW_USER_RATE_LIMIT_MAX; i++) {
+      checkNewUserRateLimit('1.1.1.1', now);
+    }
+    expect(checkNewUserRateLimit('1.1.1.1', now).allowed).toBe(false);
+    // Different IP gets a fresh bucket.
+    expect(checkNewUserRateLimit('2.2.2.2', now).allowed).toBe(true);
+  });
+
+  it('resets after the window passes', () => {
+    const now = 3_000_000;
+    for (let i = 0; i < NEW_USER_RATE_LIMIT_MAX; i++) {
+      checkNewUserRateLimit('9.9.9.9', now);
+    }
+    expect(checkNewUserRateLimit('9.9.9.9', now).allowed).toBe(false);
+
+    // Past the window — bucket should reset.
+    const after = now + NEW_USER_RATE_LIMIT_WINDOW_MS + 1;
+    expect(checkNewUserRateLimit('9.9.9.9', after).allowed).toBe(true);
+  });
+});

--- a/apps/api/src/__tests__/startup-assertions.test.ts
+++ b/apps/api/src/__tests__/startup-assertions.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { assertSessionSecret } from '../startup-assertions.js';
+
+describe('assertSessionSecret', () => {
+  it('passes silently in development even with unset secret', () => {
+    const result = assertSessionSecret({ nodeEnv: 'development' });
+    expect(result.ok).toBe(true);
+    expect(result.fatal).toBe(false);
+  });
+
+  it('passes silently in test even with the dev default', () => {
+    const result = assertSessionSecret({
+      nodeEnv: 'test',
+      sessionSecret: 'skytwin-dev-secret',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('refuses to start in production with no SESSION_SECRET set', () => {
+    const result = assertSessionSecret({ nodeEnv: 'production' });
+    expect(result.ok).toBe(false);
+    expect(result.fatal).toBe(true);
+    expect(result.message).toContain('SESSION_SECRET must be set');
+  });
+
+  it('refuses to start in production with the hardcoded dev default', () => {
+    const result = assertSessionSecret({
+      nodeEnv: 'production',
+      sessionSecret: 'skytwin-dev-secret',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.fatal).toBe(true);
+    expect(result.message).toMatch(/hardcoded dev default/);
+  });
+
+  it('refuses to start in production with a too-short secret', () => {
+    const result = assertSessionSecret({
+      nodeEnv: 'production',
+      sessionSecret: 'short',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.fatal).toBe(true);
+    expect(result.message).toMatch(/too short/);
+  });
+
+  it('passes in production with a real secret of sufficient length', () => {
+    const result = assertSessionSecret({
+      nodeEnv: 'production',
+      sessionSecret: 'a'.repeat(64),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.fatal).toBe(false);
+  });
+
+  it('honours custom defaultDevSecret/minLength overrides', () => {
+    const result = assertSessionSecret({
+      nodeEnv: 'staging',
+      sessionSecret: 'mydefault',
+      defaultDevSecret: 'mydefault',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/hardcoded dev default/);
+  });
+
+  it('treats staging the same as production (anything non-dev/test)', () => {
+    const result = assertSessionSecret({ nodeEnv: 'staging' });
+    expect(result.ok).toBe(false);
+    expect(result.fatal).toBe(true);
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express, { type Application } from 'express';
 import { loadConfig, validate } from '@skytwin/config';
+import { assertSessionSecret } from './startup-assertions.js';
 import { createEventsRouter } from './routes/events.js';
 import { createTwinRouter } from './routes/twin.js';
 import { createDecisionsRouter } from './routes/decisions.js';
@@ -26,6 +27,22 @@ import { startMdnsAdvertisement, stopMdnsAdvertisement } from './mdns.js';
 import { closePool } from '@skytwin/db';
 
 const config = loadConfig();
+
+// SESSION_SECRET is the HMAC key for bearer-token hashing AND for OAuth
+// state signatures (see apps/api/src/routes/oauth.ts). Both fall back to
+// the literal `'skytwin-dev-secret'` if unset, which is fine in dev but
+// a security hole anywhere else — the default is in the open-source code.
+// See startup-assertions.ts for the policy and unit tests.
+{
+  const result = assertSessionSecret({
+    nodeEnv: config.nodeEnv,
+    sessionSecret: process.env['SESSION_SECRET'],
+  });
+  if (!result.ok && result.fatal) {
+    console.error(`[api] Fatal: ${result.message}`);
+    process.exit(1);
+  }
+}
 
 // Validate config on startup
 const configErrors = validate(config);

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -21,6 +21,37 @@ const STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes — plenty for the consent sc
 const STATE_VERSION = 'v2';
 
 /**
+ * Rate limit for the public /google/authorize?newUser=true path. Anyone can
+ * hit it (it's the front door for sign-in-with-Google), so without a cap an
+ * attacker could mint authorize URLs in a loop and/or burn the project's
+ * Google OAuth quota. Per-IP, sliding minute window.
+ */
+export const NEW_USER_RATE_LIMIT_MAX = 5;
+export const NEW_USER_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const newUserRateBuckets = new Map<string, { count: number; resetAt: number }>();
+
+export function checkNewUserRateLimit(
+  ip: string,
+  now: number = Date.now(),
+): { allowed: boolean; resetAt: number } {
+  let bucket = newUserRateBuckets.get(ip);
+  if (!bucket || bucket.resetAt <= now) {
+    bucket = { count: 0, resetAt: now + NEW_USER_RATE_LIMIT_WINDOW_MS };
+    newUserRateBuckets.set(ip, bucket);
+  }
+  if (bucket.count >= NEW_USER_RATE_LIMIT_MAX) {
+    return { allowed: false, resetAt: bucket.resetAt };
+  }
+  bucket.count += 1;
+  return { allowed: true, resetAt: bucket.resetAt };
+}
+
+/** Test helper — clears all rate-limit buckets between cases. */
+export function _resetNewUserRateLimitForTests(): void {
+  newUserRateBuckets.clear();
+}
+
+/**
  * Google's userinfo response. We don't depend on the Google SDK so this is
  * just the fields we read after a successful token exchange.
  */
@@ -214,12 +245,29 @@ export function createOAuthRouter(): Router {
    */
   router.get('/google/authorize', async (req, res, next) => {
     try {
+      const newUser = req.query['newUser'] === 'true';
+
+      // Rate-limit the public new-user variant by IP. The authenticated
+      // path is already gated by sessionAuth so it's implicitly throttled
+      // by login, but anyone can hit ?newUser=true.
+      if (newUser) {
+        const ip = req.ip ?? req.socket.remoteAddress ?? 'unknown';
+        const { allowed, resetAt } = checkNewUserRateLimit(ip, Date.now());
+        if (!allowed) {
+          res.set('Retry-After', String(Math.ceil((resetAt - Date.now()) / 1000)));
+          res.status(429).json({
+            error: 'Too many sign-in attempts. Try again in a minute.',
+            resetAt: new Date(resetAt).toISOString(),
+          });
+          return;
+        }
+      }
+
       const googleConfig = await resolveGoogleConfig();
       const scopes = [...IDENTITY_SCOPES, ...GMAIL_SCOPES, ...CALENDAR_SCOPES];
 
       const queryUserId =
         typeof req.query['userId'] === 'string' ? req.query['userId'] : undefined;
-      const newUser = req.query['newUser'] === 'true';
       const newAccount = req.query['newAccount'] === 'true';
       const desktop = req.query['desktop'] === 'true';
 
@@ -304,6 +352,14 @@ export function createOAuthRouter(): Router {
       }
 
       // Resolve target userId.
+      //
+      // Auto-created users start at 'observer' (read-only). The interactive
+      // POST /api/users path uses 'suggest' — there a real human is filling
+      // out a form — but a passive sign-in-with-Google grant shouldn't
+      // unlock action suggestions on day one. The user earns 'suggest' via
+      // approval feedback through the trust-tier audit pipeline.
+      const NEW_USER_TIER = 'observer';
+
       let userId = parsed.userId;
       if (!userId) {
         // Auto-create or attach to a user keyed on the verified Google email.
@@ -314,8 +370,7 @@ export function createOAuthRouter(): Router {
           const created = await userRepository.create({
             email: accountEmail,
             name: userInfo.name ?? accountEmail,
-            // New users start at 'suggest'. Trust must be earned via feedback.
-            trustTier: 'suggest',
+            trustTier: NEW_USER_TIER,
           });
           userId = created.id;
         }
@@ -331,7 +386,7 @@ export function createOAuthRouter(): Router {
             const created = await userRepository.create({
               email: accountEmail,
               name: userInfo.name ?? accountEmail,
-              trustTier: 'suggest',
+              trustTier: NEW_USER_TIER,
             });
             userId = created.id;
           }

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -26,22 +26,49 @@ export function createUsersRouter(): Router {
   /**
    * GET /api/users
    *
-   * List all users. Used by the dashboard's user-switcher in dev. Gated by
-   * the same sessionAuth as the per-user routes — when SKYTWIN_DEV_AUTH_BYPASS
-   * is on (localhost dev) it returns the full set; otherwise the caller must
-   * be authenticated.
+   * Returns the list of users *visible to the caller*:
+   *   - With dev auth bypass active (localhost, NODE_ENV=development):
+   *     the full set, so the dashboard's user-switcher works.
+   *   - With a real authenticated session: only the caller's own user row.
+   *     We intentionally don't 403 — the user-switcher renders a single-row
+   *     dropdown which is correct in production.
+   *
+   * Without this scoping any authenticated user could enumerate every other
+   * user's id+email — a privacy bug found pre-launch.
    */
-  router.get('/', sessionAuth, async (_req, res, next) => {
+  router.get('/', sessionAuth, async (req, res, next) => {
     try {
-      const users = await userRepository.findAll();
+      const requesterId = req.authenticatedUserId;
+
+      // Dev auth bypass: req.authenticatedUserId is undefined and the
+      // sessionAuth middleware has already let us through (its only path
+      // that doesn't set the field). Return everything.
+      if (!requesterId) {
+        const users = await userRepository.findAll();
+        res.json({
+          users: users.map((u) => ({
+            id: u.id,
+            email: u.email,
+            name: u.name,
+            trustTier: u.trust_tier,
+            createdAt: u.created_at,
+          })),
+        });
+        return;
+      }
+
+      // Authenticated path: return only the caller.
+      const me = await userRepository.findById(requesterId);
       res.json({
-        users: users.map((u) => ({
-          id: u.id,
-          email: u.email,
-          name: u.name,
-          trustTier: u.trust_tier,
-          createdAt: u.created_at,
-        })),
+        users: me
+          ? [{
+              id: me.id,
+              email: me.email,
+              name: me.name,
+              trustTier: me.trust_tier,
+              createdAt: me.created_at,
+            }]
+          : [],
       });
     } catch (error) {
       next(error);

--- a/apps/api/src/startup-assertions.ts
+++ b/apps/api/src/startup-assertions.ts
@@ -1,0 +1,73 @@
+/**
+ * Startup-time invariants the api must satisfy *before* it accepts traffic.
+ *
+ * Kept as pure functions so failures are testable without booting the
+ * server. The actual `process.exit(1)` path lives in `index.ts` so a
+ * misbehaving caller (or test) can validate without killing the runner.
+ */
+
+export interface StartupAssertionResult {
+  ok: boolean;
+  fatal: boolean;
+  message?: string;
+}
+
+/**
+ * Reasons a SESSION_SECRET is unacceptable in non-dev:
+ *   - unset (would silently fall back to the literal default)
+ *   - matches the hardcoded dev default (open-source code reveals it)
+ *   - too short to provide meaningful HMAC entropy
+ *
+ * Returns `ok: true` with no message when the env is fine, or
+ * `ok: false` with a fatal error message when the api must refuse to start.
+ */
+export function assertSessionSecret(env: {
+  nodeEnv?: string;
+  sessionSecret?: string;
+  defaultDevSecret?: string;
+  minLength?: number;
+}): StartupAssertionResult {
+  const nodeEnv = env.nodeEnv ?? 'development';
+  const secret = env.sessionSecret;
+  const defaultDevSecret = env.defaultDevSecret ?? 'skytwin-dev-secret';
+  const minLength = env.minLength ?? 32;
+
+  // Dev/test allowed to fall back to the literal default. Everything else
+  // must set a real secret.
+  if (nodeEnv === 'development' || nodeEnv === 'test') {
+    return { ok: true, fatal: false };
+  }
+
+  if (!secret) {
+    return {
+      ok: false,
+      fatal: true,
+      message:
+        `SESSION_SECRET must be set in ${nodeEnv}. ` +
+        `Generate one with: openssl rand -hex 32`,
+    };
+  }
+
+  if (secret === defaultDevSecret) {
+    return {
+      ok: false,
+      fatal: true,
+      message:
+        `SESSION_SECRET is set to the hardcoded dev default in ${nodeEnv} — ` +
+        `this is the literal string anyone reading the open-source code knows. ` +
+        `Generate a real secret: openssl rand -hex 32`,
+    };
+  }
+
+  if (secret.length < minLength) {
+    return {
+      ok: false,
+      fatal: true,
+      message:
+        `SESSION_SECRET is too short (${secret.length} chars, minimum ${minLength}). ` +
+        `Use \`openssl rand -hex 32\`.`,
+    };
+  }
+
+  return { ok: true, fatal: false };
+}


### PR DESCRIPTION
Four launch-blocking issues found while reviewing the just-merged work through a "real users about to hit it" lens. None were flagged by Copilot — all are pre-launch-only since the dev environment hides them.

## What's hardened

- **SESSION_SECRET assertion at startup.** `session-auth.ts` and `oauth.ts` silently fall back to the literal `'skytwin-dev-secret'` when the env is unset. In production that means anyone reading the open-source code knows the prod HMAC key for both bearer tokens and OAuth state signatures. The api now refuses to start outside dev/test if the secret is unset, equals the dev default, or is shorter than 32 chars. Logic lives in `apps/api/src/startup-assertions.ts` so the failure paths are unit-testable without `process.exit`.

- **`GET /api/users` scoped to the requester.** Previously any authenticated user could enumerate every other user's id and email. Now the full set is returned only when the dev auth bypass is active; an authenticated session gets back just their own row. The user-switcher dropdown becomes a single-row dropdown in prod — which is correct.

- **Per-IP rate limit on `/google/authorize?newUser=true`.** This is the public sign-in-with-Google path. Without a cap an attacker could mint authorize URLs in a loop and burn the Google OAuth quota. Now 5 requests per minute per IP, 429 with `Retry-After` when exceeded.

- **Auto-created users start at `'observer'`** instead of `'suggest'`. Symmetric with the manual `POST /api/users` was the wrong call — a passive sign-in-with-Google grant shouldn't unlock action suggestions on day one. User earns `'suggest'` through approval feedback.

## Test plan
- [x] `apps/api`: 182 tests pass (12 new) — `startup-assertions.test.ts` (8 cases covering dev/test pass-through, prod/staging fail-loud, custom defaults, length validation), `oauth-rate-limit.test.ts` (4 cases: MAX-allowed, rejection, per-IP isolation, window reset).
- [x] `pnpm --filter @skytwin/api exec tsc --noEmit` — clean.
- [ ] Smoke: hit `/api/users` against the dev API as the auth-bypass-active localhost — returns full list.
- [ ] Smoke: hit `/api/oauth/google/authorize?newUser=true` 6 times in a minute — 6th gets 429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)