### PR TITLE
build: multi-stage Dockerfile + entrypoint for the server-side apps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,64 @@
+# Keep the docker build context small. Without this, every Docker build
+# uploads node_modules, dist, .git, etc. — slow and a privacy hole.
+
+# Dependencies (re-installed inside the build stage)
+node_modules/
+**/node_modules/
+
+# Build outputs (re-built inside the build stage)
+dist/
+**/dist/
+.turbo/
+**/.turbo/
+
+# Test coverage
+coverage/
+**/coverage/
+
+# Environment files (NEVER bake into images)
+.env
+.env.*
+!.env.example
+**/.env
+**/.env.*
+**/!.env.example
+
+# Local pids and logs
+.skytwin-pids
+*.log
+**/*.log
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+.github/
+
+# Docs and meta — not needed at runtime
+README.md
+CHANGELOG.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+LICENSE
+SECURITY.md
+TODOS.md
+docs/
+planning/
+
+# Conductor / agent-tool scratch
+.context/
+.claude/
+.conductor/
+
+# Mobile + desktop builds (large, not needed for server image)
+apps/mobile/.expo/
+apps/desktop/dist-electron/
+
+# Docker meta itself
+Dockerfile*
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,136 @@
+# syntax=docker/dockerfile:1.7
+#
+# Multi-stage build for the SkyTwin server-side apps (api / web / worker).
+#
+# Output is a single runtime image; the operator picks which app to run via
+# the APP build arg or by overriding CMD. We ship one image rather than three
+# because the apps share most of their build (turbo's dependency graph) and
+# the per-app dist is small relative to node_modules.
+#
+# Build:
+#   docker build -t skytwin -f Dockerfile .
+#
+# Run a specific app:
+#   docker run -e DATABASE_URL=... -p 3100:3100 skytwin api
+#   docker run -e DATABASE_URL=... -p 3101:3101 skytwin worker
+#   docker run -e DATABASE_URL=... -p 3200:3200 skytwin web
+#
+# Required env at runtime (api):
+#   DATABASE_URL, SESSION_SECRET, NODE_ENV
+# Optional env at runtime:
+#   API_PORT, IRONCLAW_API_URL, IRONCLAW_WEBHOOK_SECRET, OPENCLAW_API_URL,
+#   USE_MOCK_IRONCLAW, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, …
+
+ARG NODE_VERSION=20-alpine
+ARG PNPM_VERSION=9.1.0
+
+# ─── Stage 1: dependencies ──────────────────────────────────────────────────
+# Resolves the workspace and installs every package's deps in one place. Kept
+# separate from the build stage so the layer cache is reused unless the
+# lockfile or any package.json changes.
+FROM node:${NODE_VERSION} AS deps
+ARG PNPM_VERSION
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+# Copy only the manifests so the install layer reuses cache when source
+# changes but deps don't.
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY turbo.json ./
+COPY apps/api/package.json ./apps/api/
+COPY apps/web/package.json ./apps/web/
+COPY apps/worker/package.json ./apps/worker/
+COPY apps/openclaw-bridge/package.json ./apps/openclaw-bridge/
+COPY apps/desktop/package.json ./apps/desktop/
+COPY apps/mobile/package.json ./apps/mobile/
+COPY packages/shared-types/package.json ./packages/shared-types/
+COPY packages/config/package.json ./packages/config/
+COPY packages/core/package.json ./packages/core/
+COPY packages/db/package.json ./packages/db/
+COPY packages/twin-model/package.json ./packages/twin-model/
+COPY packages/decision-engine/package.json ./packages/decision-engine/
+COPY packages/policy-engine/package.json ./packages/policy-engine/
+COPY packages/ironclaw-adapter/package.json ./packages/ironclaw-adapter/
+COPY packages/execution-router/package.json ./packages/execution-router/
+COPY packages/llm-client/package.json ./packages/llm-client/
+COPY packages/explanations/package.json ./packages/explanations/
+COPY packages/connectors/package.json ./packages/connectors/
+COPY packages/mempalace/package.json ./packages/mempalace/
+COPY packages/evals/package.json ./packages/evals/
+
+# Install everything (devDeps included; needed for tsc and turbo at build time).
+# `--frozen-lockfile` to fail loud on lockfile drift.
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
+
+# ─── Stage 2: build ─────────────────────────────────────────────────────────
+# Runs `pnpm build` (turbo run build) which compiles every package's TS to
+# dist/. The runtime stage copies just those dist/ outputs, skipping src/.
+FROM deps AS build
+WORKDIR /app
+
+# Copy the rest of the source. apps/desktop and apps/mobile aren't needed
+# for a server image but copying them is cheap and avoids per-app exclusions.
+COPY . .
+
+# Turbo respects the dependency graph (shared-types → config → core → db → …),
+# so this single command builds everything in topological order.
+RUN pnpm build
+
+# `tsc` emits only `.js`/`.d.ts`; the migration runner in
+# packages/db/src/migrations/001-initial.ts reads `*.sql` files relative to
+# its own location, so we colocate them next to the compiled JS in dist/.
+RUN mkdir -p packages/db/dist/migrations packages/db/dist/schemas \
+ && cp packages/db/src/migrations/*.sql packages/db/dist/migrations/ \
+ && cp packages/db/src/schemas/*.sql packages/db/dist/schemas/
+
+# Drop devDependencies for the runtime image. `--prod` rewrites node_modules
+# to only the runtime-needed packages.
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --prod --ignore-scripts
+
+# ─── Stage 3: runtime ──────────────────────────────────────────────────────
+# Minimal image. Only the dist/ output, the pruned node_modules, and the
+# entry-point picker script. No source, no toolchain.
+FROM node:${NODE_VERSION} AS runtime
+WORKDIR /app
+
+# Tini is a tiny init that reaps zombie children and forwards signals — Node
+# alone doesn't handle SIGTERM cleanly under PID 1.
+RUN apk add --no-cache tini
+
+ENV NODE_ENV=production
+
+# Workspace metadata + pruned deps.
+COPY --from=build /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml /app/turbo.json ./
+COPY --from=build /app/node_modules ./node_modules
+
+# Per-app dist outputs and their package.json (for "main" / "type" resolution).
+COPY --from=build /app/apps/api/dist ./apps/api/dist
+COPY --from=build /app/apps/api/package.json ./apps/api/
+COPY --from=build /app/apps/web/dist ./apps/web/dist
+COPY --from=build /app/apps/web/public ./apps/web/public
+COPY --from=build /app/apps/web/package.json ./apps/web/
+COPY --from=build /app/apps/worker/dist ./apps/worker/dist
+COPY --from=build /app/apps/worker/package.json ./apps/worker/
+COPY --from=build /app/apps/openclaw-bridge ./apps/openclaw-bridge
+
+# Workspace package dist outputs that the apps require at runtime.
+COPY --from=build /app/packages ./packages
+
+# Entry-point picker. The image accepts the app name as the first arg and
+# execs the matching node entry. Operator can also bypass via `--entrypoint`.
+COPY --from=build /app/bin/docker-entrypoint.sh /usr/local/bin/skytwin-entrypoint
+RUN chmod +x /usr/local/bin/skytwin-entrypoint
+
+# Drop privileges. node:alpine ships a `node` user (uid 1000).
+USER node
+
+# /api/health/live is the liveness probe; readiness is /api/health/ready.
+# Both come from apps/api/src/index.ts. Ports default to the API; override
+# with EXPOSE/PORT for worker/web.
+EXPOSE 3100
+
+ENTRYPOINT ["/sbin/tini", "--", "skytwin-entrypoint"]
+CMD ["api"]

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# skytwin docker entrypoint — picks which app to run.
+#
+# The image bundles api, worker, and web to keep build/cache simple and
+# images small relative to triple-build. CMD selects the entry point.
+#
+# Usage:
+#   docker run skytwin                  # defaults to api
+#   docker run skytwin api
+#   docker run skytwin worker
+#   docker run skytwin web
+#   docker run skytwin migrate          # run db migrations and exit
+#   docker run skytwin sh               # drop into a shell for debugging
+
+set -e
+
+APP="${1:-api}"
+
+case "$APP" in
+  api)
+    exec node apps/api/dist/index.js
+    ;;
+  worker)
+    exec node apps/worker/dist/index.js
+    ;;
+  web)
+    exec node apps/web/dist/index.js
+    ;;
+  openclaw-bridge|openclaw)
+    # Plain JS, no transpile step. Bridge to a local Ollama instance.
+    exec node apps/openclaw-bridge/server.mjs
+    ;;
+  migrate)
+    # Run database migrations and exit. Run this once per deploy before
+    # rolling out a new api/worker that depends on a schema change. Reads
+    # `*.sql` files from packages/db/dist/migrations and applies them in
+    # name order (the Dockerfile copies them there alongside the compiled
+    # JS).
+    exec node packages/db/dist/migrations/001-initial.js
+    ;;
+  sh|shell)
+    exec /bin/sh
+    ;;
+  *)
+    echo "skytwin: unknown app '$APP'" >&2
+    echo "usage: skytwin [api|worker|web|openclaw-bridge|migrate|sh]" >&2
+    exit 64
+    ;;
+esac


### PR DESCRIPTION
Pre-launch needs a deployable artifact. Picking a host (Fly.io vs Render vs Cloud Run vs …) is a two-way-door operator decision, but the platform-agnostic substrate isn't — most modern hosts accept a Dockerfile, and shipping one means the launch question collapses to *"which host"* instead of *"how do we even package this."*

## Layout

| Stage | What |
|---|---|
| **deps** | Copies only manifests + the lockfile, runs `pnpm install --frozen-lockfile` with a BuildKit cache mount on `/root/.local/share/pnpm/store`. Cached layer reuses across source churn; invalidates only on lockfile/package.json changes. |
| **build** | Copies the rest of the source, runs `pnpm build` (turbo respects the dependency graph). Drops devDependencies via `pnpm install --prod`. Also colocates `packages/db/src/migrations/*.sql` + `schemas/*.sql` into `dist/` — `tsc` doesn't copy non-`.ts` files, and the migration runner reads them via `__dirname`-relative paths. |
| **runtime** | `node:20-alpine`, just `dist/` + pruned `node_modules` + `tini` for proper PID-1 signal forwarding. Drops privileges to the pre-existing `node` user. No toolchain. |

## One image, multiple apps
api / worker / web / openclaw-bridge are bundled together because they share most of the workspace dependency tree; building three images would mostly duplicate `node_modules`. CMD picks the entry point:

```bash
docker run skytwin api               # default
docker run skytwin worker
docker run skytwin web
docker run skytwin migrate           # one-shot, run before deploying schema-dependent code
docker run skytwin openclaw-bridge
```

`bin/docker-entrypoint.sh` handles unknown args with a usage message and exit 64 (`EX_USAGE`).

## `.dockerignore`
Keeps the build context small and prevents secrets / dev state from ever entering an image: `node_modules`, `dist`, `.turbo`, `.env*`, `.git`, `.context`, `mobile/.expo`, `desktop/dist-electron`, `coverage`, `planning/`, and the `Dockerfile` itself.

## What this PR doesn't do (operator's call)

- **Pick a host.** No `fly.toml`, `render.yaml`, or `vercel.json`. Once the host is chosen, those configs reference this Dockerfile.
- **Provision the database.** `DATABASE_URL` must point at a CockroachDB-compatible (or `pgvector`-compatible if mempalace embeddings are enabled) cluster. Hosted CRDB on CockroachCloud, Postgres on Fly/Render/Neon — all work; pick later.
- **Configure secrets.** `SESSION_SECRET` must be set (the api enforces this on startup as of #113). Plus `IRONCLAW_WEBHOOK_SECRET`, `GOOGLE_CLIENT_ID`/`SECRET`, etc.

## Test plan
- [ ] `docker build -t skytwin .` end-to-end. Couldn't verify locally — Docker daemon wasn't accepting builds during authoring. **Reviewer should run this.**
- [ ] `docker run --rm -e DATABASE_URL=… skytwin migrate` against a fresh CRDB applies every migration.
- [ ] `docker run --rm -e DATABASE_URL=… -e SESSION_SECRET=$(openssl rand -hex 32) -p 3100:3100 skytwin api` serves `/api/health/live`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)