### PR TITLE
feat(web): sign-in-with-Google as the onboarding front door

### DIFF
--- a/apps/api/src/__tests__/oauth-rate-limit.test.ts
+++ b/apps/api/src/__tests__/oauth-rate-limit.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  checkNewUserRateLimit,
+  NEW_USER_RATE_LIMIT_MAX,
+  NEW_USER_RATE_LIMIT_WINDOW_MS,
+  _resetNewUserRateLimitForTests,
+} from '../routes/oauth.js';
+
+describe('checkNewUserRateLimit', () => {
+  beforeEach(() => {
+    _resetNewUserRateLimitForTests();
+  });
+
+  it('allows up to MAX requests within the window', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < NEW_USER_RATE_LIMIT_MAX; i++) {
+      const result = checkNewUserRateLimit('1.2.3.4', now);
+      expect(result.allowed).toBe(true);
+    }
+  });
+
+  it('rejects the (MAX+1)th request inside the window', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < NEW_USER_RATE_LIMIT_MAX; i++) {
+      checkNewUserRateLimit('1.2.3.4', now);
+    }
+    const blocked = checkNewUserRateLimit('1.2.3.4', now);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.resetAt).toBe(now + NEW_USER_RATE_LIMIT_WINDOW_MS);
+  });
+
+  it('isolates buckets per IP', () => {
+    const now = 2_000_000;
+    for (let i = 0; i < NEW_USER_RATE_LIMIT_MAX; i++) {
+      checkNewUserRateLimit('1.1.1.1', now);
+    }
+    expect(checkNewUserRateLimit('1.1.1.1', now).allowed).toBe(false);
+    // Different IP gets a fresh bucket.
+    expect(checkNewUserRateLimit('2.2.2.2', now).allowed).toBe(true);
+  });
+
+  it('resets after the window passes', () => {
+    const now = 3_000_000;
+    for (let i = 0; i < NEW_USER_RATE_LIMIT_MAX; i++) {
+      checkNewUserRateLimit('9.9.9.9', now);
+    }
+    expect(checkNewUserRateLimit('9.9.9.9', now).allowed).toBe(false);
+
+    // Past the window — bucket should reset.
+    const after = now + NEW_USER_RATE_LIMIT_WINDOW_MS + 1;
+    expect(checkNewUserRateLimit('9.9.9.9', after).allowed).toBe(true);
+  });
+});

--- a/apps/api/src/__tests__/startup-assertions.test.ts
+++ b/apps/api/src/__tests__/startup-assertions.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { assertSessionSecret } from '../startup-assertions.js';
+
+describe('assertSessionSecret', () => {
+  it('passes silently in development even with unset secret', () => {
+    const result = assertSessionSecret({ nodeEnv: 'development' });
+    expect(result.ok).toBe(true);
+    expect(result.fatal).toBe(false);
+  });
+
+  it('passes silently in test even with the dev default', () => {
+    const result = assertSessionSecret({
+      nodeEnv: 'test',
+      sessionSecret: 'skytwin-dev-secret',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('refuses to start in production with no SESSION_SECRET set', () => {
+    const result = assertSessionSecret({ nodeEnv: 'production' });
+    expect(result.ok).toBe(false);
+    expect(result.fatal).toBe(true);
+    expect(result.message).toContain('SESSION_SECRET must be set');
+  });
+
+  it('refuses to start in production with the hardcoded dev default', () => {
+    const result = assertSessionSecret({
+      nodeEnv: 'production',
+      sessionSecret: 'skytwin-dev-secret',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.fatal).toBe(true);
+    expect(result.message).toMatch(/hardcoded dev default/);
+  });
+
+  it('refuses to start in production with a too-short secret', () => {
+    const result = assertSessionSecret({
+      nodeEnv: 'production',
+      sessionSecret: 'short',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.fatal).toBe(true);
+    expect(result.message).toMatch(/too short/);
+  });
+
+  it('passes in production with a real secret of sufficient length', () => {
+    const result = assertSessionSecret({
+      nodeEnv: 'production',
+      sessionSecret: 'a'.repeat(64),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.fatal).toBe(false);
+  });
+
+  it('honours custom defaultDevSecret/minLength overrides', () => {
+    const result = assertSessionSecret({
+      nodeEnv: 'staging',
+      sessionSecret: 'mydefault',
+      defaultDevSecret: 'mydefault',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/hardcoded dev default/);
+  });
+
+  it('treats staging the same as production (anything non-dev/test)', () => {
+    const result = assertSessionSecret({ nodeEnv: 'staging' });
+    expect(result.ok).toBe(false);
+    expect(result.fatal).toBe(true);
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express, { type Application } from 'express';
 import { loadConfig, validate } from '@skytwin/config';
+import { assertSessionSecret } from './startup-assertions.js';
 import { createEventsRouter } from './routes/events.js';
 import { createTwinRouter } from './routes/twin.js';
 import { createDecisionsRouter } from './routes/decisions.js';
@@ -26,6 +27,22 @@ import { startMdnsAdvertisement, stopMdnsAdvertisement } from './mdns.js';
 import { closePool } from '@skytwin/db';
 
 const config = loadConfig();
+
+// SESSION_SECRET is the HMAC key for bearer-token hashing AND for OAuth
+// state signatures (see apps/api/src/routes/oauth.ts). Both fall back to
+// the literal `'skytwin-dev-secret'` if unset, which is fine in dev but
+// a security hole anywhere else — the default is in the open-source code.
+// See startup-assertions.ts for the policy and unit tests.
+{
+  const result = assertSessionSecret({
+    nodeEnv: config.nodeEnv,
+    sessionSecret: process.env['SESSION_SECRET'],
+  });
+  if (!result.ok && result.fatal) {
+    console.error(`[api] Fatal: ${result.message}`);
+    process.exit(1);
+  }
+}
 
 // Validate config on startup
 const configErrors = validate(config);

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -21,6 +21,37 @@ const STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes — plenty for the consent sc
 const STATE_VERSION = 'v2';
 
 /**
+ * Rate limit for the public /google/authorize?newUser=true path. Anyone can
+ * hit it (it's the front door for sign-in-with-Google), so without a cap an
+ * attacker could mint authorize URLs in a loop and/or burn the project's
+ * Google OAuth quota. Per-IP, sliding minute window.
+ */
+export const NEW_USER_RATE_LIMIT_MAX = 5;
+export const NEW_USER_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const newUserRateBuckets = new Map<string, { count: number; resetAt: number }>();
+
+export function checkNewUserRateLimit(
+  ip: string,
+  now: number = Date.now(),
+): { allowed: boolean; resetAt: number } {
+  let bucket = newUserRateBuckets.get(ip);
+  if (!bucket || bucket.resetAt <= now) {
+    bucket = { count: 0, resetAt: now + NEW_USER_RATE_LIMIT_WINDOW_MS };
+    newUserRateBuckets.set(ip, bucket);
+  }
+  if (bucket.count >= NEW_USER_RATE_LIMIT_MAX) {
+    return { allowed: false, resetAt: bucket.resetAt };
+  }
+  bucket.count += 1;
+  return { allowed: true, resetAt: bucket.resetAt };
+}
+
+/** Test helper — clears all rate-limit buckets between cases. */
+export function _resetNewUserRateLimitForTests(): void {
+  newUserRateBuckets.clear();
+}
+
+/**
  * Google's userinfo response. We don't depend on the Google SDK so this is
  * just the fields we read after a successful token exchange.
  */
@@ -214,12 +245,29 @@ export function createOAuthRouter(): Router {
    */
   router.get('/google/authorize', async (req, res, next) => {
     try {
+      const newUser = req.query['newUser'] === 'true';
+
+      // Rate-limit the public new-user variant by IP. The authenticated
+      // path is already gated by sessionAuth so it's implicitly throttled
+      // by login, but anyone can hit ?newUser=true.
+      if (newUser) {
+        const ip = req.ip ?? req.socket.remoteAddress ?? 'unknown';
+        const { allowed, resetAt } = checkNewUserRateLimit(ip, Date.now());
+        if (!allowed) {
+          res.set('Retry-After', String(Math.ceil((resetAt - Date.now()) / 1000)));
+          res.status(429).json({
+            error: 'Too many sign-in attempts. Try again in a minute.',
+            resetAt: new Date(resetAt).toISOString(),
+          });
+          return;
+        }
+      }
+
       const googleConfig = await resolveGoogleConfig();
       const scopes = [...IDENTITY_SCOPES, ...GMAIL_SCOPES, ...CALENDAR_SCOPES];
 
       const queryUserId =
         typeof req.query['userId'] === 'string' ? req.query['userId'] : undefined;
-      const newUser = req.query['newUser'] === 'true';
       const newAccount = req.query['newAccount'] === 'true';
       const desktop = req.query['desktop'] === 'true';
 
@@ -304,6 +352,14 @@ export function createOAuthRouter(): Router {
       }
 
       // Resolve target userId.
+      //
+      // Auto-created users start at 'observer' (read-only). The interactive
+      // POST /api/users path uses 'suggest' — there a real human is filling
+      // out a form — but a passive sign-in-with-Google grant shouldn't
+      // unlock action suggestions on day one. The user earns 'suggest' via
+      // approval feedback through the trust-tier audit pipeline.
+      const NEW_USER_TIER = 'observer';
+
       let userId = parsed.userId;
       if (!userId) {
         // Auto-create or attach to a user keyed on the verified Google email.
@@ -314,8 +370,7 @@ export function createOAuthRouter(): Router {
           const created = await userRepository.create({
             email: accountEmail,
             name: userInfo.name ?? accountEmail,
-            // New users start at 'suggest'. Trust must be earned via feedback.
-            trustTier: 'suggest',
+            trustTier: NEW_USER_TIER,
           });
           userId = created.id;
         }
@@ -331,7 +386,7 @@ export function createOAuthRouter(): Router {
             const created = await userRepository.create({
               email: accountEmail,
               name: userInfo.name ?? accountEmail,
-              trustTier: 'suggest',
+              trustTier: NEW_USER_TIER,
             });
             userId = created.id;
           }

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -264,6 +264,16 @@ export function createOAuthRouter(): Router {
       }
 
       const googleConfig = await resolveGoogleConfig();
+      // Without configured Google credentials we'd happily build an auth URL
+      // with an empty client_id and Google would reject the user with an
+      // opaque "invalid_client" — surface a clean 503 so the dashboard can
+      // tell the user to finish Setup first.
+      if (!googleConfig.clientId || !googleConfig.clientSecret) {
+        res.status(503).json({
+          error: 'Google credentials are not configured. Open Setup and add your OAuth client_id and client_secret.',
+        });
+        return;
+      }
       const scopes = [...IDENTITY_SCOPES, ...GMAIL_SCOPES, ...CALENDAR_SCOPES];
 
       const queryUserId =

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -26,22 +26,49 @@ export function createUsersRouter(): Router {
   /**
    * GET /api/users
    *
-   * List all users. Used by the dashboard's user-switcher in dev. Gated by
-   * the same sessionAuth as the per-user routes — when SKYTWIN_DEV_AUTH_BYPASS
-   * is on (localhost dev) it returns the full set; otherwise the caller must
-   * be authenticated.
+   * Returns the list of users *visible to the caller*:
+   *   - With dev auth bypass active (localhost, NODE_ENV=development):
+   *     the full set, so the dashboard's user-switcher works.
+   *   - With a real authenticated session: only the caller's own user row.
+   *     We intentionally don't 403 — the user-switcher renders a single-row
+   *     dropdown which is correct in production.
+   *
+   * Without this scoping any authenticated user could enumerate every other
+   * user's id+email — a privacy bug found pre-launch.
    */
-  router.get('/', sessionAuth, async (_req, res, next) => {
+  router.get('/', sessionAuth, async (req, res, next) => {
     try {
-      const users = await userRepository.findAll();
+      const requesterId = req.authenticatedUserId;
+
+      // Dev auth bypass: req.authenticatedUserId is undefined and the
+      // sessionAuth middleware has already let us through (its only path
+      // that doesn't set the field). Return everything.
+      if (!requesterId) {
+        const users = await userRepository.findAll();
+        res.json({
+          users: users.map((u) => ({
+            id: u.id,
+            email: u.email,
+            name: u.name,
+            trustTier: u.trust_tier,
+            createdAt: u.created_at,
+          })),
+        });
+        return;
+      }
+
+      // Authenticated path: return only the caller.
+      const me = await userRepository.findById(requesterId);
       res.json({
-        users: users.map((u) => ({
-          id: u.id,
-          email: u.email,
-          name: u.name,
-          trustTier: u.trust_tier,
-          createdAt: u.created_at,
-        })),
+        users: me
+          ? [{
+              id: me.id,
+              email: me.email,
+              name: me.name,
+              trustTier: me.trust_tier,
+              createdAt: me.created_at,
+            }]
+          : [],
       });
     } catch (error) {
       next(error);

--- a/apps/api/src/startup-assertions.ts
+++ b/apps/api/src/startup-assertions.ts
@@ -1,0 +1,73 @@
+/**
+ * Startup-time invariants the api must satisfy *before* it accepts traffic.
+ *
+ * Kept as pure functions so failures are testable without booting the
+ * server. The actual `process.exit(1)` path lives in `index.ts` so a
+ * misbehaving caller (or test) can validate without killing the runner.
+ */
+
+export interface StartupAssertionResult {
+  ok: boolean;
+  fatal: boolean;
+  message?: string;
+}
+
+/**
+ * Reasons a SESSION_SECRET is unacceptable in non-dev:
+ *   - unset (would silently fall back to the literal default)
+ *   - matches the hardcoded dev default (open-source code reveals it)
+ *   - too short to provide meaningful HMAC entropy
+ *
+ * Returns `ok: true` with no message when the env is fine, or
+ * `ok: false` with a fatal error message when the api must refuse to start.
+ */
+export function assertSessionSecret(env: {
+  nodeEnv?: string;
+  sessionSecret?: string;
+  defaultDevSecret?: string;
+  minLength?: number;
+}): StartupAssertionResult {
+  const nodeEnv = env.nodeEnv ?? 'development';
+  const secret = env.sessionSecret;
+  const defaultDevSecret = env.defaultDevSecret ?? 'skytwin-dev-secret';
+  const minLength = env.minLength ?? 32;
+
+  // Dev/test allowed to fall back to the literal default. Everything else
+  // must set a real secret.
+  if (nodeEnv === 'development' || nodeEnv === 'test') {
+    return { ok: true, fatal: false };
+  }
+
+  if (!secret) {
+    return {
+      ok: false,
+      fatal: true,
+      message:
+        `SESSION_SECRET must be set in ${nodeEnv}. ` +
+        `Generate one with: openssl rand -hex 32`,
+    };
+  }
+
+  if (secret === defaultDevSecret) {
+    return {
+      ok: false,
+      fatal: true,
+      message:
+        `SESSION_SECRET is set to the hardcoded dev default in ${nodeEnv} — ` +
+        `this is the literal string anyone reading the open-source code knows. ` +
+        `Generate a real secret: openssl rand -hex 32`,
+    };
+  }
+
+  if (secret.length < minLength) {
+    return {
+      ok: false,
+      fatal: true,
+      message:
+        `SESSION_SECRET is too short (${secret.length} chars, minimum ${minLength}). ` +
+        `Use \`openssl rand -hex 32\`.`,
+    };
+  }
+
+  return { ok: true, fatal: false };
+}

--- a/apps/web/public/js/pages/onboarding.js
+++ b/apps/web/public/js/pages/onboarding.js
@@ -1,4 +1,4 @@
-import { createUser, getGoogleAuthUrl, updateTrustTier, fetchJSON, fetchTwinProfile } from '../api-client.js';
+import { createUser, updateTrustTier, fetchJSON, fetchTwinProfile } from '../api-client.js';
 
 // ── Domain definitions ──────────────────────────────────────────────
 
@@ -99,53 +99,80 @@ const STEPS = [
     },
   },
 
-  // Step 2: Email + name + Google connect
+  // Step 2: Sign in — Google is the front door, email is the fallback.
   {
     render: (container, next, back, setUserId) => {
       container.innerHTML = `
         <div class="onboarding-step">Step 2 of 5</div>
-        <div class="onboarding-title">What's your name and email?</div>
+        <div class="onboarding-title">Sign in to get started</div>
         <div class="onboarding-desc">
-          We'll use this to identify you. Nothing will be sent to this address.
+          Connect with Google so your twin can see your email and calendar from day one. We use the verified email as your identity — no separate password.
         </div>
-        <div class="form-group">
-          <label>Your name</label>
-          <input class="form-input" id="onb-name" type="text" placeholder="Jane" autofocus>
+        <div id="onb-error" style="color: var(--danger); font-size: 0.85rem; margin: 0.5rem 0 1rem; display: none;"></div>
+
+        <div style="margin: 1rem 0 1.5rem;">
+          <button class="btn btn-primary btn-lg" id="onb-google-signin" style="width: 100%; display: flex; align-items: center; justify-content: center; gap: 0.5rem;">
+            <span style="font-weight: 600;">G</span>
+            <span>Continue with Google</span>
+          </button>
         </div>
-        <div class="form-group">
-          <label>Your email address</label>
-          <input class="form-input" id="onb-email" type="email" placeholder="you@example.com">
-        </div>
-        <div id="onb-error" style="color: var(--danger); font-size: 0.85rem; margin-top: 0.5rem; display: none;"></div>
-        <div class="onboarding-desc" style="font-size: 0.85rem; margin-top: 1rem;">
-          <strong>Optional:</strong> Connect your Google account so SkyTwin can see your inbox and calendar. You can do this later in Settings.
-        </div>
-        <div style="margin-bottom: 1.5rem;">
-          <button class="btn btn-outline" id="onb-connect-google">Connect my email &amp; calendar</button>
-        </div>
-        <div class="onboarding-actions" style="display: flex; gap: 0.75rem;">
+
+        <details style="margin: 0 0 1rem; font-size: 0.85rem;">
+          <summary style="cursor: pointer; color: var(--text-muted);">Continue with an email address instead</summary>
+          <div style="margin-top: 1rem; padding: 1rem; border: 1px solid var(--border); border-radius: var(--radius-sm);">
+            <div class="onboarding-desc" style="font-size: 0.8rem; margin-bottom: 0.75rem;">
+              No Google connection — your twin won't see your inbox/calendar until you link one in Settings.
+            </div>
+            <div class="form-group">
+              <label>Your name</label>
+              <input class="form-input" id="onb-name" type="text" placeholder="Jane">
+            </div>
+            <div class="form-group">
+              <label>Your email address</label>
+              <input class="form-input" id="onb-email" type="email" placeholder="you@example.com">
+            </div>
+            <button class="btn btn-outline" id="onb-email-continue" style="width: 100%; margin-top: 0.5rem;">Continue with email</button>
+          </div>
+        </details>
+
+        <div class="onboarding-actions" style="margin-top: 1rem;">
           <button class="btn btn-outline" id="onb-back-2">Back</button>
-          <button class="btn btn-primary btn-lg" id="onb-next-2">Continue</button>
         </div>
       `;
 
       document.getElementById('onb-back-2').addEventListener('click', back);
 
-      document.getElementById('onb-connect-google').addEventListener('click', async () => {
-        const email = document.getElementById('onb-email').value.trim();
-        if (!email || !email.includes('@')) {
-          showError('Please enter your email address first.');
-          return;
-        }
+      // ── Google sign-in: front door ──────────────────────────────────
+      document.getElementById('onb-google-signin').addEventListener('click', async () => {
+        hideError();
+        const btn = document.getElementById('onb-google-signin');
+        const original = btn.innerHTML;
+        btn.innerHTML = '<span>Redirecting…</span>';
+        btn.disabled = true;
         try {
-          const data = await getGoogleAuthUrl(email);
-          if (data.url) window.open(data.url, '_blank');
-        } catch {
-          showError('Could not connect to Google right now. You can try again later in Settings.');
+          // Public newUser=true endpoint: no userId required. Callback will
+          // auto-create a user keyed on the verified email and redirect us
+          // back with ?userId=… which app.js picks up.
+          const data = await fetchJSON('/api/oauth/google/authorize?newUser=true');
+          if (data.url) {
+            window.location.href = data.url;
+            return;
+          }
+          throw new Error('No authorize URL returned');
+        } catch (err) {
+          btn.innerHTML = original;
+          btn.disabled = false;
+          // Most likely: Google client_id/secret not configured yet.
+          showError(
+            err.message?.includes('credentials')
+              ? 'Google credentials are not configured yet. Continue with an email below for now and connect Google later in Settings.'
+              : (err.message || 'Could not start Google sign-in. Try the email option below, or try again.'),
+          );
         }
       });
 
-      document.getElementById('onb-next-2').addEventListener('click', async () => {
+      // ── Email fallback ──────────────────────────────────────────────
+      document.getElementById('onb-email-continue').addEventListener('click', async () => {
         const email = document.getElementById('onb-email').value.trim();
         const name = document.getElementById('onb-name').value.trim() || email.split('@')[0];
         if (!email || !email.includes('@')) {
@@ -153,7 +180,7 @@ const STEPS = [
           return;
         }
         hideError();
-        const btn = document.getElementById('onb-next-2');
+        const btn = document.getElementById('onb-email-continue');
         btn.textContent = 'Setting up...';
         btn.disabled = true;
         try {
@@ -162,7 +189,7 @@ const STEPS = [
           next();
         } catch (err) {
           showError(err.message || 'Something went wrong. Please try again.');
-          btn.textContent = 'Continue';
+          btn.textContent = 'Continue with email';
           btn.disabled = false;
         }
       });


### PR DESCRIPTION
Closes the last hard launch-blocker from the auth-hardening review (sibling PR #113). A real new user arriving fresh now has a one-click path — "Continue with Google" → consent → land logged in.

## Why
The existing onboarding required a real user's first interaction to be **typing their name and email into a form**. With sign-in-with-Google now wired through (#103) and the public `/authorize?newUser=true` rate-limited (#113), the right thing is to make Google the front door and demote the email-typing path.

## What changed

- **Step 2 of the onboarding overlay** leads with a single primary "Continue with Google" button. Click → `POST /api/oauth/google/authorize?newUser=true` → `window.location.href` = returned Google URL → consent → callback → redirect back to `/?userId=…#/settings?connected=google&account=…`. The existing app.js URL handler picks it up and sets the active user.
- **Email fallback preserved** under a `<details>` toggle: name + email + "Continue with email" creates a user via `POST /api/users` and proceeds to step 3 of the wizard.
- **Graceful failure when Google creds aren't configured.** The authorize endpoint now returns 503 with a clear message instead of building an invalid URL with empty client_id and letting Google surface "invalid_client". The dashboard catches the 503 and tells the user to finish Setup first.

## Test plan
- [x] Cleared localStorage, reloaded — step 1 renders, "Let's get started" advances to step 2 with the new layout (Google primary, email collapsed).
- [x] `GET /api/oauth/google/authorize?newUser=true` returns 200 with a real `accounts.google.com/...&client_id=…` URL.
- [x] Rate limit verified: 5 successes then 429 "Too many sign-in attempts" (sibling PR #113's protection).
- [x] `pnpm --filter @skytwin/api test` — 182 passed, 24 skipped.
- [ ] Full Google round-trip (manual): button → real consent → return as new user with auto-created `'observer'` profile.

## Sequencing note
This PR depends on #113 being merged first — it relies on:
- The public `/authorize?newUser=true` (no sessionAuth)
- Rate-limiting on that public path
- Trust-tier flip to `'observer'` for auto-created users

If #113 hasn't merged yet, this PR works in dev (auth-bypass on localhost) but should not ship to prod until #113 is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)