### PR TITLE
fix(api): forward action parameters into approval payload

### DIFF
--- a/apps/api/src/routes/events.ts
+++ b/apps/api/src/routes/events.ts
@@ -211,7 +211,22 @@ export function createEventsRouter(): Router {
       let approvalRequest = null;
 
       if (outcome.requiresApproval && outcome.selectedAction) {
-        // Create an approval request so the user can review it
+        // Create an approval request so the user can review it. We include
+        // `parameters` here so the dashboard can render *what specifically*
+        // is being proposed (e.g. which Gmail label, which calendar id, the
+        // draft body) — without it the approval card asks the user to
+        // approve a generic "Apply label to the email" with no way to know
+        // what label the twin chose. Sensitive params are filtered:
+        // `accessToken` is only injected at execute time and shouldn't be
+        // round-tripped through the approval payload, and oversized free-
+        // form fields like `rawData` echoed back from the original signal
+        // are dropped to keep the JSONB row small.
+        const {
+          accessToken: _omitToken,
+          rawData: _omitRawData,
+          ...visibleParameters
+        } = (outcome.selectedAction.parameters ?? {}) as Record<string, unknown>;
+
         approvalRequest = await approvalRepository.create({
           userId,
           decisionId: decision.id,
@@ -219,6 +234,7 @@ export function createEventsRouter(): Router {
             actionType: outcome.selectedAction.actionType,
             description: outcome.selectedAction.description,
             domain: outcome.selectedAction.domain,
+            parameters: visibleParameters,
             estimatedCostCents: outcome.selectedAction.estimatedCostCents,
             reversible: outcome.selectedAction.reversible,
             confidence: outcome.selectedAction.confidence,


### PR DESCRIPTION
Found while testing the live app. The approval card today asks users to approve a generic *"Apply label to the email via Gmail API"* with no way to see **which label** the twin chose. The label is computed by `inferLabels()` in `decision-maker.ts` but `apps/api/src/routes/events.ts:212-225` cherry-picks fields when building the approval row and silently drops `parameters`. The dashboard's `label_email` template (`approvals.js:397`) already supports rendering `p.labels` — it just never receives them.

Same gap affects every action type whose specifics live in parameters:
- `label_email` → which label(s)
- `send_reply` / `draft_reply` → the draft body, recipients
- `accept_invite` → which event
- `archive_email` → which message id

## Fix
Include `parameters` on the persisted `candidate_action` JSONB. Two fields are scrubbed:
- **`accessToken`**: only injected for the auto-execute path right before routing; never legitimate to round-trip through an approval row.
- **`rawData`**: the original signal payload echoed back by the candidate generators. Already in `decisions.raw_event`; duplicating it on every approval bloats the JSONB without adding signal.

## Doesn't fix
The deeper product question this surfaces — *"how does the twin know what label **I** would apply?"* — is a separate gap. `inferLabels()` is a hardcoded keyword classifier that falls through to `'inbox'` for anything outside its small whitelist. Filing a follow-up issue.

## Test plan
- [x] `pnpm --filter @skytwin/api test` — 182 passed.
- [x] `pnpm --filter @skytwin/api exec tsc --noEmit` — clean.
- [ ] Live: trigger a Gmail signal in dev, look at the approval card, verify the label name now renders inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)