### PR TITLE
docs: sync safety-model.md trust tier criteria with engine

### DIFF
--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -149,29 +149,31 @@ Trust is earned, not assumed. Progression is domain-specific: high trust in emai
 - Purpose: Build initial twin model from observation and explicit preferences
 - Duration: Until user explicitly promotes or provides sufficient feedback
 
+Promotion criteria below match `PROMOTION_THRESHOLDS` in `@skytwin/shared-types` (`packages/shared-types/src/policy.ts`). The engine gates on `consecutiveApprovals` (resets on any rejection) AND `minApprovalRatio` (cumulative). Both must clear.
+
 **SUGGEST**
 - System generates candidate actions and presents them to the user
 - All actions require explicit approval
 - Purpose: Let the user see the system's judgment and correct it
-- Promotion criteria: Consistent approval rate > 80% over 20+ suggestions in a domain
+- Promotion criteria: 10 consecutive approvals AND ≥80% cumulative approval ratio
 
 **LOW_AUTONOMY**
 - System can auto-execute low-risk, reversible actions in allowed domains
 - Moderate-risk and irreversible actions still require approval
 - Purpose: Handle routine, low-stakes operations autonomously
-- Promotion criteria: < 5% correction rate over 50+ auto-executed actions in a domain
+- Promotion criteria: 20 consecutive approvals AND ≥85% cumulative approval ratio
 
 **MODERATE_AUTONOMY**
 - System can auto-execute moderate-risk actions in allowed domains
 - High-risk and irreversible actions still require approval (unless explicitly allowed)
 - Purpose: Handle most operational decisions with occasional escalation
-- Promotion criteria: < 3% correction rate over 100+ auto-executed actions, including moderate-risk
+- Promotion criteria: 50 consecutive approvals AND ≥90% cumulative approval ratio
 
 **HIGH_AUTONOMY**
 - System can auto-execute most actions except critical-risk
 - Irreversible actions may auto-execute if explicitly allowed by domain policy
 - Purpose: Near-full operational delegation in trusted domains
-- Promotion criteria: Sustained < 2% correction rate over 200+ actions, no safety-relevant errors
+- Promotion criteria: **Explicit user opt-in only.** There is no automatic promotion from MODERATE_AUTONOMY to HIGH_AUTONOMY — the user has to flip the switch in Settings. The engine deliberately omits this entry from `PROMOTION_THRESHOLDS` so high-stakes autonomy is always a conscious choice.
 
 ### Trust Demotion
 


### PR DESCRIPTION
## Summary

Caught during a deep documentation audit pass. \`docs/safety-model.md\` "Trust Tier Progression" section described promotion thresholds and percentages that didn't match the engine's actual gates, and described an automatic MODERATE_AUTONOMY → HIGH_AUTONOMY promotion that the engine has never implemented.

## What was wrong

| Tier | Doc said | Engine actually does |
|---|---|---|
| OBSERVER → SUGGEST | ">80% over 20+ suggestions" | 10 consecutive approvals AND ≥80% ratio |
| SUGGEST → LOW_AUTONOMY | "<5% correction over 50+" | 20 consecutive AND ≥85% ratio |
| LOW_AUTONOMY → MODERATE_AUTONOMY | "<3% over 100+" | 50 consecutive AND ≥90% ratio |
| MODERATE_AUTONOMY → HIGH_AUTONOMY | "Sustained <2% over 200+" | **No automatic promotion. Explicit user opt-in only.** |

The doc-vs-engine drift on the HIGH_AUTONOMY row is the load-bearing one — it described an automatic step that doesn't exist, which is exactly the kind of thing v0.5.1.0 fixed in the dashboard ("you've unlocked Full autopilot" toast that the engine never honored). Closing the loop: make the safety doc match the engine reality.

## What changed

- Each tier's "Promotion criteria" now matches \`PROMOTION_THRESHOLDS\` in \`@skytwin/shared-types\` (\`packages/shared-types/src/policy.ts\`), the source of truth shared by the policy engine and the \`/api/twin/:userId/progress\` route.
- Added a short header pointing readers at that source-of-truth file.
- HIGH_AUTONOMY's promotion line now says "Explicit user opt-in only" — the engine deliberately omits the entry from \`PROMOTION_THRESHOLDS\` so high-stakes autonomy stays a conscious choice.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)