### PR TITLE
feat(connectors): Gmail History API + persistent cursor (closes #102)

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -6,9 +6,11 @@ import {
   GoogleCalendarConnector,
   DbTokenStore,
   OAuthRefreshError,
+  type CursorStore,
   type GoogleOAuthConfig,
 } from '@skytwin/connectors';
 import {
+  connectorCursorRepository,
   forwardedSignalsRepository,
   oauthRepository,
   approvalRepository,
@@ -23,6 +25,21 @@ const log = createLogger('worker');
 
 /** Per-user circuit breakers to skip users with persistent failures. */
 const userCircuitBreakers = new Map<string, CircuitBreaker>();
+
+/**
+ * Persistent cursor for Gmail's History API. Survives worker restarts so
+ * the connector polls deltas (`history.list?startHistoryId=…`) instead of
+ * re-listing the inbox on every cycle.
+ */
+const gmailCursorStore: CursorStore = {
+  async get(userId, provider, kind) {
+    const row = await connectorCursorRepository.get(userId, provider, kind);
+    return row?.cursor_value ?? null;
+  },
+  async save(userId, provider, kind, value) {
+    await connectorCursorRepository.save(userId, provider, kind, value);
+  },
+};
 
 /**
  * Dedup state survives restarts via forwarded_signals: the in-memory map
@@ -279,7 +296,7 @@ async function discoverUsers(): Promise<UserConnectors[]> {
         }
         if (googleConfig) {
           const tokenStore = new DbTokenStore(oauthRepository, googleConfig);
-          connectors.push(new GmailConnector(userId, tokenStore));
+          connectors.push(new GmailConnector(userId, tokenStore, gmailCursorStore));
           connectors.push(new GoogleCalendarConnector(userId, tokenStore));
         }
       }

--- a/packages/connectors/src/__tests__/gmail-connector.test.ts
+++ b/packages/connectors/src/__tests__/gmail-connector.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { GmailConnector } from '../gmail-connector.js';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { GmailConnector, type CursorStore } from '../gmail-connector.js';
 import type { OAuthTokenStore } from '../oauth/token-store.js';
 
 function makeStubStore(token: { accessToken: string; refreshToken: string; expiresAt: Date } | null): OAuthTokenStore {
@@ -203,5 +203,230 @@ describe('GmailConnector.messageToSignal', () => {
     const sig = toSignal(msg) as { data: { from: string; subject: string } };
     expect(sig.data.from).toBe('');
     expect(sig.data.subject).toBe('');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Gmail History API integration — uses stubbed fetch responses.
+// ─────────────────────────────────────────────────────────────────────────
+
+type FetchHandler = (url: string) => Promise<Response> | Response;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeFetchRouter(routes: Record<string, FetchHandler>): typeof fetch {
+  return (async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.toString();
+    for (const [pattern, handler] of Object.entries(routes)) {
+      if (url.includes(pattern)) {
+        return handler(url);
+      }
+    }
+    throw new Error(`Unrouted fetch: ${url}`);
+  }) as typeof fetch;
+}
+
+function makeMemoryCursor(initial: Record<string, string> = {}): CursorStore & { snapshot: Record<string, string> } {
+  const store: Record<string, string> = { ...initial };
+  return {
+    snapshot: store,
+    async get(userId, provider, kind) {
+      return store[`${userId}:${provider}:${kind}`] ?? null;
+    },
+    async save(userId, provider, kind, value) {
+      store[`${userId}:${provider}:${kind}`] = value;
+    },
+  };
+}
+
+function makeFreshTokenStore(): OAuthTokenStore {
+  const tok = { accessToken: 'a', refreshToken: 'r', expiresAt: new Date(Date.now() + 60_000) };
+  return {
+    save: async () => undefined,
+    get: async () => tok,
+    delete: async () => undefined,
+    refreshIfExpired: async () => tok,
+  } as unknown as OAuthTokenStore;
+}
+
+describe('GmailConnector History API', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('bootstrap (no cursor) lists recent unread, emits signals, and persists historyId', async () => {
+    const detailFor = (id: string, hist: string) =>
+      jsonResponse({
+        id,
+        threadId: `t-${id}`,
+        labelIds: ['INBOX'],
+        snippet: `s-${id}`,
+        payload: {
+          headers: [
+            { name: 'From', value: 'sender@example.com' },
+            { name: 'Subject', value: `subject ${id}` },
+          ],
+        },
+        internalDate: '1735689600000',
+        historyId: hist,
+      });
+
+    vi.stubGlobal('fetch', makeFetchRouter({
+      '/users/me/messages?q=': () => jsonResponse({ messages: [{ id: 'm1' }, { id: 'm2' }] }),
+      '/users/me/messages/m1': () => detailFor('m1', '1010'),
+      '/users/me/messages/m2': () => detailFor('m2', '1020'),
+    }));
+
+    const cursor = makeMemoryCursor();
+    const conn = new GmailConnector('user-1', makeFreshTokenStore(), cursor);
+    await conn.connect();
+    const signals = await conn.poll();
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0]!.id).toBe('sig_gmail_m1');
+    expect(signals[1]!.id).toBe('sig_gmail_m2');
+    // Highest historyId observed becomes the persisted cursor.
+    expect(cursor.snapshot['user-1:gmail:history_id']).toBe('1020');
+  });
+
+  it('bootstrap with empty inbox falls back to /users/me/profile for the cursor', async () => {
+    vi.stubGlobal('fetch', makeFetchRouter({
+      '/users/me/messages?q=': () => jsonResponse({ messages: [] }),
+      '/users/me/profile': () => jsonResponse({ historyId: '99' }),
+    }));
+
+    const cursor = makeMemoryCursor();
+    const conn = new GmailConnector('user-1', makeFreshTokenStore(), cursor);
+    await conn.connect();
+    const signals = await conn.poll();
+
+    expect(signals).toHaveLength(0);
+    expect(cursor.snapshot['user-1:gmail:history_id']).toBe('99');
+  });
+
+  it('subsequent poll uses history.list with stored startHistoryId and emits only added messages', async () => {
+    const calls: string[] = [];
+    vi.stubGlobal('fetch', makeFetchRouter({
+      '/users/me/history': (url) => {
+        calls.push(url);
+        return jsonResponse({
+          history: [
+            { messagesAdded: [{ message: { id: 'new-1' } }] },
+            { messagesAdded: [{ message: { id: 'new-2' } }] },
+          ],
+          historyId: '2050',
+        });
+      },
+      '/users/me/messages/new-1': () => jsonResponse({
+        id: 'new-1',
+        threadId: 't-new-1',
+        labelIds: [],
+        snippet: '',
+        payload: { headers: [] },
+        internalDate: '1735689600000',
+        historyId: '2030',
+      }),
+      '/users/me/messages/new-2': () => jsonResponse({
+        id: 'new-2',
+        threadId: 't-new-2',
+        labelIds: [],
+        snippet: '',
+        payload: { headers: [] },
+        internalDate: '1735689600000',
+        historyId: '2040',
+      }),
+    }));
+
+    const cursor = makeMemoryCursor({ 'user-1:gmail:history_id': '1000' });
+    const conn = new GmailConnector('user-1', makeFreshTokenStore(), cursor);
+    await conn.connect();
+    const signals = await conn.poll();
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0]!.id).toBe('sig_gmail_new-1');
+    expect(calls[0]).toContain('startHistoryId=1000');
+    expect(calls[0]).toContain('historyTypes=messageAdded');
+    // Cursor advances to the response's historyId (which is the highest observed).
+    expect(cursor.snapshot['user-1:gmail:history_id']).toBe('2050');
+  });
+
+  it('subsequent poll with no new messages still advances the cursor to the response historyId', async () => {
+    vi.stubGlobal('fetch', makeFetchRouter({
+      '/users/me/history': () => jsonResponse({ historyId: '5500' }),
+    }));
+
+    const cursor = makeMemoryCursor({ 'user-1:gmail:history_id': '5400' });
+    const conn = new GmailConnector('user-1', makeFreshTokenStore(), cursor);
+    await conn.connect();
+    const signals = await conn.poll();
+
+    expect(signals).toHaveLength(0);
+    expect(cursor.snapshot['user-1:gmail:history_id']).toBe('5500');
+  });
+
+  it('history.list 404 (cursor expired) re-bootstraps from a fresh listing', async () => {
+    let historyHits = 0;
+    vi.stubGlobal('fetch', makeFetchRouter({
+      '/users/me/history': () => {
+        historyHits++;
+        return new Response('history too old', { status: 404 });
+      },
+      '/users/me/messages?q=': () => jsonResponse({ messages: [{ id: 'fresh' }] }),
+      '/users/me/messages/fresh': () => jsonResponse({
+        id: 'fresh',
+        threadId: 't-fresh',
+        labelIds: [],
+        snippet: '',
+        payload: { headers: [] },
+        internalDate: '1735689600000',
+        historyId: '9999',
+      }),
+    }));
+
+    const cursor = makeMemoryCursor({ 'user-1:gmail:history_id': '1' });
+    const conn = new GmailConnector('user-1', makeFreshTokenStore(), cursor);
+    await conn.connect();
+    const signals = await conn.poll();
+
+    expect(historyHits).toBe(1);
+    expect(signals).toHaveLength(1);
+    expect(signals[0]!.id).toBe('sig_gmail_fresh');
+    expect(cursor.snapshot['user-1:gmail:history_id']).toBe('9999');
+  });
+
+  it('cursor save errors do not crash the poll', async () => {
+    vi.stubGlobal('fetch', makeFetchRouter({
+      '/users/me/messages?q=': () => jsonResponse({ messages: [] }),
+      '/users/me/profile': () => jsonResponse({ historyId: '500' }),
+    }));
+
+    const failingCursor: CursorStore = {
+      get: async () => null,
+      save: async () => {
+        throw new Error('DB down');
+      },
+    };
+
+    const conn = new GmailConnector('user-1', makeFreshTokenStore(), failingCursor);
+    await conn.connect();
+    await expect(conn.poll()).resolves.toEqual([]);
+  });
+
+  it('without a cursor store, the connector still works (back-compat)', async () => {
+    vi.stubGlobal('fetch', makeFetchRouter({
+      '/users/me/messages?q=': () => jsonResponse({ messages: [] }),
+      '/users/me/profile': () => jsonResponse({ historyId: '7' }),
+    }));
+    const conn = new GmailConnector('user-1', makeFreshTokenStore());
+    await conn.connect();
+    await expect(conn.poll()).resolves.toEqual([]);
   });
 });

--- a/packages/connectors/src/__tests__/gmail-connector.test.ts
+++ b/packages/connectors/src/__tests__/gmail-connector.test.ts
@@ -220,8 +220,13 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 function makeFetchRouter(routes: Record<string, FetchHandler>): typeof fetch {
-  return (async (input: RequestInfo | URL): Promise<Response> => {
-    const url = typeof input === 'string' ? input : input.toString();
+  return (async (input: string | URL | { url: string }): Promise<Response> => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
     for (const [pattern, handler] of Object.entries(routes)) {
       if (url.includes(pattern)) {
         return handler(url);

--- a/packages/connectors/src/gmail-connector.ts
+++ b/packages/connectors/src/gmail-connector.ts
@@ -13,31 +13,59 @@ interface GmailMessage {
     headers: Array<{ name: string; value: string }>;
   };
   internalDate: string;
+  /** Present on full-format message detail responses. */
+  historyId?: string;
 }
 
 /**
- * Gmail connector that polls for new messages via the Gmail API.
- * Implements SignalConnector for the SkyTwin decision pipeline.
+ * Persistent cursor store. Wired to `@skytwin/db.connectorCursorRepository`
+ * by the worker; tests pass an in-memory stub. The connector package itself
+ * stays free of any DB dependency.
+ */
+export interface CursorStore {
+  get(userId: string, provider: string, kind: string): Promise<string | null>;
+  save(userId: string, provider: string, kind: string, value: string): Promise<void>;
+}
+
+const HISTORY_ID_KIND = 'history_id';
+
+/**
+ * Gmail connector backed by the History API.
+ *
+ * On first poll for a user (no stored cursor), we list a recent batch of
+ * unread messages and store the latest historyId we observe. On every
+ * subsequent poll we hit `users/me/history?startHistoryId=<stored>` to get
+ * only the deltas — typically 0 or a handful of message ids per minute,
+ * versus "every still-unread message in the inbox" with the previous
+ * `is:unread` query.
+ *
+ * If the stored historyId is older than ~7 days Gmail returns 404 — we
+ * detect that and re-bootstrap rather than hard-failing.
  */
 export class GmailConnector implements SignalConnector {
   readonly name = 'gmail';
 
   private handlers: SignalHandler[] = [];
   private connected = false;
-  private lastHistoryId: string | null = null;
   private readonly userId: string;
   private readonly tokenStore: OAuthTokenStore;
+  private readonly cursorStore: CursorStore | null;
+  /** In-memory mirror of the persisted cursor for the current session. */
+  private historyId: string | null = null;
 
-  constructor(userId: string, tokenStore: OAuthTokenStore) {
+  constructor(userId: string, tokenStore: OAuthTokenStore, cursorStore: CursorStore | null = null) {
     this.userId = userId;
     this.tokenStore = tokenStore;
+    this.cursorStore = cursorStore;
   }
 
   async connect(): Promise<void> {
-    // Validate that we have a token and it's not expired
     const token = await this.tokenStore.refreshIfExpired(this.userId, 'google');
     if (!token) {
       throw new Error('No Google OAuth token available. User must authorize first.');
+    }
+    if (this.cursorStore) {
+      this.historyId = await this.cursorStore.get(this.userId, 'gmail', HISTORY_ID_KIND);
     }
     this.connected = true;
   }
@@ -45,7 +73,7 @@ export class GmailConnector implements SignalConnector {
   async disconnect(): Promise<void> {
     this.connected = false;
     this.handlers = [];
-    this.lastHistoryId = null;
+    this.historyId = null;
   }
 
   async poll(): Promise<RawSignal[]> {
@@ -53,75 +81,193 @@ export class GmailConnector implements SignalConnector {
       throw new Error('GmailConnector is not connected. Call connect() first.');
     }
 
-    // List recent unread messages
-    const query = this.lastHistoryId
-      ? `is:unread`
-      : `is:unread newer_than:1d`;
+    const accessToken = (await this.tokenStore.refreshIfExpired(this.userId, 'google')).accessToken;
 
-    const listUrl = `${GMAIL_API}/users/me/messages?q=${encodeURIComponent(query)}&maxResults=10`;
-
-    let capturedAccessToken = '';
-    const listResponse = await withRetry(async () => {
-      const currentToken = await this.tokenStore.refreshIfExpired(this.userId, 'google');
-      capturedAccessToken = currentToken.accessToken;
-      const response = await fetch(listUrl, {
-        headers: { Authorization: `Bearer ${capturedAccessToken}` },
-      });
-
-      if (!response.ok) {
-        if (response.status === 401) {
-          // Token expired — refresh will happen on next attempt
-          throw new RetryableHttpError(401, 'Gmail token expired', null);
-        }
-        if ([429, 500, 502, 503].includes(response.status)) {
-          const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'));
-          throw new RetryableHttpError(response.status, `Gmail API list failed: ${response.status}`, retryAfterMs);
-        }
-        throw new Error(`Gmail API list failed: ${response.status}`);
-      }
-
-      return response;
-    }, { maxRetries: 3, baseDelayMs: 1000 });
-
-    // Reuse the same token that produced the successful list response
-    if (!capturedAccessToken) {
-      throw new Error('GmailConnector: no access token captured from successful list request');
+    if (this.historyId === null) {
+      // First poll for this user: bootstrap the cursor from a small batch
+      // of recent unread mail. We surface those messages as signals on
+      // first run so the user sees something immediately, then advance the
+      // cursor to the latest historyId observed.
+      return this.bootstrapAndEmit(accessToken);
     }
-    return this.processListResponse(listResponse, capturedAccessToken);
+
+    return this.pollHistorySince(accessToken, this.historyId);
   }
 
   onSignal(handler: SignalHandler): void {
     this.handlers.push(handler);
   }
 
-  private async processListResponse(
-    response: Response,
-    accessToken: string,
-  ): Promise<RawSignal[]> {
-    const data = await response.json() as {
-      messages?: Array<{ id: string; threadId: string }>;
-      resultSizeEstimate?: number;
-    };
+  // ── First-run bootstrap ───────────────────────────────────────────────
 
-    if (!data.messages || data.messages.length === 0) {
+  /**
+   * No cursor yet — list recent unread, emit them as signals, then store
+   * the highest historyId we observed so the next poll switches to
+   * incremental mode.
+   */
+  private async bootstrapAndEmit(accessToken: string): Promise<RawSignal[]> {
+    const listUrl = `${GMAIL_API}/users/me/messages?q=${encodeURIComponent('is:unread newer_than:1d')}&maxResults=10`;
+    const listResp = await this.gmailGet(listUrl, accessToken, 'list');
+    const listJson = await listResp.json() as { messages?: Array<{ id: string }> };
+    const ids = (listJson.messages ?? []).map((m) => m.id);
+
+    if (ids.length === 0) {
+      // Even with no messages we want a cursor for next poll. Use the
+      // mailbox's current historyId from /users/me/profile.
+      const profile = await this.fetchProfileHistoryId(accessToken);
+      if (profile) await this.persistCursor(profile);
       return [];
     }
 
-    const signals: RawSignal[] = [];
+    const { signals, maxHistoryId } = await this.fetchAndConvert(ids, accessToken);
+    if (maxHistoryId) await this.persistCursor(maxHistoryId);
+    return signals;
+  }
 
-    for (const msg of data.messages) {
-      const detail = await this.fetchMessageDetail(msg.id, accessToken);
+  // ── Incremental polling ───────────────────────────────────────────────
+
+  /**
+   * Get all `messageAdded` deltas since `startHistoryId`. Gmail returns
+   * 404 if the cursor is older than its retention window (~7 days) — in
+   * that case we treat the cursor as lost and re-bootstrap.
+   */
+  private async pollHistorySince(accessToken: string, startHistoryId: string): Promise<RawSignal[]> {
+    const params = new URLSearchParams({
+      startHistoryId,
+      historyTypes: 'messageAdded',
+      maxResults: '100',
+    });
+    const historyUrl = `${GMAIL_API}/users/me/history?${params.toString()}`;
+
+    let resp: Response;
+    try {
+      resp = await this.gmailGet(historyUrl, accessToken, 'history');
+    } catch (err) {
+      // history.list returns 404 when startHistoryId is too old. We don't
+      // throw a retryable error for 404 (it'd just keep failing), so the
+      // gmailGet wrapper passes it through as a regular error message.
+      if (err instanceof Error && err.message.includes('404')) {
+        console.warn(`[gmail] History cursor too old for user ${this.userId} — re-bootstrapping`);
+        this.historyId = null;
+        return this.bootstrapAndEmit(accessToken);
+      }
+      throw err;
+    }
+
+    const body = await resp.json() as {
+      history?: Array<{ messagesAdded?: Array<{ message: { id: string } }> }>;
+      historyId?: string;
+    };
+
+    // Collect new message ids (deduped — a single thread can show up in
+    // multiple history records as labels change).
+    const seen = new Set<string>();
+    const ids: string[] = [];
+    for (const entry of body.history ?? []) {
+      for (const added of entry.messagesAdded ?? []) {
+        if (!seen.has(added.message.id)) {
+          seen.add(added.message.id);
+          ids.push(added.message.id);
+        }
+      }
+    }
+
+    let maxHistoryId = body.historyId ?? startHistoryId;
+    let signals: RawSignal[] = [];
+    if (ids.length > 0) {
+      const result = await this.fetchAndConvert(ids, accessToken);
+      signals = result.signals;
+      // Prefer the larger of (response historyId, max observed message historyId).
+      // Both are strings of monotonically-increasing integers; compare numerically.
+      if (result.maxHistoryId && Number(result.maxHistoryId) > Number(maxHistoryId)) {
+        maxHistoryId = result.maxHistoryId;
+      }
+    }
+
+    if (maxHistoryId !== startHistoryId) {
+      await this.persistCursor(maxHistoryId);
+    }
+    return signals;
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────
+
+  private async fetchAndConvert(
+    ids: string[],
+    accessToken: string,
+  ): Promise<{ signals: RawSignal[]; maxHistoryId: string | null }> {
+    const signals: RawSignal[] = [];
+    let maxHistoryId: string | null = null;
+
+    for (const id of ids) {
+      const detail = await this.fetchMessageDetail(id, accessToken);
       if (!detail) continue;
+
+      if (detail.historyId) {
+        if (!maxHistoryId || Number(detail.historyId) > Number(maxHistoryId)) {
+          maxHistoryId = detail.historyId;
+        }
+      }
 
       const signal = this.messageToSignal(detail);
       signals.push(signal);
-
       for (const handler of this.handlers) {
         handler(signal);
       }
     }
+    return { signals, maxHistoryId };
+  }
 
-    return signals;
+  private async fetchProfileHistoryId(accessToken: string): Promise<string | null> {
+    try {
+      const resp = await this.gmailGet(`${GMAIL_API}/users/me/profile`, accessToken, 'profile');
+      const body = await resp.json() as { historyId?: string };
+      return body.historyId ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async persistCursor(historyId: string): Promise<void> {
+    this.historyId = historyId;
+    if (this.cursorStore) {
+      try {
+        await this.cursorStore.save(this.userId, 'gmail', HISTORY_ID_KIND, historyId);
+      } catch (err) {
+        console.warn(
+          `[gmail] Failed to persist history cursor for ${this.userId}:`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+  }
+
+  /**
+   * Wrap a Gmail GET with token-refresh handling and retry on the usual
+   * transient codes. 404 is *not* retried — the caller decides what 404
+   * means (history.list uses it for "cursor expired").
+   */
+  private async gmailGet(url: string, initialToken: string, label: string): Promise<Response> {
+    let accessToken = initialToken;
+    return withRetry(async () => {
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (response.ok) return response;
+      if (response.status === 401) {
+        accessToken = (await this.tokenStore.refreshIfExpired(this.userId, 'google')).accessToken;
+        throw new RetryableHttpError(401, `Gmail ${label}: token expired`, null);
+      }
+      if ([429, 500, 502, 503].includes(response.status)) {
+        const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'));
+        throw new RetryableHttpError(
+          response.status,
+          `Gmail ${label} failed: ${response.status}`,
+          retryAfterMs,
+        );
+      }
+      throw new Error(`Gmail ${label} failed: ${response.status}`);
+    }, { maxRetries: 3, baseDelayMs: 1000 });
   }
 
   private async fetchMessageDetail(
@@ -129,23 +275,8 @@ export class GmailConnector implements SignalConnector {
     accessToken: string,
   ): Promise<GmailMessage | null> {
     const url = `${GMAIL_API}/users/me/messages/${messageId}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date`;
-
     try {
-      const response = await withRetry(async () => {
-        const resp = await fetch(url, {
-          headers: { Authorization: `Bearer ${accessToken}` },
-        });
-        if (!resp.ok && [429, 500, 502, 503].includes(resp.status)) {
-          const retryAfterMs = parseRetryAfter(resp.headers.get('Retry-After'));
-          throw new RetryableHttpError(resp.status, `Gmail detail failed: ${resp.status}`, retryAfterMs);
-        }
-        return resp;
-      }, { maxRetries: 2, baseDelayMs: 500 });
-
-      if (!response.ok) {
-        console.warn(`[gmail] Failed to fetch message ${messageId}: HTTP ${response.status}`);
-        return null;
-      }
+      const response = await this.gmailGet(url, accessToken, 'detail');
       return response.json() as Promise<GmailMessage>;
     } catch (error) {
       console.warn(

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -17,6 +17,7 @@ export { MockCalendarConnector } from './mock-calendar-connector.js';
 
 // Real connector implementations
 export { GmailConnector } from './gmail-connector.js';
+export type { CursorStore } from './gmail-connector.js';
 export { GoogleCalendarConnector } from './google-calendar-connector.js';
 
 // OAuth

--- a/packages/db/src/__tests__/connector-cursor-repository.test.ts
+++ b/packages/db/src/__tests__/connector-cursor-repository.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockQuery = vi.fn();
+
+vi.mock('../connection.js', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+const { connectorCursorRepository } = await import(
+  '../repositories/connector-cursor-repository.js'
+);
+
+describe('connectorCursorRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('get() returns null when no row exists', async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    const result = await connectorCursorRepository.get('u-1', 'gmail', 'history_id');
+    expect(result).toBeNull();
+  });
+
+  it('get() returns the row keyed on (user_id, provider, cursor_kind)', async () => {
+    const row = {
+      user_id: 'u-1',
+      provider: 'gmail',
+      cursor_kind: 'history_id',
+      cursor_value: '12345',
+      updated_at: new Date('2026-04-28'),
+    };
+    mockQuery.mockResolvedValue({ rows: [row], rowCount: 1 });
+
+    const result = await connectorCursorRepository.get('u-1', 'gmail', 'history_id');
+
+    expect(result).toEqual(row);
+    const [sql, args] = mockQuery.mock.calls[0]!;
+    expect(sql).toContain('WHERE user_id = $1 AND provider = $2 AND cursor_kind = $3');
+    expect(args).toEqual(['u-1', 'gmail', 'history_id']);
+  });
+
+  it('save() upserts on (user_id, provider, cursor_kind)', async () => {
+    const row = {
+      user_id: 'u-1',
+      provider: 'gmail',
+      cursor_kind: 'history_id',
+      cursor_value: '67890',
+      updated_at: new Date('2026-04-28'),
+    };
+    mockQuery.mockResolvedValue({ rows: [row], rowCount: 1 });
+
+    await connectorCursorRepository.save('u-1', 'gmail', 'history_id', '67890');
+
+    const [sql, args] = mockQuery.mock.calls[0]!;
+    expect(sql).toContain('ON CONFLICT (user_id, provider, cursor_kind)');
+    expect(sql).toContain('DO UPDATE SET');
+    expect(args).toEqual(['u-1', 'gmail', 'history_id', '67890']);
+  });
+
+  it('delete() returns true when a row was removed', async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+    const result = await connectorCursorRepository.delete('u-1', 'gmail', 'history_id');
+    expect(result).toBe(true);
+  });
+
+  it('delete() returns false when no row matched', async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    const result = await connectorCursorRepository.delete('u-1', 'gmail', 'history_id');
+    expect(result).toBe(false);
+  });
+
+  it('delete() returns false when rowCount is null', async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: null });
+    const result = await connectorCursorRepository.delete('u-1', 'gmail', 'history_id');
+    expect(result).toBe(false);
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -88,8 +88,9 @@ export type {
 
 export { signalRepository, proposalRepository, skillGapRepository, proactiveScanRepository } from './repositories/index.js';
 
-export { trustTierAuditRepository, spendRepository, domainAutonomyRepository, escalationTriggerRepository, preferenceHistoryRepository, sessionRepository, mempalaceRepository, serviceCredentialRepository, credentialRequirementRepository, aiProviderRepository, ironClawToolRepository, forwardedSignalsRepository } from './repositories/index.js';
+export { trustTierAuditRepository, spendRepository, domainAutonomyRepository, escalationTriggerRepository, preferenceHistoryRepository, sessionRepository, mempalaceRepository, serviceCredentialRepository, credentialRequirementRepository, aiProviderRepository, ironClawToolRepository, forwardedSignalsRepository, connectorCursorRepository } from './repositories/index.js';
 export type { ForwardedSignalRow } from './repositories/index.js';
+export type { ConnectorCursorRow } from './repositories/index.js';
 export type { SessionRow } from './repositories/index.js';
 export type { UpsertServiceCredentialInput } from './repositories/index.js';
 export type { RegisterCredentialRequirementInput } from './repositories/index.js';

--- a/packages/db/src/migrations/024-connector-cursors.sql
+++ b/packages/db/src/migrations/024-connector-cursors.sql
@@ -1,0 +1,30 @@
+-- 024-connector-cursors.sql
+-- Persistent cursors for incremental connector polling.
+--
+-- The Gmail connector still queries `is:unread` every 10s and re-emits
+-- everything matching, dedup-suppressed downstream. That works but is
+-- wasteful: real users will burn the project's Gmail API quota fast,
+-- and the symptom that motivated #102 (re-emit on restart) only stays
+-- silent because of the dedupe ledger added in PR #104.
+--
+-- The right fix is the Gmail History API:
+--   GET users/me/messages → store the latest historyId once
+--   GET users/me/history?startHistoryId=<stored> → only deltas thereafter
+--
+-- That requires the cursor to survive worker restarts. This table holds it.
+-- Calendar's `syncToken` flow needs the same shape, so the column is generic
+-- and named `cursor_value` rather than `history_id`.
+
+CREATE TABLE IF NOT EXISTS connector_cursors (
+  user_id      UUID        NOT NULL,
+  provider     STRING      NOT NULL,        -- 'gmail', 'google_calendar', …
+  cursor_kind  STRING      NOT NULL,        -- 'history_id', 'sync_token', …
+  cursor_value STRING      NOT NULL,
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, provider, cursor_kind)
+);
+
+-- updated_at is bumped by the repository's UPSERT (`updated_at = now()` in
+-- the ON CONFLICT clause). CRDB doesn't run PL/pgSQL triggers the same way
+-- Postgres does, so we keep this column maintenance in app code — same
+-- pattern as oauth_tokens / twin_profiles / mempalace tables.

--- a/packages/db/src/repositories/connector-cursor-repository.ts
+++ b/packages/db/src/repositories/connector-cursor-repository.ts
@@ -1,0 +1,71 @@
+import { query } from '../connection.js';
+
+export interface ConnectorCursorRow {
+  user_id: string;
+  provider: string;
+  cursor_kind: string;
+  cursor_value: string;
+  updated_at: Date;
+}
+
+/**
+ * Per-user, per-provider cursor for incremental polling.
+ *
+ * Gmail uses `cursor_kind = 'history_id'` with the `users.history.list`
+ * endpoint; Calendar will use `cursor_kind = 'sync_token'`. The schema is
+ * deliberately generic so a new connector doesn't need a new table.
+ *
+ * Multi-account note: today we key on `(user_id, provider)`, which works
+ * for the worker's current single-account-per-user model. When the
+ * #101 follow-up wires per-account connectors, this keying will need to
+ * gain `account_email` — same shape as oauth_tokens picked up in #103.
+ */
+export const connectorCursorRepository = {
+  /** Get a cursor; returns null when none has been stored yet. */
+  async get(
+    userId: string,
+    provider: string,
+    cursorKind: string,
+  ): Promise<ConnectorCursorRow | null> {
+    const result = await query<ConnectorCursorRow>(
+      `SELECT user_id, provider, cursor_kind, cursor_value, updated_at
+         FROM connector_cursors
+        WHERE user_id = $1 AND provider = $2 AND cursor_kind = $3`,
+      [userId, provider, cursorKind],
+    );
+    return result.rows[0] ?? null;
+  },
+
+  /** Idempotent upsert — replaces the value for an existing cursor. */
+  async save(
+    userId: string,
+    provider: string,
+    cursorKind: string,
+    cursorValue: string,
+  ): Promise<ConnectorCursorRow> {
+    const result = await query<ConnectorCursorRow>(
+      `INSERT INTO connector_cursors (user_id, provider, cursor_kind, cursor_value)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (user_id, provider, cursor_kind) DO UPDATE SET
+         cursor_value = EXCLUDED.cursor_value,
+         updated_at = now()
+       RETURNING user_id, provider, cursor_kind, cursor_value, updated_at`,
+      [userId, provider, cursorKind, cursorValue],
+    );
+    return result.rows[0]!;
+  },
+
+  /** Drop a cursor (e.g. when the user disconnects the provider). */
+  async delete(
+    userId: string,
+    provider: string,
+    cursorKind: string,
+  ): Promise<boolean> {
+    const result = await query(
+      `DELETE FROM connector_cursors
+        WHERE user_id = $1 AND provider = $2 AND cursor_kind = $3`,
+      [userId, provider, cursorKind],
+    );
+    return (result.rowCount ?? 0) > 0;
+  },
+};

--- a/packages/db/src/repositories/index.ts
+++ b/packages/db/src/repositories/index.ts
@@ -87,3 +87,6 @@ export type { UpsertIronClawToolInput } from './ironclaw-tool-repository.js';
 
 export { forwardedSignalsRepository } from './forwarded-signals-repository.js';
 export type { ForwardedSignalRow } from './forwarded-signals-repository.js';
+
+export { connectorCursorRepository } from './connector-cursor-repository.js';
+export type { ConnectorCursorRow } from './connector-cursor-repository.js';


### PR DESCRIPTION
The big remaining piece of #102. The persistent dedupe ledger from PR #104 made worker restarts safe; this PR fixes the **steady-state** polling. The connector now hits Gmail's delta endpoint (`users.history.list?startHistoryId=…`) instead of re-listing every unread message in the inbox on every poll.

For a single dev user: the worker stops loudly re-emitting hundreds of dedupe-suppressed signals per minute. For real users at scale: the project's Gmail API quota stops being burned on duplicate work.

## Schema (`024-connector-cursors.sql`)
- `connector_cursors(user_id UUID, provider STRING, cursor_kind STRING, cursor_value STRING, updated_at TIMESTAMPTZ)` — PK on `(user_id, provider, cursor_kind)`. Generic so Calendar's `syncToken` flow (follow-up) reuses the same table.

## Repository (`@skytwin/db`)
- `connectorCursorRepository.{ get, save, delete }` — small, idempotent, unit-tested.

## Connector (`@skytwin/connectors`)
- New `CursorStore` interface — kept inside the connectors package so it doesn't take a DB dep. Worker wires it to `connectorCursorRepository`; tests use an in-memory stub.
- `connect()` loads the cursor; constructor accepts an optional store so existing callers/tests keep working without changes.
- **First poll** (no cursor): lists `is:unread newer_than:1d`, emits up to 10 signals, persists the highest `historyId` observed. Empty inbox falls back to `users/me/profile` so the next poll has a starting point.
- **Subsequent polls**: `users/me/history?startHistoryId=<stored>&historyTypes=messageAdded`. Dedupes `messagesAdded` entries, fetches details for new ids only, and advances the cursor to the larger of (response historyId, max message historyId).
- **404 on history.list** (cursor older than ~7 days): re-bootstraps in place rather than hard-failing.
- 401/429/5xx still go through the existing retry+token-refresh wrapper. Cursor save errors are logged and swallowed — the dedupe ledger from #104 is still the correctness backstop.

## Worker
Thin adapter over `connectorCursorRepository`, passed into `new GmailConnector(...)`. No other behaviour change — per-account routing waits on the #101 follow-up.

## Out of scope (follow-ups)
- Calendar `syncToken` cursor — same `connector_cursors` shape, separate connector.
- Per-account cursor keying — depends on #101 connector multi-account routing.

## Test plan
- [x] `packages/db`: 6 new tests for the cursor repo. 146 total pass.
- [x] `packages/connectors`: 7 new History API tests using stubbed `globalThis.fetch` — bootstrap, empty-bootstrap via profile, history delta, no-changes cursor advance, 404 re-bootstrap, save-error containment, no-cursor-store back-compat. 50 connector tests pass.
- [x] `packages/worker`: 15 dedupe tests still pass.
- [x] `pnpm db:migrate` against dev CRDB — applied.
- [x] `pnpm --filter @skytwin/worker exec tsc --noEmit` — clean.
- [ ] Live: bring up worker, watch the log show `Hydrated dedupe ledger`, then on first poll bootstrap; subsequent polls hit `/users/me/history?startHistoryId=…` with growing cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)