### PR TITLE
feat(#190): self-portrait + risk profile + always-visible Pause-everything

### DIFF
--- a/apps/api/src/__tests__/about-me-routes.test.ts
+++ b/apps/api/src/__tests__/about-me-routes.test.ts
@@ -1,0 +1,204 @@
+/**
+ * @file about-me-routes.test.ts
+ * Tests for GET /api/about-me and POST /api/about-me/correct (#190).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import type { Express } from 'express';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { mockQuery } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+}));
+
+vi.mock('@skytwin/db', () => ({
+  query: mockQuery,
+}));
+
+vi.mock('@skytwin/core', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { createAboutMeRouter } from '../routes/about-me.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-000000000001';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildApp(userId = USER_ID): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { user: { id: string } }).user = { id: userId };
+    next();
+  });
+  app.use('/api/about-me', createAboutMeRouter());
+  app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(500).json({ error: err.message });
+  });
+  return app;
+}
+
+function buildAppNoUser(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/about-me', createAboutMeRouter());
+  app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(500).json({ error: err.message });
+  });
+  return app;
+}
+
+async function request(
+  app: Express,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close();
+        reject(new Error('Could not determine port'));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      const options: RequestInit = { method, headers };
+      if (body !== undefined) options.body = JSON.stringify(body);
+      fetch(url, options)
+        .then(async (res) => {
+          const json = await res.json().catch(() => null);
+          server.close();
+          resolve({ status: res.status, body: json });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('About Me API routes (#190)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+  });
+
+  // =========================================================================
+  // GET /api/about-me
+  // =========================================================================
+  describe('GET /api/about-me', () => {
+    it('returns stub self-portrait with paragraphs array (TODO #185)', async () => {
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'GET', '/api/about-me');
+
+      expect(res.status).toBe(200);
+      const body = res.body as {
+        paragraphs: Array<{ text: string; citations: unknown[] }>;
+        generatedAt: string;
+        modelVersion: string;
+      };
+      expect(Array.isArray(body.paragraphs)).toBe(true);
+      expect(body.paragraphs.length).toBeGreaterThan(0);
+      // Each paragraph has text and citations
+      for (const p of body.paragraphs) {
+        expect(typeof p.text).toBe('string');
+        expect(Array.isArray(p.citations)).toBe(true);
+      }
+      expect(typeof body.generatedAt).toBe('string');
+      expect(body.modelVersion).toBe('stub-v0');
+    });
+
+    it('returns 400 when no userId can be resolved', async () => {
+      const app = buildAppNoUser();
+      const res = await request(app, 'GET', '/api/about-me');
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // =========================================================================
+  // POST /api/about-me/correct
+  // =========================================================================
+  describe('POST /api/about-me/correct', () => {
+    it('records a correction and returns success', async () => {
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'POST', '/api/about-me/correct', {
+        paragraphIndex: 0,
+        sentenceIndex: 1,
+        correction: 'I prefer more conservative actions.',
+      });
+
+      expect(res.status).toBe(200);
+      const body = res.body as { success: boolean };
+      expect(body.success).toBe(true);
+    });
+
+    it('writes a provenance feedback node on every correction (hard rail)', async () => {
+      const app = buildApp(USER_ID);
+      await request(app, 'POST', '/api/about-me/correct', {
+        paragraphIndex: 0,
+        sentenceIndex: 0,
+        correction: 'This is wrong.',
+      });
+
+      expect(mockQuery).toHaveBeenCalled();
+      const callArgs = mockQuery.mock.calls;
+      const provenanceInsert = callArgs.find(
+        (args: unknown[]) =>
+          typeof args[0] === 'string' &&
+          (args[0] as string).includes('capability_provenance_nodes'),
+      );
+      expect(provenanceInsert).toBeDefined();
+    });
+
+    it('returns 400 when paragraphIndex is missing', async () => {
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'POST', '/api/about-me/correct', {
+        sentenceIndex: 0,
+        correction: 'Fix this.',
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when correction is empty string', async () => {
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'POST', '/api/about-me/correct', {
+        paragraphIndex: 0,
+        sentenceIndex: 0,
+        correction: '   ',
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when no userId can be resolved', async () => {
+      const app = buildAppNoUser();
+      const res = await request(app, 'POST', '/api/about-me/correct', {
+        paragraphIndex: 0,
+        sentenceIndex: 0,
+        correction: 'Fix this.',
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/api/src/__tests__/risk-profile-routes.test.ts
+++ b/apps/api/src/__tests__/risk-profile-routes.test.ts
@@ -1,0 +1,282 @@
+/**
+ * @file risk-profile-routes.test.ts
+ * Tests for GET/PUT /api/risk-profile and POST /api/risk-profile/reinterpret (#190).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import type { Express } from 'express';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { mockRiskProfileRepository } = vi.hoisted(() => ({
+  mockRiskProfileRepository: {
+    getForUser: vi.fn(),
+    upsert: vi.fn(),
+    updateInterpretedCaps: vi.fn(),
+  },
+}));
+
+vi.mock('@skytwin/db', () => ({
+  riskProfileRepository: mockRiskProfileRepository,
+}));
+
+vi.mock('@skytwin/core', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { createRiskProfileRouter } from '../routes/risk-profile.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-000000000001';
+const OTHER_USER_ID = 'ffffffff-eeee-dddd-cccc-000000000099';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildApp(userId = USER_ID): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { user: { id: string } }).user = { id: userId };
+    next();
+  });
+  app.use('/api/risk-profile', createRiskProfileRouter());
+  app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(500).json({ error: err.message });
+  });
+  return app;
+}
+
+function buildAppNoUser(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/risk-profile', createRiskProfileRouter());
+  app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(500).json({ error: err.message });
+  });
+  return app;
+}
+
+async function request(
+  app: Express,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close();
+        reject(new Error('Could not determine port'));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      const options: RequestInit = { method, headers };
+      if (body !== undefined) options.body = JSON.stringify(body);
+      fetch(url, options)
+        .then(async (res) => {
+          const json = await res.json().catch(() => null);
+          server.close();
+          resolve({ status: res.status, body: json });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+function makeRow(overrides: Partial<{
+  user_id: string;
+  profile_text: string;
+  interpreted_caps: Record<string, unknown>;
+  last_interpreted_at: Date | null;
+  last_model_version: string | null;
+}> = {}) {
+  return {
+    user_id: overrides.user_id ?? USER_ID,
+    profile_text: overrides.profile_text ?? 'I want low risk.',
+    interpreted_caps: overrides.interpreted_caps ?? {},
+    last_interpreted_at: overrides.last_interpreted_at ?? null,
+    last_model_version: overrides.last_model_version ?? null,
+    created_at: new Date('2026-01-01'),
+    updated_at: new Date('2026-01-02'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Risk Profile API routes (#190)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // =========================================================================
+  // GET /api/risk-profile
+  // =========================================================================
+  describe('GET /api/risk-profile', () => {
+    it('returns defaults when no row exists for the user', async () => {
+      mockRiskProfileRepository.getForUser.mockResolvedValue(null);
+
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'GET', '/api/risk-profile');
+
+      expect(res.status).toBe(200);
+      const body = res.body as {
+        profileText: string;
+        interpretedCaps: Record<string, unknown>;
+        lastInterpretedAt: null;
+        lastModelVersion: null;
+      };
+      expect(body.profileText).toBe('');
+      expect(body.interpretedCaps).toEqual({});
+      expect(body.lastInterpretedAt).toBeNull();
+      expect(body.lastModelVersion).toBeNull();
+    });
+
+    it('returns stored profile when row exists', async () => {
+      const row = makeRow({
+        profile_text: 'Keep spend under $10 per action.',
+        last_model_version: 'stub-v0',
+        last_interpreted_at: new Date('2026-04-01'),
+      });
+      mockRiskProfileRepository.getForUser.mockResolvedValue(row);
+
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'GET', '/api/risk-profile');
+
+      expect(res.status).toBe(200);
+      const body = res.body as {
+        profileText: string;
+        interpretedCaps: Record<string, unknown>;
+        lastInterpretedAt: string;
+        lastModelVersion: string;
+      };
+      expect(body.profileText).toBe('Keep spend under $10 per action.');
+      expect(body.lastModelVersion).toBe('stub-v0');
+      expect(typeof body.lastInterpretedAt).toBe('string');
+    });
+
+    it('returns 400 when no userId can be resolved', async () => {
+      const app = buildAppNoUser();
+      const res = await request(app, 'GET', '/api/risk-profile');
+      expect(res.status).toBe(400);
+    });
+
+    it('only fetches profile for the requesting user (ownership)', async () => {
+      mockRiskProfileRepository.getForUser.mockResolvedValue(null);
+
+      const app = buildApp(USER_ID);
+      await request(app, 'GET', '/api/risk-profile');
+
+      expect(mockRiskProfileRepository.getForUser).toHaveBeenCalledWith(USER_ID);
+      expect(mockRiskProfileRepository.getForUser).not.toHaveBeenCalledWith(OTHER_USER_ID);
+    });
+  });
+
+  // =========================================================================
+  // PUT /api/risk-profile
+  // =========================================================================
+  describe('PUT /api/risk-profile', () => {
+    it('upserts profile text and returns updated row', async () => {
+      const row = makeRow({ profile_text: 'Be cautious.', last_model_version: 'stub-v0' });
+      mockRiskProfileRepository.upsert.mockResolvedValue(row);
+      mockRiskProfileRepository.updateInterpretedCaps.mockResolvedValue({
+        ...row,
+        last_interpreted_at: new Date(),
+        last_model_version: 'stub-v0',
+      });
+
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'PUT', '/api/risk-profile', { profileText: 'Be cautious.' });
+
+      expect(res.status).toBe(200);
+      const body = res.body as {
+        profileText: string;
+        interpretedCaps: Record<string, unknown>;
+        lastModelVersion: string;
+      };
+      expect(body.profileText).toBe('Be cautious.');
+      expect(body.lastModelVersion).toBe('stub-v0');
+      expect(mockRiskProfileRepository.upsert).toHaveBeenCalledWith({
+        userId: USER_ID,
+        profileText: 'Be cautious.',
+      });
+    });
+
+    it('stub interpretation stores empty interpretedCaps (TODO #185)', async () => {
+      const row = makeRow({ profile_text: 'Low risk please.' });
+      mockRiskProfileRepository.upsert.mockResolvedValue(row);
+      mockRiskProfileRepository.updateInterpretedCaps.mockResolvedValue({
+        ...row,
+        last_model_version: 'stub-v0',
+        last_interpreted_at: new Date(),
+      });
+
+      const app = buildApp(USER_ID);
+      await request(app, 'PUT', '/api/risk-profile', { profileText: 'Low risk please.' });
+
+      expect(mockRiskProfileRepository.updateInterpretedCaps).toHaveBeenCalledWith({
+        userId: USER_ID,
+        interpretedCaps: {},
+        modelVersion: 'stub-v0',
+      });
+    });
+
+    it('returns 400 when profileText is missing', async () => {
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'PUT', '/api/risk-profile', {});
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when profileText is not a string', async () => {
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'PUT', '/api/risk-profile', { profileText: 42 });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when no userId can be resolved', async () => {
+      const app = buildAppNoUser();
+      const res = await request(app, 'PUT', '/api/risk-profile', { profileText: 'hello' });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // =========================================================================
+  // POST /api/risk-profile/reinterpret
+  // =========================================================================
+  describe('POST /api/risk-profile/reinterpret', () => {
+    it('returns stubbed status (TODO #185)', async () => {
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'POST', '/api/risk-profile/reinterpret');
+
+      expect(res.status).toBe(200);
+      const body = res.body as { status: string; message: string };
+      expect(body.status).toBe('stubbed');
+      expect(typeof body.message).toBe('string');
+      expect(body.message).toContain('#185');
+    });
+
+    it('returns 400 when no userId can be resolved', async () => {
+      const app = buildAppNoUser();
+      const res = await request(app, 'POST', '/api/risk-profile/reinterpret');
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -28,6 +28,8 @@ import { createCredentialsRouter } from './routes/credentials.js';
 import { createRoutinesRouter } from './routes/routines.js';
 import { createDemoRouter } from './routes/demo.js';
 import { createCapabilitiesRouter } from './routes/capabilities.js';
+import { createRiskProfileRouter } from './routes/risk-profile.js';
+import { createAboutMeRouter } from './routes/about-me.js';
 import { getExecutionRouter } from './execution-setup.js';
 import { startMdnsAdvertisement, stopMdnsAdvertisement } from './mdns.js';
 import { closePool } from '@skytwin/db';
@@ -201,6 +203,8 @@ app.use('/api/credentials', sessionAuth, requireOwnership, createCredentialsRout
 app.use('/api/routines', sessionAuth, requireOwnership, createRoutinesRouter());
 app.use('/api/v1/demo', createDemoRouter()); // public — onboarding tour discovery
 app.use('/api/capabilities', sessionAuth, requireOwnership, createCapabilitiesRouter());
+app.use('/api/risk-profile', sessionAuth, requireOwnership, createRiskProfileRouter());
+app.use('/api/about-me', sessionAuth, requireOwnership, createAboutMeRouter());
 
 // Error handling middleware
 app.use(

--- a/apps/api/src/routes/about-me.ts
+++ b/apps/api/src/routes/about-me.ts
@@ -1,0 +1,130 @@
+import { Router } from 'express';
+import { query } from '@skytwin/db';
+import { createLogger } from '@skytwin/core';
+
+const log = createLogger('api:about-me');
+
+/**
+ * Routes for the self-portrait feature (#190).
+ *
+ * The self-portrait is an LLM-generated narrative of what the twin has learned
+ * about the user, with inline citations to the signals that contributed.
+ * LLM integration is stubbed with TODO(#185) until @skytwin/policy-prompts
+ * reaches this stack.
+ *
+ * Endpoints (all under /api/about-me):
+ *   GET  /         — return the self-portrait (stub)
+ *   POST /correct  — submit a correction for a paragraph/sentence
+ */
+export function createAboutMeRouter(): Router {
+  const router = Router();
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GET /
+  // Returns the self-portrait paragraphs with citation metadata.
+  // v1: stubbed — returns a single placeholder paragraph.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.get('/', async (req, res, next) => {
+    try {
+      const userId: string | undefined =
+        (req as unknown as { user?: { id?: string } }).user?.id ??
+        (req.query['userId'] as string | undefined);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      // TODO(#185): replace with runPrompt('self-portrait', { user_facts: aggregatedFacts })
+      // from @skytwin/policy-prompts, where aggregatedFacts are derived from
+      // mempalace knowledge triples + recent decision history for this user.
+      // The stub returns a single paragraph directing the user to connect capabilities.
+      res.json({
+        paragraphs: [
+          {
+            text: 'Your twin is still gathering signals to build a portrait. Connect Gmail or another capability to begin.',
+            citations: [],
+          },
+        ],
+        generatedAt: new Date().toISOString(),
+        modelVersion: 'stub-v0',
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // POST /correct
+  // Body: { paragraphIndex: number, sentenceIndex: number, correction: string }
+  // Records a user correction as a provenance feedback node.
+  // Hard rail: every correction writes a provenance node before returning.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.post('/correct', async (req, res, next) => {
+    try {
+      const userId: string | undefined =
+        (req as unknown as { user?: { id?: string } }).user?.id ??
+        (req.query['userId'] as string | undefined);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const body = req.body as {
+        paragraphIndex?: unknown;
+        sentenceIndex?: unknown;
+        correction?: unknown;
+      };
+
+      if (typeof body?.paragraphIndex !== 'number') {
+        res.status(400).json({ error: 'paragraphIndex must be a number' });
+        return;
+      }
+      if (typeof body?.sentenceIndex !== 'number') {
+        res.status(400).json({ error: 'sentenceIndex must be a number' });
+        return;
+      }
+      if (typeof body?.correction !== 'string' || !body.correction.trim()) {
+        res.status(400).json({ error: 'correction must be a non-empty string' });
+        return;
+      }
+
+      const { paragraphIndex, sentenceIndex, correction } = body as {
+        paragraphIndex: number;
+        sentenceIndex: number;
+        correction: string;
+      };
+
+      // Hard rail: write a provenance feedback node for every correction.
+      // This ensures no self-portrait mutation happens without an audit trail.
+      // The ref_id is the user_id (the portrait is user-scoped, not record-scoped).
+      await query(
+        `INSERT INTO capability_provenance_nodes
+           (user_id, node_type, ref_table, ref_id, server_id, occurred_at, payload)
+         VALUES ($1, 'feedback', 'users', $2, NULL, now(), $3)`,
+        [
+          userId,
+          userId,
+          JSON.stringify({
+            source: 'self_portrait_correction',
+            paragraphIndex,
+            sentenceIndex,
+            correction,
+          }),
+        ],
+      );
+
+      log.info('Self-portrait correction recorded', {
+        userId,
+        paragraphIndex,
+        sentenceIndex,
+        correctionLength: correction.length,
+      });
+
+      res.json({ success: true });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/apps/api/src/routes/capabilities.ts
+++ b/apps/api/src/routes/capabilities.ts
@@ -799,5 +799,66 @@ export function createCapabilitiesRouter(): Router {
     }
   });
 
+  // ─────────────────────────────────────────────────────────────────────────
+  // POST /pause-all
+  // Pauses all active/installed/authorized capability servers for the
+  // requesting user. Writes a provenance node per server (#190 hard rail).
+  // Returns { pausedCount: number }.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.post('/pause-all', async (req, res, next) => {
+    try {
+      const userId: string | undefined = (req as unknown as { user?: { id?: string } }).user?.id
+        ?? (req.query['userId'] as string | undefined);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const pausedServers = await mcpServerRepository.markAllPausedForUser(userId);
+
+      // Hard rail: write a provenance feedback node for every server paused.
+      await Promise.allSettled(
+        pausedServers.map((server) =>
+          writeProvenanceNode({
+            userId,
+            nodeType: 'feedback',
+            refTable: 'mcp_servers',
+            refId: server.id,
+            serverId: server.id,
+            payload: { reason: 'global_pause' },
+          }),
+        ),
+      );
+
+      log.info('Paused all capability servers', { userId, count: pausedServers.length });
+      res.json({ pausedCount: pausedServers.length });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // POST /resume-all
+  // Resumes all paused capability servers for the requesting user.
+  // Returns { resumedCount: number }.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.post('/resume-all', async (req, res, next) => {
+    try {
+      const userId: string | undefined = (req as unknown as { user?: { id?: string } }).user?.id
+        ?? (req.query['userId'] as string | undefined);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const resumedServers = await mcpServerRepository.markAllResumedForUser(userId);
+
+      log.info('Resumed all capability servers', { userId, count: resumedServers.length });
+      res.json({ resumedCount: resumedServers.length });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   return router;
 }

--- a/apps/api/src/routes/risk-profile.ts
+++ b/apps/api/src/routes/risk-profile.ts
@@ -1,0 +1,148 @@
+import { Router } from 'express';
+import { riskProfileRepository } from '@skytwin/db';
+import { createLogger } from '@skytwin/core';
+
+const log = createLogger('api:risk-profile');
+
+/**
+ * Routes for the user risk profile (#190).
+ *
+ * The risk profile is a free-form English description of the user's autonomy
+ * preferences. It is interpreted by an LLM into structured `interpreted_caps`
+ * that narrow the effective AutonomySettings on the hot path. LLM integration
+ * is stubbed with TODO(#185) until @skytwin/policy-prompts reaches this stack.
+ *
+ * Endpoints (all under /api/risk-profile):
+ *   GET  /           — return profile text + interpreted_caps for requesting user
+ *   PUT  /           — upsert profile text, trigger stub interpretation
+ *   POST /reinterpret — manual trigger for LLM re-interpretation (stubbed)
+ */
+export function createRiskProfileRouter(): Router {
+  const router = Router();
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GET /
+  // Returns { profileText, interpretedCaps, lastInterpretedAt, lastModelVersion }
+  // for the requesting user. If no row exists, returns defaults.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.get('/', async (req, res, next) => {
+    try {
+      const userId: string | undefined =
+        (req as unknown as { user?: { id?: string } }).user?.id ??
+        (req.query['userId'] as string | undefined);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const row = await riskProfileRepository.getForUser(userId);
+      if (!row) {
+        res.json({
+          profileText: '',
+          interpretedCaps: {},
+          lastInterpretedAt: null,
+          lastModelVersion: null,
+        });
+        return;
+      }
+
+      res.json({
+        profileText: row.profile_text,
+        interpretedCaps: row.interpreted_caps,
+        lastInterpretedAt: row.last_interpreted_at?.toISOString() ?? null,
+        lastModelVersion: row.last_model_version,
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // PUT /
+  // Body: { profileText: string }
+  // Upserts the profile text then runs a stub interpretation.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.put('/', async (req, res, next) => {
+    try {
+      const userId: string | undefined =
+        (req as unknown as { user?: { id?: string } }).user?.id ??
+        (req.query['userId'] as string | undefined);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const body = req.body as { profileText?: unknown };
+      if (typeof body?.profileText !== 'string') {
+        res.status(400).json({ error: 'profileText must be a string' });
+        return;
+      }
+
+      const profileText = body.profileText;
+
+      // Step 1: Upsert the profile text row.
+      await riskProfileRepository.upsert({ userId, profileText });
+
+      // Step 2: Stub interpretation.
+      // TODO(#185): replace with runPrompt('risk-profile-interpretation', { text: profileText })
+      // from @skytwin/policy-prompts once that package reaches this stack.
+      // For v1, just store an empty interpretedCaps so SpendTracker falls back
+      // to user-global AutonomySettings caps. The stub keeps the API contract
+      // stable and makes the field non-null for downstream consumers.
+      const interpretedCaps = {};
+      const updatedRow = await riskProfileRepository.updateInterpretedCaps({
+        userId,
+        interpretedCaps,
+        modelVersion: 'stub-v0',
+      });
+
+      if (!updatedRow) {
+        // Should never happen — we just upserted above
+        res.status(500).json({ error: 'Failed to update interpreted caps' });
+        return;
+      }
+
+      log.info('Risk profile upserted', { userId, profileLength: profileText.length });
+
+      res.json({
+        profileText: updatedRow.profile_text,
+        interpretedCaps: updatedRow.interpreted_caps,
+        lastInterpretedAt: updatedRow.last_interpreted_at?.toISOString() ?? null,
+        lastModelVersion: updatedRow.last_model_version,
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // POST /reinterpret
+  // Manual trigger for re-running LLM interpretation.
+  // v1: stubbed — returns status='stubbed'.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.post('/reinterpret', async (req, res, next) => {
+    try {
+      const userId: string | undefined =
+        (req as unknown as { user?: { id?: string } }).user?.id ??
+        (req.query['userId'] as string | undefined);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      // TODO(#185): replace with runPrompt('risk-profile-interpretation', { text: profileText })
+      // from @skytwin/policy-prompts. This endpoint exists so the frontend can
+      // manually trigger re-interpretation after a profile edit; the real implementation
+      // will enqueue a background job and return a jobId.
+      log.info('Risk profile reinterpret requested (stubbed)', { userId });
+      res.json({
+        status: 'stubbed',
+        message: 'LLM interpretation lands when #185 reaches this stack',
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -43,6 +43,7 @@
       <li><a href="#/decisions" class="nav-link" data-page="decisions">What happened</a></li>
       <li><a href="#/twin" class="nav-link" data-page="twin">What I've learned</a></li>
       <li><a href="#/capabilities" class="nav-link" data-page="capabilities">Capabilities</a></li>
+      <li><a href="#/about-me" class="nav-link" data-page="about-me">About me</a></li>
       <li><a href="#/audit" class="nav-link" data-page="audit">Audit trail</a></li>
       <li><a href="#/settings" class="nav-link" data-page="settings">Settings</a></li>
       <li><a href="#/setup" class="nav-link" data-page="setup">Connect</a></li>

--- a/apps/web/public/js/api-client.js
+++ b/apps/web/public/js/api-client.js
@@ -741,3 +741,49 @@ export function regretCapability(id, userId, withinHours = 24) {
     body: JSON.stringify({ withinHours }),
   });
 }
+
+// ── Pause / Resume all capabilities (#190) ───────────────────────────────────
+
+export function pauseAllCapabilities(userId) {
+  return fetchJSON(`${API}/capabilities/pause-all?userId=${encodeURIComponent(userId)}`, {
+    method: 'POST',
+  });
+}
+
+export function resumeAllCapabilities(userId) {
+  return fetchJSON(`${API}/capabilities/resume-all?userId=${encodeURIComponent(userId)}`, {
+    method: 'POST',
+  });
+}
+
+// ── Risk profile (#190) ───────────────────────────────────────────────────────
+
+export function fetchRiskProfile(userId) {
+  return fetchJSON(`${API}/risk-profile?userId=${encodeURIComponent(userId)}`);
+}
+
+export function saveRiskProfile(userId, profileText) {
+  return fetchJSON(`${API}/risk-profile?userId=${encodeURIComponent(userId)}`, {
+    method: 'PUT',
+    body: JSON.stringify({ profileText }),
+  });
+}
+
+export function reinterpretRiskProfile(userId) {
+  return fetchJSON(`${API}/risk-profile/reinterpret?userId=${encodeURIComponent(userId)}`, {
+    method: 'POST',
+  });
+}
+
+// ── About Me / self-portrait (#190) ──────────────────────────────────────────
+
+export function fetchAboutMe(userId) {
+  return fetchJSON(`${API}/about-me?userId=${encodeURIComponent(userId)}`);
+}
+
+export function submitSelfPortraitCorrection(userId, paragraphIndex, sentenceIndex, correction) {
+  return fetchJSON(`${API}/about-me/correct?userId=${encodeURIComponent(userId)}`, {
+    method: 'POST',
+    body: JSON.stringify({ paragraphIndex, sentenceIndex, correction }),
+  });
+}

--- a/apps/web/public/js/app.js
+++ b/apps/web/public/js/app.js
@@ -9,6 +9,8 @@ import { renderAssistant } from './pages/assistant.js';
 import { renderOnboarding } from './pages/onboarding.js';
 import { renderCapabilities } from './pages/capabilities.js';
 import { renderCapabilityDetail } from './pages/capability-detail.js';
+import { renderAboutMe } from './pages/about-me.js';
+import { renderGlobalPauseButton } from './components/global-pause-button.js';
 import { fetchPendingApprovals, fetchHealth, fetchUser, listUsers, escapeHtml, isApiKnownOffline } from './api-client.js';
 import { initTheme } from './theme-switcher.js';
 import { connectSSE, disconnectSSE, isConnected } from './sse-client.js';
@@ -28,6 +30,7 @@ const routes = {
   '/audit': { title: 'Audit Trail', render: renderAudit },
   '/setup': { title: 'Connect', render: renderSetup },
   '/capabilities': { title: 'Capabilities', render: renderCapabilities },
+  '/about-me': { title: 'About me', render: renderAboutMe },
 };
 
 /**
@@ -400,6 +403,17 @@ window.addEventListener('DOMContentLoaded', () => {
   // Wire dashboard event handlers + document-level delegators.
   // Idempotent so re-running this in tests is safe.
   initDashboardGlobals();
+
+  // Mount the always-visible Pause-everything safety button (#190).
+  // Floats top-right across all routes so the panic affordance is always
+  // accessible. Component handles its own state + SSE subscription.
+  if (!document.getElementById('global-pause-button-mount')) {
+    const mount = document.createElement('div');
+    mount.id = 'global-pause-button-mount';
+    mount.className = 'global-pause-mount';
+    document.body.appendChild(mount);
+    renderGlobalPauseButton(mount);
+  }
 
   // Handle mobile QR pairing entry (/mobile?token=...&userId=...)
   const urlParams = new URLSearchParams(window.location.search);

--- a/apps/web/public/js/components/global-pause-button.js
+++ b/apps/web/public/js/components/global-pause-button.js
@@ -1,0 +1,126 @@
+/**
+ * global-pause-button.js
+ *
+ * Always-visible "Pause everything" / "Resume all" safety-net affordance (#190).
+ *
+ * Mount by calling renderGlobalPauseButton(targetEl) once on boot. The component:
+ *   1. Fetches current pause state on mount (any paused servers → "Resume all").
+ *   2. On click: calls the appropriate API endpoint, updates UI state.
+ *   3. Subscribes to SSE capability:health events to update state when status changes.
+ *
+ * Singleton delegator: _pauseButtonWired guards a single document-level click
+ * listener so re-renders never stack listeners.
+ */
+
+import { fetchCapabilities, pauseAllCapabilities, resumeAllCapabilities, escapeHtml } from '../api-client.js';
+import { showToast } from '../toast.js';
+import { KEY_USER_ID } from '../storage-keys.js';
+
+// Module-level state
+let _isPaused = false;
+let _pauseButtonTargetEl = null;
+let _pauseButtonListenerWired = false;
+
+function getCurrentUserId() {
+  return localStorage.getItem(KEY_USER_ID) || '';
+}
+
+/**
+ * Render the button into the target element.
+ * Safe to call multiple times — re-renders in place without stacking listeners.
+ */
+export function renderGlobalPauseButton(targetEl) {
+  if (!targetEl) return;
+  _pauseButtonTargetEl = targetEl;
+  ensurePauseButtonListener();
+  _renderButton();
+  // Fetch current state asynchronously; update button when it resolves.
+  _refreshPauseState();
+}
+
+function _renderButton() {
+  if (!_pauseButtonTargetEl) return;
+  if (_isPaused) {
+    _pauseButtonTargetEl.innerHTML = `
+      <button
+        class="btn btn-sm"
+        data-action="global-resume"
+        style="background: var(--color-warning, #e6a700); color: #000; border: none; font-weight: 600; font-size: 0.8rem; padding: 0.3rem 0.75rem; border-radius: var(--radius-sm); cursor: pointer;"
+        title="All capability servers are paused. Click to resume."
+      >Resume all</button>
+    `;
+  } else {
+    _pauseButtonTargetEl.innerHTML = `
+      <button
+        class="btn btn-sm btn-outline"
+        data-action="global-pause"
+        style="font-size: 0.8rem; padding: 0.3rem 0.75rem; border-radius: var(--radius-sm); cursor: pointer;"
+        title="Pause all capability servers immediately."
+      >Pause everything</button>
+    `;
+  }
+}
+
+async function _refreshPauseState() {
+  const userId = getCurrentUserId();
+  if (!userId) return;
+  try {
+    const data = await fetchCapabilities(userId);
+    // If any server has status=paused, treat the global state as paused.
+    const hasPaused =
+      Array.isArray(data?.dormant) && data.dormant.some((s) => s.status === 'paused') ||
+      Array.isArray(data?.installed) && data.installed.some((s) => s.status === 'paused');
+    _isPaused = hasPaused;
+    _renderButton();
+  } catch {
+    // Non-critical — leave button in current state
+  }
+}
+
+function ensurePauseButtonListener() {
+  if (_pauseButtonListenerWired || typeof document === 'undefined') return;
+  _pauseButtonListenerWired = true;
+
+  document.addEventListener('click', async (e) => {
+    const target = e.target instanceof Element ? e.target : null;
+    if (!target) return;
+    const btn = target.closest('[data-action]');
+    if (!btn) return;
+    const action = btn.getAttribute('data-action');
+    if (action !== 'global-pause' && action !== 'global-resume') return;
+
+    const userId = getCurrentUserId();
+    if (!userId) return;
+
+    // Optimistic UI update
+    btn.disabled = true;
+    btn.textContent = action === 'global-pause' ? 'Pausing…' : 'Resuming…';
+
+    try {
+      if (action === 'global-pause') {
+        const result = await pauseAllCapabilities(userId);
+        _isPaused = true;
+        showToast(
+          `Paused ${result.pausedCount ?? 0} capability server${(result.pausedCount ?? 0) !== 1 ? 's' : ''}. Your twin is standing by.`,
+          { kind: 'success' },
+        );
+      } else {
+        const result = await resumeAllCapabilities(userId);
+        _isPaused = false;
+        showToast(
+          `Resumed ${result.resumedCount ?? 0} capability server${(result.resumedCount ?? 0) !== 1 ? 's' : ''}. Your twin is active again.`,
+          { kind: 'success' },
+        );
+      }
+    } catch (err) {
+      showToast(`Could not ${action === 'global-pause' ? 'pause' : 'resume'} capabilities: ${escapeHtml(err.message)}`, { kind: 'error' });
+    } finally {
+      _renderButton();
+    }
+  });
+
+  // SSE: refresh state when any capability:health event arrives.
+  window.addEventListener('sse:capability:health', () => {
+    _refreshPauseState();
+  });
+}

--- a/apps/web/public/js/pages/about-me.js
+++ b/apps/web/public/js/pages/about-me.js
@@ -1,0 +1,283 @@
+import {
+  fetchAboutMe,
+  submitSelfPortraitCorrection,
+  fetchRiskProfile,
+  saveRiskProfile,
+  escapeHtml,
+  renderApiError,
+} from '../api-client.js';
+import { showToast } from '../toast.js';
+import { KEY_USER_ID } from '../storage-keys.js';
+
+// Singleton delegator — see CLAUDE.md "Frontend Event Handling".
+// Hash-gated, not container-gated, because the SPA reuses #page-content
+// across all routes and container.contains is always true.
+let _aboutMeListenerWired = false;
+let _saveDebounce = null;
+let _container = null;
+let _profileText = '';
+let _portrait = null;
+
+function getCurrentUserId() {
+  return localStorage.getItem(KEY_USER_ID) || '';
+}
+
+function ensureAboutMeListener() {
+  if (_aboutMeListenerWired || typeof document === 'undefined') return;
+  _aboutMeListenerWired = true;
+  document.addEventListener('click', handleAboutMeClick);
+  document.addEventListener('input', handleAboutMeInput);
+  document.addEventListener('blur', handleAboutMeBlur, true);
+}
+
+function isOnAboutMe() {
+  return (window.location.hash || '').split('?')[0] === '#/about-me';
+}
+
+function handleAboutMeClick(e) {
+  if (!isOnAboutMe()) return;
+  const target = e.target instanceof HTMLElement ? e.target.closest('[data-action]') : null;
+  if (!target) return;
+
+  const action = target.dataset.action;
+  const userId = getCurrentUserId();
+  if (!userId) return;
+
+  if (action === 'correct-sentence') {
+    const paragraphIndex = parseInt(target.dataset.paragraphIndex || '0', 10);
+    const sentenceIndex = parseInt(target.dataset.sentenceIndex || '0', 10);
+    openCorrectionModal(userId, paragraphIndex, sentenceIndex);
+  } else if (action === 'save-risk-profile') {
+    const textarea = document.getElementById('risk-profile-textarea');
+    if (textarea) {
+      saveRiskProfileNow(userId, textarea.value);
+    }
+  } else if (action === 'cancel-correction') {
+    closeCorrectionModal();
+  } else if (action === 'submit-correction') {
+    submitCorrectionFromModal(userId);
+  }
+}
+
+function handleAboutMeInput(e) {
+  if (!isOnAboutMe()) return;
+  const target = e.target instanceof HTMLElement ? e.target : null;
+  if (!target || target.id !== 'risk-profile-textarea') return;
+  // Debounce auto-save: 1.2s after last keystroke.
+  if (_saveDebounce) clearTimeout(_saveDebounce);
+  _saveDebounce = setTimeout(() => {
+    _saveDebounce = null;
+    const userId = getCurrentUserId();
+    if (userId) saveRiskProfileNow(userId, target.value);
+  }, 1200);
+}
+
+function handleAboutMeBlur(e) {
+  if (!isOnAboutMe()) return;
+  const target = e.target instanceof HTMLElement ? e.target : null;
+  if (!target || target.id !== 'risk-profile-textarea') return;
+  // Save immediately on blur if there's a pending debounce.
+  if (_saveDebounce) {
+    clearTimeout(_saveDebounce);
+    _saveDebounce = null;
+    const userId = getCurrentUserId();
+    if (userId) saveRiskProfileNow(userId, target.value);
+  }
+}
+
+async function saveRiskProfileNow(userId, text) {
+  if (text === _profileText) return; // no-op
+  _profileText = text;
+  try {
+    const res = await saveRiskProfile(userId, text);
+    if (res && res.ok === false) {
+      showToast('Could not save risk profile — will retry on next change.', { kind: 'warning' });
+      return;
+    }
+    showToast('Risk profile saved.', { kind: 'success', durationMs: 2000 });
+    renderInterpretedCaps(res?.profile?.interpretedCaps || {});
+  } catch (err) {
+    showToast('Risk profile save failed: ' + (err?.message || 'unknown error'), { kind: 'error' });
+  }
+}
+
+function renderInterpretedCaps(caps) {
+  const el = document.getElementById('interpreted-caps');
+  if (!el) return;
+  const keys = Object.keys(caps || {});
+  if (keys.length === 0) {
+    el.innerHTML = `<p class="muted">No profile interpretation yet — using safe defaults from your global autonomy settings.</p>
+      <p class="muted small">LLM-driven interpretation will surface here when the prompts pipeline is wired up.</p>`;
+    return;
+  }
+  const rows = keys.map((k) => {
+    const v = caps[k];
+    return `<dt>${escapeHtml(k)}</dt><dd>${escapeHtml(JSON.stringify(v))}</dd>`;
+  }).join('');
+  el.innerHTML = `<p>I understood your profile to mean:</p><dl class="interpreted-caps">${rows}</dl>`;
+}
+
+function openCorrectionModal(userId, paragraphIndex, sentenceIndex) {
+  const existing = document.getElementById('correction-modal');
+  if (existing) existing.remove();
+
+  const sentence = lookupSentence(paragraphIndex, sentenceIndex);
+  const modal = document.createElement('div');
+  modal.id = 'correction-modal';
+  modal.className = 'modal-overlay';
+  modal.innerHTML = `
+    <div class="modal-content">
+      <h3>Actually that's wrong</h3>
+      <p class="muted">Tell us what's wrong with this sentence:</p>
+      <blockquote>${escapeHtml(sentence)}</blockquote>
+      <textarea id="correction-text" placeholder="What's the correction?" rows="4"></textarea>
+      <div class="modal-actions">
+        <button data-action="cancel-correction" class="btn btn-secondary">Cancel</button>
+        <button data-action="submit-correction" class="btn btn-primary"
+                data-paragraph-index="${paragraphIndex}"
+                data-sentence-index="${sentenceIndex}">Submit correction</button>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(modal);
+  setTimeout(() => {
+    const ta = document.getElementById('correction-text');
+    if (ta) ta.focus();
+  }, 50);
+}
+
+function closeCorrectionModal() {
+  const modal = document.getElementById('correction-modal');
+  if (modal) modal.remove();
+}
+
+async function submitCorrectionFromModal(userId) {
+  const button = document.querySelector('#correction-modal [data-action="submit-correction"]');
+  const textarea = document.getElementById('correction-text');
+  if (!button || !textarea) return;
+
+  const paragraphIndex = parseInt(button.dataset.paragraphIndex || '0', 10);
+  const sentenceIndex = parseInt(button.dataset.sentenceIndex || '0', 10);
+  const correction = textarea.value.trim();
+  if (!correction) {
+    showToast('Please enter a correction.', { kind: 'warning' });
+    return;
+  }
+
+  try {
+    await submitSelfPortraitCorrection(userId, paragraphIndex, sentenceIndex, correction);
+    showToast('Correction recorded. Your twin will adjust.', { kind: 'success' });
+    closeCorrectionModal();
+  } catch (err) {
+    showToast('Could not record correction: ' + (err?.message || 'unknown'), { kind: 'error' });
+  }
+}
+
+function lookupSentence(paragraphIndex, sentenceIndex) {
+  if (!_portrait || !Array.isArray(_portrait.paragraphs)) return '';
+  const p = _portrait.paragraphs[paragraphIndex];
+  if (!p) return '';
+  const sentences = (p.text || '').split(/(?<=[.!?])\s+/);
+  return sentences[sentenceIndex] || p.text || '';
+}
+
+function renderPortraitParagraph(paragraph, idx) {
+  const text = escapeHtml(paragraph.text || '');
+  const sentences = text.split(/(?<=[.!?])\s+/);
+  const sentenceHtml = sentences.map((s, sIdx) => {
+    return `<span class="self-portrait-sentence">
+      ${s}
+      <button class="inline-correct-btn"
+              data-action="correct-sentence"
+              data-paragraph-index="${idx}"
+              data-sentence-index="${sIdx}"
+              title="Actually that's wrong">✏︎</button>
+    </span>`;
+  }).join(' ');
+
+  const cites = Array.isArray(paragraph.citations) && paragraph.citations.length > 0
+    ? `<div class="self-portrait-citations">${paragraph.citations.map((c) =>
+        `<a href="#${escapeHtml(c.ref || '')}" class="citation-link">[${escapeHtml(c.label || c.ref || 'source')}]</a>`
+      ).join(' ')}</div>`
+    : '';
+
+  return `<div class="self-portrait-paragraph">
+    <p>${sentenceHtml}</p>
+    ${cites}
+  </div>`;
+}
+
+export async function renderAboutMe(container) {
+  ensureAboutMeListener();
+  _container = container;
+  const userId = getCurrentUserId();
+  if (!userId) {
+    container.innerHTML = '<p>Please log in to view your About me page.</p>';
+    return;
+  }
+
+  container.innerHTML = `
+    <section class="about-me-page">
+      <header>
+        <h1>About me</h1>
+        <p class="subtle">Your twin's understanding of you, plus how autonomously it should act on your behalf.</p>
+      </header>
+
+      <section class="self-portrait" aria-busy="true">
+        <h2>What I think I know about you</h2>
+        <div id="self-portrait-content"><p class="muted">Loading…</p></div>
+      </section>
+
+      <section class="risk-profile">
+        <h2>How should I act on your behalf?</h2>
+        <p class="subtle">Describe your autonomy preferences in plain English. Hard rails (FS denylist, resource caps, your absolute spend ceiling) are never relaxed by this profile.</p>
+        <textarea id="risk-profile-textarea"
+                  placeholder="e.g. 'I'm a developer. Spend up to $50/day without asking. Never touch financial accounts.'"
+                  rows="6"></textarea>
+        <div class="risk-profile-actions">
+          <button data-action="save-risk-profile" class="btn btn-primary">Save</button>
+          <span class="muted small">Auto-saves on blur or after 1.2s of inactivity.</span>
+        </div>
+        <div id="interpreted-caps" class="interpreted-caps-section"></div>
+      </section>
+    </section>
+  `;
+
+  // Fetch in parallel.
+  try {
+    const [portrait, profile] = await Promise.all([
+      fetchAboutMe(userId).catch((err) => ({ error: err })),
+      fetchRiskProfile(userId).catch((err) => ({ error: err })),
+    ]);
+
+    const portraitEl = document.getElementById('self-portrait-content');
+    if (portraitEl) {
+      if (portrait && !portrait.error && Array.isArray(portrait.paragraphs)) {
+        _portrait = portrait;
+        portraitEl.innerHTML = portrait.paragraphs.map(renderPortraitParagraph).join('');
+        portraitEl.parentElement?.removeAttribute('aria-busy');
+      } else {
+        portraitEl.innerHTML = renderApiError({
+          message: 'Could not load your portrait',
+          context: portrait?.error?.message || 'Unknown error',
+          retry: () => renderAboutMe(container),
+        });
+      }
+    }
+
+    if (profile && !profile.error) {
+      _profileText = profile.profileText || '';
+      const ta = document.getElementById('risk-profile-textarea');
+      if (ta) ta.value = _profileText;
+      renderInterpretedCaps(profile.interpretedCaps || {});
+    } else {
+      renderInterpretedCaps({});
+    }
+  } catch (err) {
+    container.innerHTML = renderApiError({
+      message: 'Could not load About me',
+      context: err?.message || 'unknown',
+      retry: () => renderAboutMe(container),
+    });
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -88,9 +88,14 @@ export type {
 
 export { signalRepository, proposalRepository, skillGapRepository, proactiveScanRepository } from './repositories/index.js';
 
-export { trustTierAuditRepository, spendRepository, domainAutonomyRepository, escalationTriggerRepository, preferenceHistoryRepository, sessionRepository, mempalaceRepository, serviceCredentialRepository, credentialRequirementRepository, aiProviderRepository, ironClawToolRepository, forwardedSignalsRepository, connectorCursorRepository, emailLabelRepository, assistantRepository, deriveThreadTitle, appSuggestionRepository, mcpServerRepository } from './repositories/index.js';
+export { trustTierAuditRepository, spendRepository, domainAutonomyRepository, escalationTriggerRepository, preferenceHistoryRepository, sessionRepository, mempalaceRepository, serviceCredentialRepository, credentialRequirementRepository, aiProviderRepository, ironClawToolRepository, forwardedSignalsRepository, connectorCursorRepository, emailLabelRepository, assistantRepository, deriveThreadTitle, appSuggestionRepository, mcpServerRepository, riskProfileRepository } from './repositories/index.js';
 export type { AppSuggestionRow, UpsertPendingSuggestionInput } from './repositories/index.js';
 export type { McpServerRow } from './repositories/index.js';
+export type {
+  RiskProfileRow,
+  UpsertRiskProfileInput,
+  UpdateInterpretedCapsInput,
+} from './repositories/index.js';
 export type { AssistantThread, AssistantMessage } from './repositories/index.js';
 export type { ForwardedSignalRow } from './repositories/index.js';
 export type { ConnectorCursorRow } from './repositories/index.js';

--- a/packages/db/src/migrations/028-risk-profiles.sql
+++ b/packages/db/src/migrations/028-risk-profiles.sql
@@ -1,0 +1,22 @@
+-- 028-risk-profiles.sql
+-- User-stated risk profile for the Capability Acquisition Loop (#190).
+-- See docs/architecture-philosophy.md "Risk profile" section.
+--
+-- Free-form text describing autonomy preferences in plain English.
+-- The text is the canonical source of truth; interpreted_caps is a
+-- hot-path-readable structured projection produced by the LLM
+-- risk-profile-interpretation prompt (#185).
+--
+-- Hard rails are NEVER subject to the risk profile, even on maximum
+-- boldness. The interpreted_caps may only narrow autonomy below the
+-- user-global AutonomySettings caps; it cannot widen.
+
+CREATE TABLE IF NOT EXISTS user_risk_profiles (
+  user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  profile_text STRING NOT NULL DEFAULT '',
+  interpreted_caps JSONB NOT NULL DEFAULT '{}'::JSONB,
+  last_interpreted_at TIMESTAMPTZ,
+  last_model_version STRING,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/packages/db/src/repositories/index.ts
+++ b/packages/db/src/repositories/index.ts
@@ -113,3 +113,10 @@ export type {
 
 export { mcpServerRepository } from './mcp-server-repository.js';
 export type { McpServerRow } from './mcp-server-repository.js';
+
+export { riskProfileRepository } from './risk-profile-repository.js';
+export type {
+  RiskProfileRow,
+  UpsertRiskProfileInput,
+  UpdateInterpretedCapsInput,
+} from './risk-profile-repository.js';

--- a/packages/db/src/repositories/mcp-server-repository.ts
+++ b/packages/db/src/repositories/mcp-server-repository.ts
@@ -136,4 +136,36 @@ export const mcpServerRepository = {
     );
     return result.rows;
   },
+
+  /**
+   * Pause all active capability servers for a user (#190 Pause-everything button).
+   * Returns the list of servers that were transitioned to 'paused'.
+   */
+  async markAllPausedForUser(userId: string): Promise<McpServerRow[]> {
+    const result = await query<McpServerRow>(
+      `UPDATE mcp_servers
+       SET status = 'paused', updated_at = now()
+       WHERE user_id = $1
+         AND status IN ('active', 'installed', 'authorized')
+       RETURNING *`,
+      [userId],
+    );
+    return result.rows;
+  },
+
+  /**
+   * Resume all paused capability servers for a user (#190 Pause-everything button).
+   * Returns the list of servers that were transitioned back to 'active'.
+   */
+  async markAllResumedForUser(userId: string): Promise<McpServerRow[]> {
+    const result = await query<McpServerRow>(
+      `UPDATE mcp_servers
+       SET status = 'active', updated_at = now()
+       WHERE user_id = $1
+         AND status = 'paused'
+       RETURNING *`,
+      [userId],
+    );
+    return result.rows;
+  },
 };

--- a/packages/db/src/repositories/risk-profile-repository.ts
+++ b/packages/db/src/repositories/risk-profile-repository.ts
@@ -1,0 +1,60 @@
+import { query } from '../connection.js';
+
+export interface RiskProfileRow {
+  user_id: string;
+  profile_text: string;
+  interpreted_caps: Record<string, unknown>;
+  last_interpreted_at: Date | null;
+  last_model_version: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface UpsertRiskProfileInput {
+  userId: string;
+  profileText: string;
+}
+
+export interface UpdateInterpretedCapsInput {
+  userId: string;
+  interpretedCaps: Record<string, unknown>;
+  modelVersion: string;
+}
+
+export const riskProfileRepository = {
+  async getForUser(userId: string): Promise<RiskProfileRow | null> {
+    const result = await query<RiskProfileRow>(
+      `SELECT * FROM user_risk_profiles WHERE user_id = $1`,
+      [userId],
+    );
+    return result.rows[0] ?? null;
+  },
+
+  async upsert(input: UpsertRiskProfileInput): Promise<RiskProfileRow> {
+    const result = await query<RiskProfileRow>(
+      `INSERT INTO user_risk_profiles (user_id, profile_text, updated_at)
+       VALUES ($1, $2, now())
+       ON CONFLICT (user_id)
+       DO UPDATE SET
+         profile_text = EXCLUDED.profile_text,
+         updated_at   = now()
+       RETURNING *`,
+      [input.userId, input.profileText],
+    );
+    return result.rows[0]!;
+  },
+
+  async updateInterpretedCaps(input: UpdateInterpretedCapsInput): Promise<RiskProfileRow | null> {
+    const result = await query<RiskProfileRow>(
+      `UPDATE user_risk_profiles
+       SET interpreted_caps      = $1,
+           last_interpreted_at   = now(),
+           last_model_version    = $2,
+           updated_at            = now()
+       WHERE user_id = $3
+       RETURNING *`,
+      [JSON.stringify(input.interpretedCaps), input.modelVersion, input.userId],
+    );
+    return result.rows[0] ?? null;
+  },
+};

--- a/packages/policy-engine/src/__tests__/risk-profile-clamp.test.ts
+++ b/packages/policy-engine/src/__tests__/risk-profile-clamp.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @file risk-profile-clamp.test.ts
+ * Tests for the interpretedCaps parameter added to resolveEffectiveCaps (#190).
+ *
+ * Hard rail: interpretedCaps may NEVER widen autonomy beyond user-global settings.
+ * interpretedCaps narrows below global; per-app overrides narrow further on top.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { resolveEffectiveCaps, SpendTracker } from '../spend-tracker.js';
+import type { SpendRepositoryPort } from '../spend-tracker.js';
+import type { AutonomySettings } from '@skytwin/shared-types';
+
+function settings(overrides?: Partial<AutonomySettings>): AutonomySettings {
+  return {
+    maxSpendPerActionCents: 10000,
+    maxDailySpendCents: 50000,
+    allowedDomains: [],
+    blockedDomains: [],
+    requireApprovalForIrreversible: false,
+    ...overrides,
+  };
+}
+
+function repo(dailyTotal = 0): SpendRepositoryPort {
+  return {
+    getDailyTotal: vi.fn().mockResolvedValue(dailyTotal),
+    reconcile: vi.fn().mockResolvedValue(null),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolveEffectiveCaps with interpretedCaps
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('resolveEffectiveCaps — interpretedCaps parameter (#190)', () => {
+  it('no interpretedCaps → returns user-global caps unchanged', () => {
+    const caps = resolveEffectiveCaps(settings());
+    expect(caps.maxDailySpendCents).toBe(50000);
+    expect(caps.maxSpendPerActionCents).toBe(10000);
+    expect(caps.requireApprovalForIrreversible).toBe(false);
+  });
+
+  it('interpretedCaps that NARROWS daily cap is honoured', () => {
+    const caps = resolveEffectiveCaps(settings(), undefined, {
+      maxDailySpendCents: 5000,
+    });
+    expect(caps.maxDailySpendCents).toBe(5000);
+    // per-action unchanged
+    expect(caps.maxSpendPerActionCents).toBe(10000);
+  });
+
+  it('interpretedCaps that NARROWS per-action cap is honoured', () => {
+    const caps = resolveEffectiveCaps(settings(), undefined, {
+      maxSpendPerActionCents: 500,
+    });
+    expect(caps.maxSpendPerActionCents).toBe(500);
+  });
+
+  it('HARD RAIL: interpretedCaps that tries to WIDEN daily cap is clamped to global', () => {
+    // User global is 50000; interpretedCaps claims 999999 → must stay at 50000.
+    const caps = resolveEffectiveCaps(settings(), undefined, {
+      maxDailySpendCents: 999999,
+    });
+    expect(caps.maxDailySpendCents).toBe(50000);
+  });
+
+  it('HARD RAIL: interpretedCaps that tries to WIDEN per-action cap is clamped to global', () => {
+    const caps = resolveEffectiveCaps(settings(), undefined, {
+      maxSpendPerActionCents: 999999,
+    });
+    expect(caps.maxSpendPerActionCents).toBe(10000);
+  });
+
+  it('interpretedCaps tightens requireApprovalForIrreversible from false to true', () => {
+    const s = settings({ requireApprovalForIrreversible: false });
+    const caps = resolveEffectiveCaps(s, undefined, {
+      requireApprovalForIrreversible: true,
+    });
+    expect(caps.requireApprovalForIrreversible).toBe(true);
+  });
+
+  it('HARD RAIL: interpretedCaps cannot relax requireApprovalForIrreversible when global is true', () => {
+    const s = settings({ requireApprovalForIrreversible: true });
+    const caps = resolveEffectiveCaps(s, undefined, {
+      requireApprovalForIrreversible: false,
+    });
+    // Global hard rail: must stay true
+    expect(caps.requireApprovalForIrreversible).toBe(true);
+  });
+
+  it('per-app override clamps FURTHER on top of interpretedCaps narrowing', () => {
+    // interpretedCaps narrows daily to 5000; per-app narrows further to 2000.
+    const s = settings({
+      perAppOverrides: {
+        'gmail-mcp': { maxDailySpendCents: 2000 },
+      },
+    });
+    const caps = resolveEffectiveCaps(s, 'gmail-mcp', {
+      maxDailySpendCents: 5000,
+    });
+    expect(caps.maxDailySpendCents).toBe(2000);
+  });
+
+  it('per-app override cannot widen beyond interpretedCaps-narrowed base', () => {
+    // interpretedCaps narrows daily to 5000; per-app tries to go to 10000 (wider than
+    // the interpreted base of 5000). Must stay at 5000.
+    const s = settings({
+      perAppOverrides: {
+        'gmail-mcp': { maxDailySpendCents: 10000 },
+      },
+    });
+    const caps = resolveEffectiveCaps(s, 'gmail-mcp', {
+      maxDailySpendCents: 5000,
+    });
+    expect(caps.maxDailySpendCents).toBe(5000);
+  });
+
+  it('empty interpretedCaps object is a no-op', () => {
+    const caps = resolveEffectiveCaps(settings(), undefined, {});
+    expect(caps.maxDailySpendCents).toBe(50000);
+    expect(caps.maxSpendPerActionCents).toBe(10000);
+    expect(caps.requireApprovalForIrreversible).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SpendTracker.checkDailyLimit with interpretedCaps
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('SpendTracker.checkDailyLimit — interpretedCaps parameter (#190)', () => {
+  it('interpretedCaps that narrows daily cap causes rejection when it would otherwise pass', async () => {
+    const r = repo(4000);
+    const tracker = new SpendTracker(r);
+    const s = settings({ maxDailySpendCents: 50000 });
+
+    // Without interpretedCaps: 4000 + 1500 = 5500 < 50000 → allowed.
+    // With interpretedCaps narrowing to 5000: 4000 + 1500 = 5500 > 5000 → rejected.
+    const result = await tracker.checkDailyLimit('user-1', 1500, s, 24, undefined, {
+      maxDailySpendCents: 5000,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.dailyLimitCents).toBe(5000);
+  });
+
+  it('HARD RAIL: interpretedCaps cannot widen limit beyond global', async () => {
+    // global is 5000; interpretedCaps claims 1000000; must stay at 5000.
+    const r = repo(4900);
+    const tracker = new SpendTracker(r);
+    const s = settings({ maxDailySpendCents: 5000 });
+
+    const result = await tracker.checkDailyLimit('user-1', 200, s, 24, undefined, {
+      maxDailySpendCents: 1000000,
+    });
+    // 4900 + 200 = 5100 > 5000 → must still reject
+    expect(result.allowed).toBe(false);
+    expect(result.dailyLimitCents).toBe(5000);
+  });
+
+  it('per-app override and interpretedCaps both narrow independently', async () => {
+    // global 50000, interpretedCaps narrows to 10000, per-app narrows to 3000.
+    // Effective cap should be min(50000, 10000, 3000) = 3000.
+    const r = repo(2500);
+    const tracker = new SpendTracker(r);
+    const s = settings({
+      maxDailySpendCents: 50000,
+      perAppOverrides: {
+        'linear-mcp': { maxDailySpendCents: 3000 },
+      },
+    });
+
+    const result = await tracker.checkDailyLimit('user-1', 600, s, 24, 'linear-mcp', {
+      maxDailySpendCents: 10000,
+    });
+    // 2500 + 600 = 3100 > 3000 → rejected
+    expect(result.allowed).toBe(false);
+    expect(result.dailyLimitCents).toBe(3000);
+  });
+});

--- a/packages/policy-engine/src/spend-tracker.ts
+++ b/packages/policy-engine/src/spend-tracker.ts
@@ -1,35 +1,81 @@
 import type { AutonomySettings, PerAppOverride } from '@skytwin/shared-types';
 
 /**
- * Resolves the effective caps for a given action, given the user's
- * AutonomySettings and an optional per-app override (Capability
- * Acquisition Loop, #173).
+ * Apply interpreted_caps as a clamp-down on top of user-global settings.
  *
- * Per-app overrides may only narrow autonomy. The user-global cap is
- * always the upper bound; an override that requests a higher cap is
- * silently clamped down to the global value.
+ * interpreted_caps (derived from the user's free-form risk profile, #190) may
+ * only NARROW autonomy below the user-global value. Fields that would widen
+ * autonomy beyond the global cap are silently discarded.
+ *
+ * Hard rails (e.g. requireApprovalForIrreversible=true globally) are never
+ * relaxed by interpreted_caps — this function OR-combines boolean flags.
+ *
+ * @internal Used by resolveEffectiveCaps. Not exported separately.
+ */
+function applyInterpretedCaps(
+  settings: AutonomySettings,
+  interpretedCaps: Partial<AutonomySettings>,
+): AutonomySettings {
+  return {
+    ...settings,
+    maxSpendPerActionCents: clampDown(
+      settings.maxSpendPerActionCents,
+      interpretedCaps.maxSpendPerActionCents,
+    ),
+    maxDailySpendCents: clampDown(
+      settings.maxDailySpendCents,
+      interpretedCaps.maxDailySpendCents,
+    ),
+    // requireApprovalForIrreversible is OR-ed: interpreted_caps can only tighten.
+    requireApprovalForIrreversible:
+      settings.requireApprovalForIrreversible ||
+      interpretedCaps.requireApprovalForIrreversible === true,
+  };
+}
+
+/**
+ * Resolves the effective caps for a given action, given the user's
+ * AutonomySettings, an optional per-app override (Capability
+ * Acquisition Loop, #173), and an optional interpreted_caps projection
+ * from the user's risk profile (#190).
+ *
+ * Resolution order (each layer may only narrow, never widen):
+ *   1. user-global AutonomySettings (upper bound / hard ceiling)
+ *   2. interpretedCaps — LLM-interpreted risk profile projection (#190)
+ *   3. per-app override — further narrows for a specific app
+ *
+ * Any cap that tries to widen beyond the user-global ceiling is silently
+ * clamped. Hard rails are not subject to this: a global
+ * requireApprovalForIrreversible=true cannot be relaxed by any layer.
  */
 export function resolveEffectiveCaps(
   settings: AutonomySettings,
   appRegistryId?: string,
+  interpretedCaps?: Partial<AutonomySettings>,
 ): {
   maxSpendPerActionCents: number;
   maxDailySpendCents: number;
   requireApprovalForIrreversible: boolean;
   override?: PerAppOverride;
 } {
-  const override = appRegistryId ? settings.perAppOverrides?.[appRegistryId] : undefined;
+  // Layer 2: apply interpreted_caps on top of global settings (narrows only).
+  const baseSettings = interpretedCaps
+    ? applyInterpretedCaps(settings, interpretedCaps)
+    : settings;
+
+  // Layer 3: apply per-app override on top of the (possibly narrowed) base.
+  const override = appRegistryId ? baseSettings.perAppOverrides?.[appRegistryId] : undefined;
   const maxPerAction = clampDown(
-    settings.maxSpendPerActionCents,
+    baseSettings.maxSpendPerActionCents,
     override?.maxSpendPerActionCents,
   );
   const maxDaily = clampDown(
-    settings.maxDailySpendCents,
+    baseSettings.maxDailySpendCents,
     override?.maxDailySpendCents,
   );
   // Require-approval is OR-ed: either the global flag or a stricter override turns it on.
   const requireApproval =
-    settings.requireApprovalForIrreversible ||
+    baseSettings.requireApprovalForIrreversible ||
     override?.requireApprovalForIrreversible === true;
 
   return {
@@ -104,6 +150,9 @@ export class SpendTracker {
    *   When supplied, per-app overrides from `settings.perAppOverrides` are
    *   applied, narrowing the effective daily cap if the override is tighter.
    *   Per-app caps may never widen autonomy beyond the user-global cap.
+   * @param interpretedCaps Optional structured projection of the user's risk profile (#190).
+   *   When supplied, this narrows the effective caps below the user-global value before
+   *   per-app overrides are applied. May only narrow — never widen.
    */
   async checkDailyLimit(
     userId: string,
@@ -111,8 +160,9 @@ export class SpendTracker {
     settings: AutonomySettings,
     windowHours: number = 24,
     appRegistryId?: string,
+    interpretedCaps?: Partial<AutonomySettings>,
   ): Promise<SpendCheckResult> {
-    const effectiveDaily = resolveEffectiveCaps(settings, appRegistryId).maxDailySpendCents;
+    const effectiveDaily = resolveEffectiveCaps(settings, appRegistryId, interpretedCaps).maxDailySpendCents;
 
     // Reject negative costs — these could bypass spend tracking
     if (proposedCostCents < 0) {


### PR DESCRIPTION
Phase 2 child #190. Stacked on PR #204 (#176 web UX), which stacks on PR #203 → #202 → #198.

The deepest trust surface in the epic. The user can see what their twin thinks about them, correct it inline, and reprogram its risk profile in plain English. Plus an always-visible Pause-everything button — the panic affordance.

## What ships

- **Migration 028** — `user_risk_profiles` table (profile_text canonical, interpreted_caps hot-path-readable)
- **`riskProfileRepository`** — getForUser, upsert, updateInterpretedCaps
- **`resolveEffectiveCaps`** in policy-engine — now takes optional `interpretedCaps` parameter; clamps below user-global, per-app override clamps further
- **2 new API route modules**: `/api/risk-profile/*` and `/api/about-me/*`
- **`POST /api/capabilities/pause-all`** + `resume-all` — bulk safety control with provenance writes
- **`#/about-me` page** — self-portrait with sentence-level corrections, risk profile auto-save textarea, interpreted-caps display
- **Global pause button** — floating always-visible button, mounted once on DOMContentLoaded

## Hard rails

- `interpreted_caps` may **never** widen autonomy beyond user-global settings (4 dedicated unit tests verify this)
- `requireApprovalForIrreversible` is OR-combined — user-global `true` cannot be relaxed by any layer
- `pause-all` writes provenance per server before mutating status
- Self-portrait corrections write `capability_provenance_nodes(node_type='feedback')` — never directly mutate user data

## Acceptance criteria from #190

- [x] AC#1 — `#/about-me` page renders portrait
- [x] AC#2 — Self-portrait with citations + sentence-level "actually that's wrong" buttons
- [x] AC#3 — Inline correction writes provenance feedback node
- [x] AC#4 — Risk profile textarea: auto-save on blur + 1.2s debounce
- [x] AC#5 — Default risk profile (when blank): inherits conservative defaults
- [x] AC#6 — Reinterpretation runs against current model version (stubbed; TODO #185)
- [x] AC#7 — Pause-everything button visible across all routes; toggles to "Resume all"
- [x] AC#8 — Hard rails not subject to risk profile (4 dedicated unit tests)
- [x] AC#9 — Tests: 28 unit (4 clamp + 11 risk-profile-routes + 7 about-me-routes + 6 pause-all)

## TODO(#185) markers

LLM integration is stubbed with deterministic placeholders. When PR #200 (policy-prompts) reaches this stack, three call sites become one-line `runPrompt(...)` wire-ups:
- `risk-profile.ts` PUT — `runPrompt('risk-profile-interpretation', { text: profileText })`
- `risk-profile.ts` POST `/reinterpret` — same prompt
- `about-me.ts` GET — `runPrompt('self-portrait', { user_facts: aggregatedFacts })`

## Stacking

PR #198 → #202 → #203 → #204 → THIS PR. GitHub auto-rebases bases as upstream PRs merge.

## Tests

- 116/116 policy-engine (4 new clamp-down tests)
- 253/253 api (24 skipped) — 11 risk-profile + 7 about-me + 6 pause-all added
- Full workspace `pnpm build` green across 23 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)