### PR TITLE
docs: bump README version badge → 0.6.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <a href="https://github.com/jayzalowitz/skytwin/actions/workflows/build.yml"><img src="https://github.com/jayzalowitz/skytwin/actions/workflows/build.yml/badge.svg" alt="Build"></a>
 <a href="https://github.com/jayzalowitz/skytwin/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
-<img src="https://img.shields.io/badge/version-0.5.4.0-green.svg" alt="Version">
+<img src="https://img.shields.io/badge/version-0.6.17.0-green.svg" alt="Version">
 <img src="https://img.shields.io/badge/tests-1436%20passing-brightgreen.svg" alt="Tests">
 <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux%20%7C%20iOS%20%7C%20Android-lightgrey.svg" alt="Platform">
 


### PR DESCRIPTION
## Summary

The README version badge said `0.5.4.0` — twelve releases stale. Bump to current (`0.6.17.0` after the recent toast component, assistant chat polish, electron-store v11, and audit page bug fixes).

Doc-only; no behavior change, no `VERSION` bump.

## Test plan
- [x] Markdown renders correctly (badge URL only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)