### PR TITLE
feat(connectors): persist Calendar syncToken across worker restarts

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -297,7 +297,7 @@ async function discoverUsers(): Promise<UserConnectors[]> {
         if (googleConfig) {
           const tokenStore = new DbTokenStore(oauthRepository, googleConfig);
           connectors.push(new GmailConnector(userId, tokenStore, gmailCursorStore));
-          connectors.push(new GoogleCalendarConnector(userId, tokenStore));
+          connectors.push(new GoogleCalendarConnector(userId, tokenStore, gmailCursorStore));
         }
       }
 

--- a/packages/connectors/src/__tests__/google-calendar-connector.test.ts
+++ b/packages/connectors/src/__tests__/google-calendar-connector.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { GoogleCalendarConnector } from '../google-calendar-connector.js';
+import type { CursorStore } from '../gmail-connector.js';
 import type { OAuthTokenStore } from '../oauth/token-store.js';
 
 function makeStubStore(token: { accessToken: string; refreshToken: string; expiresAt: Date } | null): OAuthTokenStore {
@@ -196,5 +197,154 @@ describe('GoogleCalendarConnector.detectConflicts', () => {
     const conflicts = detect(events);
     // Only a is dateTime; allday is ignored — no overlap detected
     expect(conflicts.size).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Persistent syncToken — survives worker restarts
+// ─────────────────────────────────────────────────────────────────────────
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function memoryCursor(initial: Record<string, string> = {}): CursorStore & { snapshot: Record<string, string> } {
+  const store: Record<string, string> = { ...initial };
+  return {
+    snapshot: store,
+    async get(userId, provider, kind) {
+      return store[`${userId}:${provider}:${kind}`] ?? null;
+    },
+    async save(userId, provider, kind, value) {
+      store[`${userId}:${provider}:${kind}`] = value;
+    },
+  };
+}
+
+describe('GoogleCalendarConnector syncToken persistence', () => {
+  let lastUrl = '';
+  beforeEach(() => {
+    lastUrl = '';
+    vi.unstubAllGlobals();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('on first poll uses timeMin/timeMax (no syncToken) and persists nextSyncToken', async () => {
+    vi.stubGlobal('fetch', (async (input: string | URL | { url: string }): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      lastUrl = url;
+      return jsonResponse({
+        items: [makeEvent({ id: 'evt-init' })],
+        nextSyncToken: 'sync-token-1',
+      });
+    }) as typeof fetch);
+
+    const cursor = memoryCursor();
+    const tokenStore = makeStubStore({
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const conn = new GoogleCalendarConnector('user-1', tokenStore, cursor);
+    await conn.connect();
+    const signals = await conn.poll();
+
+    expect(signals).toHaveLength(1);
+    expect(lastUrl).toContain('timeMin=');
+    expect(lastUrl).toContain('timeMax=');
+    expect(lastUrl).not.toContain('syncToken=');
+    expect(cursor.snapshot['user-1:google_calendar:sync_token']).toBe('sync-token-1');
+  });
+
+  it('subsequent poll loads stored syncToken and sends it on the request', async () => {
+    vi.stubGlobal('fetch', (async (input: string | URL | { url: string }): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      lastUrl = url;
+      return jsonResponse({
+        items: [],
+        nextSyncToken: 'sync-token-2',
+      });
+    }) as typeof fetch);
+
+    const cursor = memoryCursor({ 'user-1:google_calendar:sync_token': 'sync-token-1' });
+    const tokenStore = makeStubStore({
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const conn = new GoogleCalendarConnector('user-1', tokenStore, cursor);
+    await conn.connect();
+    await conn.poll();
+
+    expect(lastUrl).toContain('syncToken=sync-token-1');
+    expect(cursor.snapshot['user-1:google_calendar:sync_token']).toBe('sync-token-2');
+  });
+
+  it('410 (sync token expired) clears the cursor and retries from scratch', async () => {
+    let callCount = 0;
+    vi.stubGlobal('fetch', (async (input: string | URL | { url: string }): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      lastUrl = url;
+      callCount++;
+      // First call (with syncToken): 410. Second call (no token): 200.
+      if (callCount === 1) {
+        return new Response('gone', { status: 410 });
+      }
+      return jsonResponse({ items: [], nextSyncToken: 'fresh-token' });
+    }) as typeof fetch);
+
+    const cursor = memoryCursor({ 'user-1:google_calendar:sync_token': 'expired' });
+    const tokenStore = makeStubStore({
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const conn = new GoogleCalendarConnector('user-1', tokenStore, cursor);
+    await conn.connect();
+    await conn.poll();
+
+    expect(callCount).toBe(2);
+    expect(cursor.snapshot['user-1:google_calendar:sync_token']).toBe('fresh-token');
+  });
+
+  it('back-compat: third arg as a string still sets calendarId, not the cursor', async () => {
+    vi.stubGlobal('fetch', (async (input: string | URL | { url: string }): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      lastUrl = url;
+      return jsonResponse({ items: [] });
+    }) as typeof fetch);
+
+    const tokenStore = makeStubStore({
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const conn = new GoogleCalendarConnector('user-1', tokenStore, 'work@example.com');
+    await conn.connect();
+    await conn.poll();
+
+    expect(lastUrl).toContain('/calendars/work%40example.com/events');
+  });
+
+  it('cursor save errors do not crash the poll', async () => {
+    vi.stubGlobal('fetch', (async () => jsonResponse({ items: [], nextSyncToken: 't' })) as typeof fetch);
+
+    const failing: CursorStore = {
+      get: async () => null,
+      save: async () => { throw new Error('DB down'); },
+    };
+    const tokenStore = makeStubStore({
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const conn = new GoogleCalendarConnector('user-1', tokenStore, failing);
+    await conn.connect();
+    await expect(conn.poll()).resolves.toEqual([]);
   });
 });

--- a/packages/connectors/src/google-calendar-connector.ts
+++ b/packages/connectors/src/google-calendar-connector.ts
@@ -1,6 +1,9 @@
 import type { SignalConnector, RawSignal, SignalHandler } from './connector-interface.js';
 import type { OAuthTokenStore } from './oauth/token-store.js';
+import type { CursorStore } from './gmail-connector.js';
 import { withRetry, RetryableHttpError, parseRetryAfter } from '@skytwin/core';
+
+const SYNC_TOKEN_KIND = 'sync_token';
 
 const CALENDAR_API = 'https://www.googleapis.com/calendar/v3';
 
@@ -34,18 +37,36 @@ export class GoogleCalendarConnector implements SignalConnector {
   private syncToken: string | null = null;
   private readonly userId: string;
   private readonly tokenStore: OAuthTokenStore;
+  private readonly cursorStore: CursorStore | null;
   private readonly calendarId: string;
 
-  constructor(userId: string, tokenStore: OAuthTokenStore, calendarId = 'primary') {
+  constructor(
+    userId: string,
+    tokenStore: OAuthTokenStore,
+    cursorStoreOrCalendarId: CursorStore | string | null = null,
+    calendarId = 'primary',
+  ) {
     this.userId = userId;
     this.tokenStore = tokenStore;
-    this.calendarId = calendarId;
+    // Back-compat: the third arg used to be calendarId. New callers pass a
+    // CursorStore here and `calendarId` as the fourth arg. Distinguish by
+    // shape so existing tests/mocks keep working.
+    if (typeof cursorStoreOrCalendarId === 'string') {
+      this.cursorStore = null;
+      this.calendarId = cursorStoreOrCalendarId;
+    } else {
+      this.cursorStore = cursorStoreOrCalendarId;
+      this.calendarId = calendarId;
+    }
   }
 
   async connect(): Promise<void> {
     const token = await this.tokenStore.refreshIfExpired(this.userId, 'google');
     if (!token) {
       throw new Error('No Google OAuth token available. User must authorize first.');
+    }
+    if (this.cursorStore) {
+      this.syncToken = await this.cursorStore.get(this.userId, 'google_calendar', SYNC_TOKEN_KIND);
     }
     this.connected = true;
   }
@@ -54,6 +75,20 @@ export class GoogleCalendarConnector implements SignalConnector {
     this.connected = false;
     this.handlers = [];
     this.syncToken = null;
+  }
+
+  private async persistSyncToken(token: string): Promise<void> {
+    this.syncToken = token;
+    if (this.cursorStore) {
+      try {
+        await this.cursorStore.save(this.userId, 'google_calendar', SYNC_TOKEN_KIND, token);
+      } catch (err) {
+        console.warn(
+          `[google-calendar] Failed to persist sync token for ${this.userId}:`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
   }
 
   private syncRetryCount = 0;
@@ -126,9 +161,11 @@ export class GoogleCalendarConnector implements SignalConnector {
       nextPageToken?: string;
     };
 
-    // Store sync token for next incremental poll
+    // Store sync token for next incremental poll. Persist via the cursor
+    // store so it survives worker restarts — without this, every restart
+    // would re-fetch the next 7 days of events and emit them all again.
     if (data.nextSyncToken) {
-      this.syncToken = data.nextSyncToken;
+      await this.persistSyncToken(data.nextSyncToken);
     }
 
     const events = data.items ?? [];


### PR DESCRIPTION
Reopened from #117 — original PR auto-closed when its base branch (PR #116) was deleted on merge. Same code, retargeted to main.

Companion to #116 (now merged). The Calendar connector already used Google's `syncToken` flow, but the token lived in process memory — every worker restart fell back to the initial 7-day window and re-emitted every event. Now persisted to the same `connector_cursors` table #116 added.

## What changed
- `GoogleCalendarConnector` takes an optional `CursorStore` as its third constructor arg (same interface from #116). Existing callers passing a `calendarId` string still work — constructor branches on shape and keeps `calendarId` at the fourth position for the cursor case.
- `connect()` loads the syncToken via `cursorStore.get(…)`. After every successful poll, `nextSyncToken` is persisted via `persistSyncToken()`. Save errors logged and swallowed; the in-memory cursor still advances so the current session keeps working.
- The existing **410 → reset → re-poll** path is unchanged.
- **Worker** passes the same `gmailCursorStore` to both connectors. They share the table without collision because `provider` and `cursor_kind` columns disambiguate (`gmail`/`history_id` vs `google_calendar`/`sync_token`).

## Test plan
- [x] 5 new Calendar tests covering initial poll, subsequent poll with stored token, 410 reset, back-compat constructor, save-error containment
- [x] 55 connector tests pass
- [x] `pnpm --filter @skytwin/connectors exec tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)