### PR TITLE
feat(#184 follow-up): capability changelog flow + new-skill opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,68 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Capability changelog flow + new-skill opt-in (#184 follow-up)
+
+Implements #184 AC#2 deferred from the previous PR: `changelog://` resource
+fetching, new-destructive-skill opt-in prompts, hard-rail execution block, and
+weekly worker sweep.
+
+### Added — Migration `033-mcp-server-changelogs.sql`
+
+Two new tables:
+- `mcp_server_changelogs` — one row per installed server; tracks
+  `current_version`, `raw_text`, `fetched_at`, `last_seen_skills`, and
+  `last_known_destructive_skills`. Updated on install, on `list_tools`
+  refresh, and on the weekly worker sweep.
+- `pending_skill_opt_ins` — pending opt-in prompts for newly added
+  destructive skills. Unique on `(server_id, skill_name)`. Partial index
+  on unresolved rows.
+
+### Added — `mcpServerChangelogRepository` (`@skytwin/db`)
+
+Methods: `upsert`, `getForServer`, `addPendingOptIn` (idempotent),
+`listPendingOptInsForUser`, `acceptOptIn`, `rejectOptIn`,
+`hasPendingOptIn`.
+
+### Added — `McpHost.fetchChangelog` + `isDestructiveSkill` (`@skytwin/mcp-host`)
+
+`fetchChangelog(serverId)` uses `client.listResources()` to locate a
+`changelog://` resource and reads its text content. Version extraction
+uses a `## vX.Y.Z` / `# X.Y.Z` heuristic (first match wins). Returns
+null on any error — best-effort.
+
+`isDestructiveSkill(skillName)` heuristic gating for opt-in prompts.
+Matches create/delete/update/write/send/post/commit/push/merge/mutate/set/remove.
+
+`onChangelogFetch` hook added to `McpHostOptions` — mirrors `onToolCall`
+pattern. Wired in `execution-setup.ts` to persist changelog snapshots.
+
+Hard rail: `checkPendingOptIn` injected from `execution-setup.ts` blocks
+execution of any destructive skill that has an unaccepted `pending_skill_opt_ins`
+row. Fail-safe: if the check itself throws, execution is blocked.
+
+### Added — Worker job `changelog-poll.ts` (7-day cadence)
+
+`runChangelogPollJob` iterates all active MCP servers, rate-limits per server
+to 12 hours, diffs new destructive skills against `last_known_destructive_skills`,
+and writes opt-in prompts for new ones. Wired in `apps/worker/src/index.ts`
+alongside the existing metrics-rollup pattern.
+
+### Added — API routes (in `createCapabilitiesRouter`)
+
+- `GET  /api/capabilities/:id/changelog` — ownership-checked changelog read
+- `GET  /api/capabilities/pending-opt-ins` — pending opt-in feed for user
+- `POST /api/capabilities/pending-opt-ins/:id/accept` — accept with ownership check
+- `POST /api/capabilities/pending-opt-ins/:id/reject` — reject with ownership check
+
+### Added — Web UI extensions
+
+`apps/web/public/js/pages/capability-detail.js` — Changelog card (version badge
++ collapsible raw_text). Singleton delegator unchanged.
+
+`apps/web/public/js/pages/capabilities.js` — "New skills awaiting opt-in" section
+at top of page with Accept/Reject buttons. Uses existing `_capabilitiesListenerWired`
+singleton guard and adds `accept-opt-in` / `reject-opt-in` to the delegator.
+
 ## [unreleased] — Credential vault envelope encryption (#183 follow-up)
 
 Implements AC#5 from issue #183: envelope encryption of OAuth tokens in the

--- a/apps/api/src/__tests__/changelog-routes.test.ts
+++ b/apps/api/src/__tests__/changelog-routes.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import type { Express } from 'express';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const SERVER_ID  = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const OPT_IN_ID  = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const USER_ID    = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+const {
+  mockMcpServerRepo,
+  mockChangelogRepo,
+  mockAppSuggestionRepo,
+  mockQuery,
+  mockProvenanceRepo,
+  mockMetricsRepo,
+} = vi.hoisted(() => ({
+  mockMcpServerRepo: {
+    getById: vi.fn(),
+    listForUser: vi.fn(),
+    listActive: vi.fn(),
+    markDormant: vi.fn(),
+    markPaused: vi.fn(),
+    markActive: vi.fn(),
+    softDelete: vi.fn(),
+    updateLastActive: vi.fn(),
+    getInactiveSince: vi.fn(),
+    markAllPausedForUser: vi.fn(),
+    markAllResumedForUser: vi.fn(),
+    updateTrustTier: vi.fn(),
+    pauseAutoPromotion: vi.fn(),
+  },
+  mockChangelogRepo: {
+    getForServer: vi.fn(),
+    upsert: vi.fn(),
+    addPendingOptIn: vi.fn(),
+    listPendingOptInsForUser: vi.fn(),
+    acceptOptIn: vi.fn(),
+    rejectOptIn: vi.fn(),
+    hasPendingOptIn: vi.fn(),
+  },
+  mockAppSuggestionRepo: {
+    getPendingForUser: vi.fn().mockResolvedValue([]),
+    getActiveForUser: vi.fn().mockResolvedValue([]),
+    markDismissed: vi.fn(),
+    markSnoozed: vi.fn(),
+  },
+  mockQuery: vi.fn().mockResolvedValue({ rows: [] }),
+  mockProvenanceRepo: {
+    getForServer: vi.fn().mockResolvedValue([]),
+    writeNode: vi.fn().mockResolvedValue(undefined),
+  },
+  mockMetricsRepo: {
+    getSparkline: vi.fn().mockResolvedValue([]),
+    getRecent: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('@skytwin/db', () => ({
+  mcpServerRepository: mockMcpServerRepo,
+  mcpServerChangelogRepository: mockChangelogRepo,
+  appSuggestionRepository: mockAppSuggestionRepo,
+  provenanceRepository: mockProvenanceRepo,
+  mcpServerMetricsRepository: mockMetricsRepo,
+  query: mockQuery,
+}));
+
+vi.mock('@skytwin/registry-client', () => ({
+  RegistryClient: vi.fn().mockImplementation(() => ({
+    search: vi.fn().mockResolvedValue([]),
+    getAll: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+vi.mock('@skytwin/policy-engine', () => ({
+  TrustTierEngine: vi.fn().mockImplementation(() => ({
+    evaluateProgression: vi.fn().mockReturnValue({ shouldChange: false, reason: 'not enough' }),
+  })),
+}));
+
+vi.mock('@skytwin/shared-types', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('@skytwin/shared-types')>();
+  return {
+    ...orig,
+    PROMOTION_THRESHOLDS: {},
+  };
+});
+
+vi.mock('../lib/llm-client-factory.js', () => ({
+  getLlmClientFromConfig: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../sse.js', () => ({
+  sseManager: { emitAll: vi.fn(), emit: vi.fn() },
+  SSE_CAPABILITY_PROMOTION_OFFERED: 'capability:promotion-offered',
+}));
+
+// ---------------------------------------------------------------------------
+// App + fetch helper
+// ---------------------------------------------------------------------------
+
+import { createCapabilitiesRouter } from '../routes/capabilities.js';
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  // Inject userId from query param for tests (mimics session-auth middleware)
+  app.use((req, _res, next) => {
+    const userId = req.query['userId'] as string | undefined;
+    if (userId) {
+      (req as unknown as { user: { id: string } }).user = { id: userId };
+    }
+    next();
+  });
+  app.use('/api/capabilities', createCapabilitiesRouter());
+  app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(500).json({ error: err.message });
+  });
+  return app;
+}
+
+async function httpRequest(
+  app: Express,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close();
+        reject(new Error('Could not determine port'));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      const options: RequestInit = { method, headers };
+      if (body !== undefined) {
+        options.body = JSON.stringify(body);
+      }
+      fetch(url, options)
+        .then(async (res) => {
+          const json = await res.json().catch(() => null);
+          server.close();
+          resolve({ status: res.status, body: json });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+let app: Express;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockQuery.mockResolvedValue({ rows: [] });
+  app = buildApp();
+});
+
+// ---------------------------------------------------------------------------
+// GET /:id/changelog
+// ---------------------------------------------------------------------------
+
+describe('GET /api/capabilities/:id/changelog', () => {
+  const changelogRow = {
+    server_id: SERVER_ID,
+    current_version: '1.4.0',
+    raw_text: '## v1.4.0\n\nAdded create_database.',
+    fetched_at: new Date('2026-05-01'),
+    last_seen_skills: ['create_database', 'read_page'],
+    last_known_destructive_skills: ['create_database'],
+  };
+
+  it('returns changelog when owned by user', async () => {
+    mockMcpServerRepo.getById.mockResolvedValue({ id: SERVER_ID, user_id: USER_ID, status: 'active' });
+    mockChangelogRepo.getForServer.mockResolvedValue(changelogRow);
+
+    const { status, body } = await httpRequest(
+      app, 'GET',
+      `/api/capabilities/${SERVER_ID}/changelog?userId=${USER_ID}`,
+    );
+
+    expect(status).toBe(200);
+    expect((body as { changelog: { current_version: string } }).changelog.current_version).toBe('1.4.0');
+  });
+
+  it('returns 404 when no changelog has been fetched', async () => {
+    mockMcpServerRepo.getById.mockResolvedValue({ id: SERVER_ID, user_id: USER_ID, status: 'active' });
+    mockChangelogRepo.getForServer.mockResolvedValue(null);
+
+    const { status } = await httpRequest(
+      app, 'GET',
+      `/api/capabilities/${SERVER_ID}/changelog?userId=${USER_ID}`,
+    );
+    expect(status).toBe(404);
+  });
+
+  it('returns 403 when server belongs to another user', async () => {
+    mockMcpServerRepo.getById.mockResolvedValue({ id: SERVER_ID, user_id: 'other-user', status: 'active' });
+
+    const { status } = await httpRequest(
+      app, 'GET',
+      `/api/capabilities/${SERVER_ID}/changelog?userId=${USER_ID}`,
+    );
+    expect(status).toBe(403);
+  });
+
+  it('returns 400 for invalid UUID', async () => {
+    const { status } = await httpRequest(
+      app, 'GET',
+      '/api/capabilities/not-a-uuid/changelog?userId=x',
+    );
+    expect(status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /pending-opt-ins
+// ---------------------------------------------------------------------------
+
+describe('GET /api/capabilities/pending-opt-ins', () => {
+  it('returns pending opt-ins for the user', async () => {
+    mockChangelogRepo.listPendingOptInsForUser.mockResolvedValue([
+      {
+        id: OPT_IN_ID,
+        server_id: SERVER_ID,
+        skill_name: 'create_database',
+        changelog_version: '1.4.0',
+        detected_at: new Date('2026-05-01'),
+        accepted_at: null,
+        rejected_at: null,
+        server_display_name: 'Notion',
+        server_registry_id: '@notionhq/notion-mcp-server',
+      },
+    ]);
+
+    const { status, body } = await httpRequest(
+      app, 'GET',
+      `/api/capabilities/pending-opt-ins?userId=${USER_ID}`,
+    );
+
+    expect(status).toBe(200);
+    const b = body as { optIns: Array<{ skill_name: string }> };
+    expect(b.optIns).toHaveLength(1);
+    expect(b.optIns[0]?.skill_name).toBe('create_database');
+  });
+
+  it('returns empty array when no pending opt-ins', async () => {
+    mockChangelogRepo.listPendingOptInsForUser.mockResolvedValue([]);
+
+    const { status, body } = await httpRequest(
+      app, 'GET',
+      `/api/capabilities/pending-opt-ins?userId=${USER_ID}`,
+    );
+
+    expect(status).toBe(200);
+    expect((body as { optIns: unknown[] }).optIns).toHaveLength(0);
+  });
+
+  it('returns 400 when userId is missing', async () => {
+    const { status } = await httpRequest(
+      app, 'GET',
+      '/api/capabilities/pending-opt-ins',
+    );
+    expect(status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /pending-opt-ins/:id/accept
+// ---------------------------------------------------------------------------
+
+describe('POST /api/capabilities/pending-opt-ins/:id/accept', () => {
+  it('accepts the opt-in when ownership is verified', async () => {
+    mockChangelogRepo.listPendingOptInsForUser.mockResolvedValue([
+      {
+        id: OPT_IN_ID,
+        server_id: SERVER_ID,
+        skill_name: 'create_database',
+        changelog_version: '1.4.0',
+        detected_at: new Date(),
+        accepted_at: null,
+        rejected_at: null,
+        server_display_name: 'Notion',
+        server_registry_id: null,
+      },
+    ]);
+    mockChangelogRepo.acceptOptIn.mockResolvedValue({ found: true });
+
+    const { status } = await httpRequest(
+      app, 'POST',
+      `/api/capabilities/pending-opt-ins/${OPT_IN_ID}/accept?userId=${USER_ID}`,
+    );
+
+    expect(status).toBe(204);
+    expect(mockChangelogRepo.acceptOptIn).toHaveBeenCalledWith(OPT_IN_ID);
+  });
+
+  it('returns 404 when opt-in does not belong to user', async () => {
+    mockChangelogRepo.listPendingOptInsForUser.mockResolvedValue([]);
+
+    const { status } = await httpRequest(
+      app, 'POST',
+      `/api/capabilities/pending-opt-ins/${OPT_IN_ID}/accept?userId=${USER_ID}`,
+    );
+    expect(status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /pending-opt-ins/:id/reject
+// ---------------------------------------------------------------------------
+
+describe('POST /api/capabilities/pending-opt-ins/:id/reject', () => {
+  it('rejects the opt-in when ownership is verified', async () => {
+    mockChangelogRepo.listPendingOptInsForUser.mockResolvedValue([
+      {
+        id: OPT_IN_ID,
+        server_id: SERVER_ID,
+        skill_name: 'create_database',
+        changelog_version: null,
+        detected_at: new Date(),
+        accepted_at: null,
+        rejected_at: null,
+        server_display_name: 'Notion',
+        server_registry_id: null,
+      },
+    ]);
+    mockChangelogRepo.rejectOptIn.mockResolvedValue({ found: true });
+
+    const { status } = await httpRequest(
+      app, 'POST',
+      `/api/capabilities/pending-opt-ins/${OPT_IN_ID}/reject?userId=${USER_ID}`,
+    );
+
+    expect(status).toBe(204);
+    expect(mockChangelogRepo.rejectOptIn).toHaveBeenCalledWith(OPT_IN_ID);
+  });
+
+  it('returns 404 when opt-in does not belong to user', async () => {
+    mockChangelogRepo.listPendingOptInsForUser.mockResolvedValue([]);
+
+    const { status } = await httpRequest(
+      app, 'POST',
+      `/api/capabilities/pending-opt-ins/${OPT_IN_ID}/reject?userId=${USER_ID}`,
+    );
+    expect(status).toBe(404);
+  });
+});

--- a/apps/api/src/execution-setup.ts
+++ b/apps/api/src/execution-setup.ts
@@ -30,7 +30,7 @@ import {
 import { McpHost } from '@skytwin/mcp-host';
 import { sharedMetricsCollector } from '@skytwin/observability';
 import type { OpenClawCredentialRequirement } from '@skytwin/execution-router';
-import { credentialRequirementRepository, ironClawToolRepository, serviceCredentialRepository } from '@skytwin/db';
+import { credentialRequirementRepository, ironClawToolRepository, serviceCredentialRepository, mcpServerChangelogRepository } from '@skytwin/db';
 import { createLogger } from '@skytwin/core';
 import { sseManager } from './sse.js';
 
@@ -139,6 +139,9 @@ export async function createExecutionRouter(): Promise<ExecutionRouter> {
   // are added via the user-facing install flow (#176). On first boot the host
   // has zero servers and reports healthy with empty skill set.
   // onToolCall feeds the shared metrics collector for #183 observability.
+  // onChangelogFetch persists changelog snapshots to DB (#184 AC#2).
+  // checkPendingOptIn enforces the hard rail: destructive skills require
+  //   explicit user acceptance before the MCP host will invoke them.
   const mcpHost = new McpHost({
     onToolCall: (event) => {
       sharedMetricsCollector.record({
@@ -150,6 +153,22 @@ export async function createExecutionRouter(): Promise<ExecutionRouter> {
         ts: event.ts,
       });
     },
+    onChangelogFetch: (event) => {
+      // Best-effort — errors must never block execution
+      mcpServerChangelogRepository.upsert(event.serverId, {
+        currentVersion: event.currentVersion,
+        rawText: event.rawText ?? undefined,
+        lastSeenSkills: [],
+        lastKnownDestructiveSkills: [],
+      }).catch((err) => {
+        log.warn('onChangelogFetch: failed to persist changelog', {
+          serverId: event.serverId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    },
+    checkPendingOptIn: (serverId, skillName) =>
+      mcpServerChangelogRepository.hasPendingOptIn(serverId, skillName),
   });
   registry.register('mcp-host', mcpHost, MCP_HOST_TRUST_PROFILE);
   log.info('Registered MCP host adapter (Capability Acquisition Loop)');

--- a/apps/api/src/routes/capabilities.ts
+++ b/apps/api/src/routes/capabilities.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { mcpServerRepository, appSuggestionRepository, provenanceRepository, mcpServerMetricsRepository, query } from '@skytwin/db';
+import { mcpServerRepository, appSuggestionRepository, provenanceRepository, mcpServerMetricsRepository, mcpServerChangelogRepository, query } from '@skytwin/db';
 import type { McpServerRow } from '@skytwin/db';
 import type { Request } from 'express';
 import { createLogger } from '@skytwin/core';
@@ -1641,6 +1641,161 @@ export function createCapabilitiesRouter(): Router {
       }
 
       res.json({ nodes, edges });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GET /:id/changelog
+  //
+  // Returns the most recently fetched changelog snapshot for a server.
+  // Returns 404 if no changelog has been fetched yet.
+  // Ownership check: server must belong to the requesting user.
+  // Issue #184 AC#2 — Capability changelog flow.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.get('/:id/changelog', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      if (!id || !UUID_REGEX.test(id)) {
+        res.status(400).json({ error: 'id path param must be a UUID' });
+        return;
+      }
+
+      const userId: string | undefined = (req as unknown as { user?: { id?: string } }).user?.id
+        ?? (req.query['userId'] as string | undefined);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const server = await mcpServerRepository.getById(id);
+      if (!server) {
+        res.status(404).json({ error: 'Capability server not found' });
+        return;
+      }
+      if (server.user_id !== userId) {
+        res.status(403).json({ error: 'Forbidden: you do not own this capability server' });
+        return;
+      }
+
+      const changelog = await mcpServerChangelogRepository.getForServer(id);
+      if (!changelog) {
+        res.status(404).json({ error: 'No changelog fetched yet for this server' });
+        return;
+      }
+
+      res.json({ changelog });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GET /pending-opt-ins
+  //
+  // Returns all unresolved opt-in prompts for the requesting user.
+  // Used by the Capabilities page to surface the opt-in prompt feed.
+  // Issue #184 AC#2 — Capability changelog flow.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.get('/pending-opt-ins', async (req, res, next) => {
+    try {
+      const userId: string | undefined = (req as unknown as { user?: { id?: string } }).user?.id
+        ?? (req.query['userId'] as string | undefined);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const optIns = await mcpServerChangelogRepository.listPendingOptInsForUser(userId);
+      res.json({ optIns });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // POST /pending-opt-ins/:id/accept
+  //
+  // Accept a pending opt-in prompt.
+  // Verifies ownership via JOIN with mcp_servers (done in listPendingOptInsForUser
+  // cross-check — we re-check here by fetching and confirming user_id).
+  // Issue #184 AC#2 — Capability changelog flow.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.post('/pending-opt-ins/:id/accept', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      if (!id || !UUID_REGEX.test(id)) {
+        res.status(400).json({ error: 'id path param must be a UUID' });
+        return;
+      }
+
+      const userId: string | undefined = (req as unknown as { user?: { id?: string } }).user?.id
+        ?? (req.query['userId'] as string | undefined);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      // Ownership check: the opt-in must be for a server owned by this user.
+      // We re-use listPendingOptInsForUser which filters by user_id.
+      const userOptIns = await mcpServerChangelogRepository.listPendingOptInsForUser(userId);
+      const optIn = userOptIns.find((o) => o.id === id);
+      if (!optIn) {
+        res.status(404).json({ error: 'Pending opt-in not found or already resolved' });
+        return;
+      }
+
+      const result = await mcpServerChangelogRepository.acceptOptIn(id);
+      if (!result.found) {
+        res.status(409).json({ error: 'Opt-in already accepted or rejected' });
+        return;
+      }
+
+      log.info('Skill opt-in accepted', { userId, optInId: id, skillName: optIn.skill_name, serverId: optIn.server_id });
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // POST /pending-opt-ins/:id/reject
+  //
+  // Reject a pending opt-in prompt.
+  // Issue #184 AC#2 — Capability changelog flow.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.post('/pending-opt-ins/:id/reject', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      if (!id || !UUID_REGEX.test(id)) {
+        res.status(400).json({ error: 'id path param must be a UUID' });
+        return;
+      }
+
+      const userId: string | undefined = (req as unknown as { user?: { id?: string } }).user?.id
+        ?? (req.query['userId'] as string | undefined);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      // Ownership check: same pattern as accept above.
+      const userOptIns = await mcpServerChangelogRepository.listPendingOptInsForUser(userId);
+      const optIn = userOptIns.find((o) => o.id === id);
+      if (!optIn) {
+        res.status(404).json({ error: 'Pending opt-in not found or already resolved' });
+        return;
+      }
+
+      const result = await mcpServerChangelogRepository.rejectOptIn(id);
+      if (!result.found) {
+        res.status(409).json({ error: 'Opt-in already accepted or rejected' });
+        return;
+      }
+
+      log.info('Skill opt-in rejected', { userId, optInId: id, skillName: optIn.skill_name, serverId: optIn.server_id });
+      res.status(204).end();
     } catch (err) {
       next(err);
     }

--- a/apps/web/public/js/api-client.js
+++ b/apps/web/public/js/api-client.js
@@ -866,3 +866,25 @@ export function postOnboardingComplete(userId, choice, recipeSlug) {
     body: JSON.stringify({ choice, recipeSlug }),
   });
 }
+
+// ── Capability changelog + skill opt-ins (#184 AC#2) ─────────────────────────
+
+export function fetchCapabilityChangelog(serverId, userId) {
+  return fetchJSON(`${API}/capabilities/${encodeURIComponent(serverId)}/changelog?userId=${encodeURIComponent(userId)}`);
+}
+
+export function fetchPendingSkillOptIns(userId) {
+  return fetchJSON(`${API}/capabilities/pending-opt-ins?userId=${encodeURIComponent(userId)}`);
+}
+
+export function acceptSkillOptIn(optInId, userId) {
+  return fetchJSON(`${API}/capabilities/pending-opt-ins/${encodeURIComponent(optInId)}/accept?userId=${encodeURIComponent(userId)}`, {
+    method: 'POST',
+  });
+}
+
+export function rejectSkillOptIn(optInId, userId) {
+  return fetchJSON(`${API}/capabilities/pending-opt-ins/${encodeURIComponent(optInId)}/reject?userId=${encodeURIComponent(userId)}`, {
+    method: 'POST',
+  });
+}

--- a/apps/web/public/js/pages/capabilities.js
+++ b/apps/web/public/js/pages/capabilities.js
@@ -6,6 +6,9 @@ import {
   snoozeCapabilitySuggestion,
   installCapabilityRecipe,
   uninstallCapability,
+  fetchPendingSkillOptIns,
+  acceptSkillOptIn,
+  rejectSkillOptIn,
   escapeHtml,
   renderApiError,
   wireApiRetry,
@@ -31,6 +34,7 @@ let _cachedInstalled = [];
 let _cachedSuggestions = [];
 let _cachedDormant = [];
 let _cachedRecipes = [];
+let _cachedPendingOptIns = [];
 let _lastContainer = null;
 
 function getCurrentUserId() {
@@ -128,6 +132,16 @@ function handleCapabilitiesAction(e) {
       showToast('Reactivation not yet wired — coming soon.', { kind: 'info' });
       break;
     }
+    case 'accept-opt-in': {
+      const optInId = btn.getAttribute('data-opt-in-id');
+      if (optInId) handleAcceptOptIn(optInId, userId, btn);
+      break;
+    }
+    case 'reject-opt-in': {
+      const optInId = btn.getAttribute('data-opt-in-id');
+      if (optInId) handleRejectOptIn(optInId, userId, btn);
+      break;
+    }
   }
 }
 
@@ -142,6 +156,7 @@ export async function renderCapabilities(container, userId) {
 
   let capData;
   let recipesData;
+  let optInsData;
 
   try {
     [capData, recipesData] = await Promise.all([
@@ -157,13 +172,23 @@ export async function renderCapabilities(container, userId) {
     return;
   }
 
+  // Best-effort — don't block capabilities render if opt-ins fetch fails
+  try {
+    optInsData = await fetchPendingSkillOptIns(userId);
+  } catch {
+    optInsData = { optIns: [] };
+  }
+
   _cachedInstalled = capData.installed ?? [];
   _cachedSuggestions = capData.suggestions ?? [];
   _cachedDormant = capData.dormant ?? [];
   _cachedRecipes = recipesData.recipes ?? [];
+  _cachedPendingOptIns = optInsData.optIns ?? [];
 
   container.innerHTML = `
     <div style="display: flex; flex-direction: column; gap: 1.5rem;">
+
+      ${renderPendingOptInsSection(_cachedPendingOptIns)}
 
       ${renderSuggestionsSection(_cachedSuggestions)}
 
@@ -586,5 +611,104 @@ async function handleUninstall(serverId, userId, btn) {
   } catch (err) {
     showToast(err.friendlyMessage || err.message || 'Could not uninstall.', { kind: 'error' });
     if (btn) { btn.disabled = false; btn.textContent = 'Uninstall'; }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pending skill opt-ins (#184 AC#2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function renderPendingOptInsSection(optIns) {
+  if (!optIns || optIns.length === 0) return '';
+
+  return `
+    <div class="card" id="pending-opt-ins-section">
+      <div class="card-header">
+        <span class="card-title">New skills awaiting opt-in</span>
+        <span class="badge badge-warning">${optIns.length}</span>
+      </div>
+      <div class="card-subtitle" style="margin-bottom: 1rem;">
+        These destructive skills were added to installed servers since your last review.
+        You must explicitly accept each skill before it can be called.
+      </div>
+      <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+        ${optIns.map(renderOptInCard).join('')}
+      </div>
+    </div>
+  `;
+}
+
+function renderOptInCard(optIn) {
+  const version = optIn.changelog_version
+    ? `<span class="badge badge-muted" style="font-size: 0.72rem;">${escapeHtml(optIn.changelog_version)}</span>`
+    : '';
+  const serverName = optIn.server_display_name
+    ? escapeHtml(optIn.server_display_name)
+    : escapeHtml(optIn.server_id);
+
+  return `
+    <div id="opt-in-${escapeHtml(optIn.id)}" style="display: flex; align-items: center; justify-content: space-between; padding: 0.65rem 0.75rem; background: var(--bg); border-radius: var(--radius-sm); border-left: 3px solid var(--warning);">
+      <div style="min-width: 0;">
+        <div style="font-weight: 600; font-size: 0.9rem; font-family: monospace;">${escapeHtml(optIn.skill_name)}</div>
+        <div style="font-size: 0.75rem; color: var(--text-muted); margin-top: 0.1rem;">
+          ${serverName} ${version}
+        </div>
+      </div>
+      <div style="display: flex; gap: 0.4rem; align-items: center; flex-shrink: 0;">
+        <button class="btn btn-primary btn-sm"
+          data-action="accept-opt-in"
+          data-opt-in-id="${escapeHtml(optIn.id)}">Accept</button>
+        <button class="btn btn-outline btn-sm"
+          data-action="reject-opt-in"
+          data-opt-in-id="${escapeHtml(optIn.id)}"
+          style="color: var(--danger);">Reject</button>
+      </div>
+    </div>
+  `;
+}
+
+async function handleAcceptOptIn(optInId, userId, btn) {
+  if (btn) { btn.disabled = true; btn.textContent = 'Accepting…'; }
+  try {
+    await acceptSkillOptIn(optInId, userId);
+    const el = document.getElementById(`opt-in-${optInId}`);
+    if (el) {
+      el.style.opacity = '0.4';
+      el.style.pointerEvents = 'none';
+      const actionBtns = el.querySelectorAll('[data-action]');
+      actionBtns.forEach((b) => b.replaceWith(
+        Object.assign(document.createElement('span'), {
+          className: 'badge badge-success',
+          textContent: 'Accepted',
+        }),
+      ));
+    }
+    showToast('Skill opt-in accepted.', { kind: 'success' });
+  } catch (err) {
+    showToast(err.friendlyMessage || err.message || 'Could not accept opt-in.', { kind: 'error' });
+    if (btn) { btn.disabled = false; btn.textContent = 'Accept'; }
+  }
+}
+
+async function handleRejectOptIn(optInId, userId, btn) {
+  if (btn) { btn.disabled = true; btn.textContent = 'Rejecting…'; }
+  try {
+    await rejectSkillOptIn(optInId, userId);
+    const el = document.getElementById(`opt-in-${optInId}`);
+    if (el) {
+      el.style.opacity = '0.4';
+      el.style.pointerEvents = 'none';
+      const actionBtns = el.querySelectorAll('[data-action]');
+      actionBtns.forEach((b) => b.replaceWith(
+        Object.assign(document.createElement('span'), {
+          className: 'badge badge-muted',
+          textContent: 'Rejected',
+        }),
+      ));
+    }
+    showToast('Skill opt-in rejected.', { kind: 'info' });
+  } catch (err) {
+    showToast(err.friendlyMessage || err.message || 'Could not reject opt-in.', { kind: 'error' });
+    if (btn) { btn.disabled = false; btn.textContent = 'Reject'; }
   }
 }

--- a/apps/web/public/js/pages/capability-detail.js
+++ b/apps/web/public/js/pages/capability-detail.js
@@ -4,6 +4,7 @@ import {
   rehearseCapability,
   regretCapability,
   fetchCapabilityProvenance,
+  fetchCapabilityChangelog,
   escapeHtml,
   renderApiError,
   wireApiRetry,
@@ -194,6 +195,16 @@ export async function renderCapabilityDetail(container, userId, serverId) {
         </div>
       </div>
 
+      <!-- Changelog (#184 AC#2) -->
+      <div class="card" id="changelog-card">
+        <div class="card-header">
+          <span class="card-title">Changelog</span>
+        </div>
+        <div id="changelog-container">
+          <div style="color: var(--text-muted); font-size: 0.85rem;">Loading changelog…</div>
+        </div>
+      </div>
+
       <!-- Monthly cost meter (#183) -->
       <div class="card" id="monthly-cost-card">
         <div class="card-header">
@@ -271,9 +282,10 @@ export async function renderCapabilityDetail(container, userId, serverId) {
     </div>
   `;
 
-  // Best-effort: load sparklines and monthly cost meter asynchronously
+  // Best-effort: load sparklines, monthly cost meter, and changelog asynchronously
   loadSparklines(serverId, userId);
   loadMonthlyCostMeter(serverId, userId, server);
+  loadChangelog(serverId, userId);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -400,6 +412,51 @@ async function loadMonthlyCostMeter(serverId, userId, server) {
     `;
   } catch {
     el.innerHTML = '<div style="color: var(--text-muted); font-size: 0.82rem;">Spend data unavailable.</div>';
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Changelog card (#184 AC#2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function loadChangelog(serverId, userId) {
+  const el = document.getElementById('changelog-container');
+  if (!el) return;
+  try {
+    const data = await fetchCapabilityChangelog(serverId, userId);
+    const changelog = data.changelog;
+    if (!changelog) {
+      el.innerHTML = '<div style="color: var(--text-muted); font-size: 0.85rem;">No changelog published by this server.</div>';
+      return;
+    }
+
+    const version = changelog.current_version
+      ? `<span style="font-weight: 600; font-size: 1rem;">${escapeHtml(changelog.current_version)}</span>`
+      : '<span style="color: var(--text-muted); font-size: 0.85rem;">Version unknown</span>';
+
+    const fetchedAt = changelog.fetched_at
+      ? `<div style="font-size: 0.75rem; color: var(--text-dim); margin-top: 0.25rem;">Last fetched: ${escapeHtml(formatRelative(changelog.fetched_at))}</div>`
+      : '';
+
+    const rawHtml = changelog.raw_text
+      ? `<details style="margin-top: 0.75rem;">
+           <summary style="cursor: pointer; font-size: 0.85rem; color: var(--accent);">Show full changelog</summary>
+           <pre style="white-space: pre-wrap; word-break: break-word; font-size: 0.78rem; color: var(--text); margin-top: 0.5rem; background: var(--surface-2); padding: 0.75rem; border-radius: var(--radius-sm); overflow-x: auto;">${escapeHtml(changelog.raw_text)}</pre>
+         </details>`
+      : '<div style="font-size: 0.82rem; color: var(--text-muted); margin-top: 0.5rem;">No changelog text available.</div>';
+
+    el.innerHTML = `
+      <div>${version}</div>
+      ${fetchedAt}
+      ${rawHtml}
+    `;
+  } catch (err) {
+    // 404 means no changelog fetched yet — show a gentle nudge
+    if (err && err.kind === 'not-found') {
+      el.innerHTML = '<div style="color: var(--text-muted); font-size: 0.85rem;">No changelog fetched yet. The weekly sweep will check again soon.</div>';
+    } else {
+      el.innerHTML = '<div style="color: var(--text-muted); font-size: 0.82rem;">Changelog unavailable.</div>';
+    }
   }
 }
 

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@skytwin/capability-engine": "workspace:*",
+    "@skytwin/mcp-host": "workspace:*",
     "@skytwin/observability": "workspace:*",
     "@skytwin/config": "workspace:*",
     "@skytwin/connectors": "workspace:*",

--- a/apps/worker/src/__tests__/changelog-poll.test.ts
+++ b/apps/worker/src/__tests__/changelog-poll.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the job
+// ---------------------------------------------------------------------------
+
+const {
+  mockChangelogRepo,
+  mockServerRepo,
+} = vi.hoisted(() => ({
+  mockChangelogRepo: {
+    getForServer: vi.fn(),
+    upsert: vi.fn(),
+    addPendingOptIn: vi.fn(),
+    listPendingOptInsForUser: vi.fn(),
+    acceptOptIn: vi.fn(),
+    rejectOptIn: vi.fn(),
+    hasPendingOptIn: vi.fn(),
+  },
+  mockServerRepo: {
+    listActive: vi.fn(),
+    getById: vi.fn(),
+    markDormant: vi.fn(),
+    markActive: vi.fn(),
+  },
+}));
+
+vi.mock('@skytwin/db', () => ({
+  mcpServerChangelogRepository: mockChangelogRepo,
+  mcpServerRepository: mockServerRepo,
+}));
+
+// ---------------------------------------------------------------------------
+// Import job under test AFTER mocks are wired
+// ---------------------------------------------------------------------------
+
+import { runChangelogPollJob } from '../jobs/changelog-poll.js';
+import { McpHost, isDestructiveSkill } from '@skytwin/mcp-host';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeServer(overrides: {
+  id?: string;
+  display_name?: string;
+  user_id?: string;
+  status?: string;
+  transport?: 'stdio' | 'http' | 'sse';
+  command?: string | null;
+  args?: unknown;
+  env?: unknown;
+  url?: string | null;
+} = {}) {
+  return {
+    id: overrides.id ?? 'server-1',
+    display_name: overrides.display_name ?? 'Test Server',
+    user_id: overrides.user_id ?? 'user-1',
+    status: overrides.status ?? 'active',
+    transport: overrides.transport ?? ('stdio' as const),
+    command: overrides.command ?? null,
+    args: overrides.args ?? null,
+    env: overrides.env ?? null,
+    url: overrides.url ?? null,
+    registry_id: null,
+    trust_tier: 'observer' as const,
+    per_app_spend_per_action_cents: null,
+    per_app_daily_spend_cents: null,
+    per_app_monthly_spend_cents: null,
+    per_app_monthly_rollover: false,
+    per_app_irreversible_requires_approval: null,
+    zero_trust_mode: false,
+    last_health_check_at: null,
+    health_status: null,
+    last_active_at: null,
+    installed_at: null,
+    uninstalled_at: null,
+    auto_promote_paused_until: null,
+    created_at: new Date('2026-01-01'),
+    updated_at: new Date('2026-01-01'),
+    oauth_provider: null,
+    oauth_token_id: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockChangelogRepo.upsert.mockResolvedValue(undefined);
+  mockChangelogRepo.addPendingOptIn.mockResolvedValue(undefined);
+});
+
+describe('runChangelogPollJob', () => {
+  it('handles empty server list gracefully', async () => {
+    mockServerRepo.listActive.mockResolvedValue([]);
+
+    await expect(runChangelogPollJob({
+      changelogRepo: mockChangelogRepo,
+      serverRepo: mockServerRepo as unknown as typeof import('@skytwin/db').mcpServerRepository,
+    })).resolves.toBeUndefined();
+
+    expect(mockChangelogRepo.upsert).not.toHaveBeenCalled();
+  });
+
+  it('skips servers fetched within 12 hours', async () => {
+    const server = makeServer({ id: 'server-1' });
+    mockServerRepo.listActive.mockResolvedValue([server]);
+
+    // fetched_at is 1 hour ago — within 12h rate limit
+    mockChangelogRepo.getForServer.mockResolvedValue({
+      server_id: 'server-1',
+      fetched_at: new Date(Date.now() - 1 * 60 * 60 * 1000),
+      last_known_destructive_skills: [],
+    });
+
+    const mockFactory = vi.fn();
+
+    await runChangelogPollJob({
+      changelogRepo: mockChangelogRepo,
+      serverRepo: mockServerRepo as unknown as typeof import('@skytwin/db').mcpServerRepository,
+      mcpHostFactory: mockFactory,
+    });
+
+    // Rate-limited: no host created, no upsert
+    expect(mockFactory).not.toHaveBeenCalled();
+    expect(mockChangelogRepo.upsert).not.toHaveBeenCalled();
+  });
+
+  it('detects new destructive skills and creates pending opt-ins', async () => {
+    const server = makeServer({ id: 'server-1', display_name: 'Notion' });
+    mockServerRepo.listActive.mockResolvedValue([server]);
+
+    // No prior changelog — first fetch
+    mockChangelogRepo.getForServer.mockResolvedValue(null);
+
+    // Create a fake McpHost that knows about a new destructive skill
+    const mockHost = {
+      installServer: vi.fn().mockResolvedValue({ success: true }),
+      fetchChangelog: vi.fn().mockResolvedValue({
+        currentVersion: '1.4.0',
+        rawText: '## v1.4.0\n\nAdded create_database.',
+      }),
+      listSkills: vi.fn().mockResolvedValue({
+        success: true,
+        skills: [
+          { name: 'create_database' },
+          { name: 'read_page' },
+        ],
+      }),
+      uninstallServer: vi.fn().mockResolvedValue({ success: true }),
+    };
+
+    await runChangelogPollJob({
+      changelogRepo: mockChangelogRepo,
+      serverRepo: mockServerRepo as unknown as typeof import('@skytwin/db').mcpServerRepository,
+      mcpHostFactory: () => mockHost as unknown as McpHost,
+    });
+
+    // create_database is destructive — must create opt-in
+    expect(mockChangelogRepo.addPendingOptIn).toHaveBeenCalledWith(
+      'server-1',
+      'create_database',
+      '1.4.0',
+    );
+
+    // read_page is not destructive — no opt-in
+    const calls = mockChangelogRepo.addPendingOptIn.mock.calls;
+    const skillNames = calls.map((c) => c[1]);
+    expect(skillNames).not.toContain('read_page');
+
+    // Upsert the changelog row
+    expect(mockChangelogRepo.upsert).toHaveBeenCalledWith(
+      'server-1',
+      expect.objectContaining({
+        currentVersion: '1.4.0',
+        lastKnownDestructiveSkills: ['create_database'],
+      }),
+    );
+  });
+
+  it('does not create opt-ins for skills already in last_known_destructive_skills', async () => {
+    const server = makeServer({ id: 'server-1' });
+    mockServerRepo.listActive.mockResolvedValue([server]);
+
+    // create_database was already known — 12h+ ago
+    mockChangelogRepo.getForServer.mockResolvedValue({
+      server_id: 'server-1',
+      fetched_at: new Date(Date.now() - 13 * 60 * 60 * 1000),
+      last_known_destructive_skills: ['create_database'],
+    });
+
+    const mockHost = {
+      installServer: vi.fn().mockResolvedValue({ success: true }),
+      fetchChangelog: vi.fn().mockResolvedValue({ currentVersion: '1.4.0', rawText: '## v1.4.0' }),
+      listSkills: vi.fn().mockResolvedValue({
+        success: true,
+        skills: [{ name: 'create_database' }, { name: 'read_page' }],
+      }),
+      uninstallServer: vi.fn().mockResolvedValue({ success: true }),
+    };
+
+    await runChangelogPollJob({
+      changelogRepo: mockChangelogRepo,
+      serverRepo: mockServerRepo as unknown as typeof import('@skytwin/db').mcpServerRepository,
+      mcpHostFactory: () => mockHost as unknown as McpHost,
+    });
+
+    // No new opt-ins since create_database was already known
+    expect(mockChangelogRepo.addPendingOptIn).not.toHaveBeenCalled();
+  });
+
+  it('handles server connect failure gracefully and continues with other servers', async () => {
+    const server1 = makeServer({ id: 'server-1' });
+    const server2 = makeServer({ id: 'server-2', display_name: 'Other' });
+    mockServerRepo.listActive.mockResolvedValue([server1, server2]);
+
+    mockChangelogRepo.getForServer.mockResolvedValue(null);
+
+    let callCount = 0;
+    const mockFactory = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        // server-1 fails to connect
+        return {
+          installServer: vi.fn().mockResolvedValue({ success: false, error: 'connection refused' }),
+          fetchChangelog: vi.fn(),
+          listSkills: vi.fn(),
+          uninstallServer: vi.fn(),
+        } as unknown as McpHost;
+      }
+      // server-2 succeeds
+      return {
+        installServer: vi.fn().mockResolvedValue({ success: true }),
+        fetchChangelog: vi.fn().mockResolvedValue(null),
+        listSkills: vi.fn().mockResolvedValue({ success: true, skills: [] }),
+        uninstallServer: vi.fn().mockResolvedValue({ success: true }),
+      } as unknown as McpHost;
+    });
+
+    await runChangelogPollJob({
+      changelogRepo: mockChangelogRepo,
+      serverRepo: mockServerRepo as unknown as typeof import('@skytwin/db').mcpServerRepository,
+      mcpHostFactory: mockFactory,
+    });
+
+    // server-2 should still be upserted
+    expect(mockChangelogRepo.upsert).toHaveBeenCalledWith('server-2', expect.any(Object));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDestructiveSkill integration (quick smoke-test from worker perspective)
+// ---------------------------------------------------------------------------
+
+describe('isDestructiveSkill (worker integration)', () => {
+  it('correctly identifies destructive and non-destructive skills used in job', () => {
+    expect(isDestructiveSkill('create_database')).toBe(true);
+    expect(isDestructiveSkill('delete_record')).toBe(true);
+    expect(isDestructiveSkill('read_page')).toBe(false);
+    expect(isDestructiveSkill('list_issues')).toBe(false);
+  });
+});

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -23,6 +23,7 @@ import { withRetry, RetryableHttpError, CircuitBreaker, createLogger } from '@sk
 import { SignalDeduper, DEFAULT_TTL_MS } from './signal-dedupe.js';
 import { createPruneThrottle } from './label-signal-pruner.js';
 import { runMetricsRollupJob } from './jobs/metrics-rollup.js';
+import { runChangelogPollJob } from './jobs/changelog-poll.js';
 
 const config = loadConfig();
 const log = createLogger('worker');
@@ -458,6 +459,8 @@ async function main(): Promise<void> {
   let pollCount = 0;
   let lastMetricsRollupAt = 0;
   const METRICS_ROLLUP_INTERVAL_MS = 60_000;
+  let lastChangelogPollAt = 0;
+  const CHANGELOG_POLL_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
   // Poll loop
   while (running) {
@@ -472,6 +475,17 @@ async function main(): Promise<void> {
     if (nowMs - lastMetricsRollupAt >= METRICS_ROLLUP_INTERVAL_MS) {
       await runMetricsRollupJob();
       lastMetricsRollupAt = nowMs;
+    }
+
+    // Sweep MCP server changelogs weekly (#184 AC#2).
+    // Individual server errors are caught inside the job — never propagate here.
+    if (nowMs - lastChangelogPollAt >= CHANGELOG_POLL_INTERVAL_MS) {
+      await runChangelogPollJob().catch((err) => {
+        log.warn('Changelog poll job failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+      lastChangelogPollAt = nowMs;
     }
 
     // Expire stale approval requests every 10 poll cycles

--- a/apps/worker/src/jobs/changelog-poll.ts
+++ b/apps/worker/src/jobs/changelog-poll.ts
@@ -1,0 +1,155 @@
+import { createLogger } from '@skytwin/core';
+import { McpHost, isDestructiveSkill } from '@skytwin/mcp-host';
+import { mcpServerChangelogRepository, mcpServerRepository } from '@skytwin/db';
+import type { McpServerRow } from '@skytwin/db';
+import type { McpServerConfig } from '@skytwin/mcp-host';
+
+const log = createLogger('worker:changelog-poll');
+
+/** 12-hour rate limit: skip if fetched within this window. */
+const CHANGELOG_REFRESH_MIN_MS = 12 * 60 * 60 * 1000;
+
+export interface ChangelogPollDeps {
+  /**
+   * Inject for testing. If omitted, the job creates an ephemeral McpHost
+   * instance for each server. Because the worker does not hold live
+   * McpHost instances across jobs, this job instantiates a short-lived host,
+   * connects, polls, then disconnects.
+   */
+  mcpHostFactory?: (config: McpServerConfig) => McpHost;
+  /** Inject the repository for testing. */
+  changelogRepo?: typeof mcpServerChangelogRepository;
+  /** Inject the server repository for testing. */
+  serverRepo?: typeof mcpServerRepository;
+}
+
+/**
+ * Changelog poll job (#184 AC#2).
+ *
+ * For each installed MCP server:
+ *   1. Rate-limit: skip if fetched within the last 12 hours.
+ *   2. Fetch the changelog (changelog:// resource).
+ *   3. List current skills.
+ *   4. Diff against last_known_destructive_skills — create pending_skill_opt_ins
+ *      rows for each NEW destructive skill (idempotent via ON CONFLICT DO NOTHING).
+ *   5. Upsert the changelog snapshot.
+ *
+ * Intended to be called by the worker main loop with a 7-day timestamp gate.
+ * Individual server errors are caught and logged; they do not abort the job.
+ */
+export async function runChangelogPollJob(deps: ChangelogPollDeps = {}): Promise<void> {
+  const repo = deps.changelogRepo ?? mcpServerChangelogRepository;
+  const serverRepo = deps.serverRepo ?? mcpServerRepository;
+
+  log.info('Changelog poll job starting');
+
+  let servers: McpServerRow[];
+  try {
+    servers = await serverRepo.listActive();
+  } catch (err) {
+    log.warn('Changelog poll: could not list active servers', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  log.info(`Changelog poll: processing ${servers.length} active server(s)`);
+
+  for (const server of servers) {
+    try {
+      await pollServerChangelog(server, repo, deps.mcpHostFactory);
+    } catch (err) {
+      log.warn(`Changelog poll: error processing server ${server.id}`, {
+        serverId: server.id,
+        displayName: server.display_name,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  log.info('Changelog poll job complete');
+}
+
+async function pollServerChangelog(
+  server: McpServerRow,
+  repo: typeof mcpServerChangelogRepository,
+  mcpHostFactory?: (config: McpServerConfig) => McpHost,
+): Promise<void> {
+  // Rate-limit: skip if we fetched within the last 12 hours
+  const existing = await repo.getForServer(server.id);
+  if (existing) {
+    const ageMs = Date.now() - new Date(existing.fetched_at).getTime();
+    if (ageMs < CHANGELOG_REFRESH_MIN_MS) {
+      log.info(`Changelog poll: skipping ${server.display_name} (fetched ${Math.round(ageMs / 3600_000)}h ago)`);
+      return;
+    }
+  }
+
+  // Build a short-lived McpHost for this server
+  const config: McpServerConfig = {
+    id: server.id,
+    transport: server.transport,
+    command: server.command ?? undefined,
+    args: Array.isArray(server.args) ? (server.args as string[]) : undefined,
+    env: server.env != null && typeof server.env === 'object' && !Array.isArray(server.env)
+      ? (server.env as Record<string, string>)
+      : undefined,
+    url: server.url ?? undefined,
+  };
+
+  const host = mcpHostFactory ? mcpHostFactory(config) : new McpHost();
+
+  // In the poll job we can't actually connect to every server (they may not
+  // be running). We use a best-effort approach: try to install, fetch, clean up.
+  let installed = false;
+  try {
+    const installResult = await host.installServer(config);
+    if (!installResult.success) {
+      log.info(`Changelog poll: could not connect to ${server.display_name}: ${installResult.error}`);
+      return;
+    }
+    installed = true;
+
+    // Fetch changelog
+    const changelog = await host.fetchChangelog(server.id);
+
+    // List current skills
+    const skillsResult = await host.listSkills(server.id);
+    const currentSkills: string[] = skillsResult.success
+      ? skillsResult.skills.map((s) => s.name)
+      : [];
+
+    // Identify new destructive skills vs what we last knew
+    const lastKnownDestructive: string[] = existing?.last_known_destructive_skills ?? [];
+    const lastKnownSet = new Set(lastKnownDestructive);
+    const currentDestructive = currentSkills.filter((name) => isDestructiveSkill(name));
+
+    const newDestructiveSkills = currentDestructive.filter((name) => !lastKnownSet.has(name));
+
+    // Create opt-in prompts for newly discovered destructive skills
+    for (const skillName of newDestructiveSkills) {
+      log.info(`Changelog poll: new destructive skill detected on ${server.display_name}: ${skillName}`);
+      await repo.addPendingOptIn(server.id, skillName, changelog?.currentVersion);
+    }
+
+    // Upsert changelog row
+    await repo.upsert(server.id, {
+      currentVersion: changelog?.currentVersion,
+      rawText: changelog?.rawText,
+      lastSeenSkills: currentSkills,
+      lastKnownDestructiveSkills: currentDestructive,
+    });
+
+    log.info(`Changelog poll: updated ${server.display_name}`, {
+      version: changelog?.currentVersion ?? 'unknown',
+      skills: currentSkills.length,
+      newDestructive: newDestructiveSkills.length,
+    });
+  } finally {
+    if (installed) {
+      await host.uninstallServer(server.id).catch(() => {
+        // best-effort cleanup
+      });
+    }
+  }
+}

--- a/packages/db/src/__tests__/changelog-repository.test.ts
+++ b/packages/db/src/__tests__/changelog-repository.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock the connection module so no real DB is needed in unit tests.
+// We return a controllable "rows" result from query().
+// ---------------------------------------------------------------------------
+
+const mockRows: unknown[] = [];
+let mockThrow: Error | null = null;
+
+vi.mock('../connection.js', () => ({
+  query: vi.fn(async (_sql: string, _params?: unknown[]) => {
+    if (mockThrow) {
+      const err = mockThrow;
+      throw err;
+    }
+    return { rows: mockRows, rowCount: mockRows.length };
+  }),
+}));
+
+// Import after mock registration so the module picks up the mock.
+import { mcpServerChangelogRepository } from '../repositories/mcp-server-changelog-repository.js';
+import { query } from '../connection.js';
+
+const mockQuery = vi.mocked(query);
+
+const SERVER_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const OPT_IN_ID  = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const USER_ID    = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+beforeEach(() => {
+  mockRows.length = 0;
+  mockThrow = null;
+  mockQuery.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// upsert
+// ---------------------------------------------------------------------------
+
+describe('mcpServerChangelogRepository.upsert', () => {
+  it('calls INSERT ... ON CONFLICT with expected params', async () => {
+    await mcpServerChangelogRepository.upsert(SERVER_ID, {
+      currentVersion: '1.2.3',
+      rawText: '## v1.2.3\n\nAdded stuff.',
+      lastSeenSkills: ['read_file', 'create_file'],
+      lastKnownDestructiveSkills: ['create_file'],
+    });
+
+    expect(mockQuery).toHaveBeenCalledOnce();
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('ON CONFLICT');
+    expect(params[0]).toBe(SERVER_ID);
+    expect(params[1]).toBe('1.2.3');
+    expect(params[2]).toContain('Added stuff');
+  });
+
+  it('handles undefined optional fields (currentVersion, rawText)', async () => {
+    await mcpServerChangelogRepository.upsert(SERVER_ID, {
+      lastSeenSkills: [],
+      lastKnownDestructiveSkills: [],
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[1]).toBeNull(); // currentVersion
+    expect(params[2]).toBeNull(); // rawText
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getForServer
+// ---------------------------------------------------------------------------
+
+describe('mcpServerChangelogRepository.getForServer', () => {
+  it('returns null when no row found', async () => {
+    const result = await mcpServerChangelogRepository.getForServer(SERVER_ID);
+    expect(result).toBeNull();
+  });
+
+  it('returns the row when found', async () => {
+    mockRows.push({
+      server_id: SERVER_ID,
+      current_version: '2.0.0',
+      raw_text: '## v2.0.0\n\nBig update.',
+      fetched_at: new Date('2026-01-01'),
+      last_seen_skills: ['read_file'],
+      last_known_destructive_skills: [],
+    });
+
+    const result = await mcpServerChangelogRepository.getForServer(SERVER_ID);
+    expect(result).not.toBeNull();
+    expect(result?.current_version).toBe('2.0.0');
+    expect(result?.server_id).toBe(SERVER_ID);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addPendingOptIn
+// ---------------------------------------------------------------------------
+
+describe('mcpServerChangelogRepository.addPendingOptIn', () => {
+  it('calls INSERT ... ON CONFLICT DO NOTHING (idempotent)', async () => {
+    await mcpServerChangelogRepository.addPendingOptIn(SERVER_ID, 'create_database', '1.4.0');
+
+    expect(mockQuery).toHaveBeenCalledOnce();
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('ON CONFLICT');
+    expect(sql).toContain('DO NOTHING');
+    expect(params[0]).toBe(SERVER_ID);
+    expect(params[1]).toBe('create_database');
+    expect(params[2]).toBe('1.4.0');
+  });
+
+  it('passes null for changelogVersion when not provided', async () => {
+    await mcpServerChangelogRepository.addPendingOptIn(SERVER_ID, 'delete_record');
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[2]).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listPendingOptInsForUser
+// ---------------------------------------------------------------------------
+
+describe('mcpServerChangelogRepository.listPendingOptInsForUser', () => {
+  it('returns only pending rows (accepted_at and rejected_at are null)', async () => {
+    mockRows.push({
+      id: OPT_IN_ID,
+      server_id: SERVER_ID,
+      skill_name: 'create_database',
+      changelog_version: '1.4.0',
+      detected_at: new Date('2026-05-01'),
+      accepted_at: null,
+      rejected_at: null,
+      server_display_name: 'Notion',
+      server_registry_id: '@notionhq/notion-mcp-server',
+    });
+
+    const results = await mcpServerChangelogRepository.listPendingOptInsForUser(USER_ID);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.skill_name).toBe('create_database');
+    expect(results[0]?.server_display_name).toBe('Notion');
+    expect(results[0]?.accepted_at).toBeNull();
+    expect(results[0]?.rejected_at).toBeNull();
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('accepted_at IS NULL');
+    expect(sql).toContain('rejected_at IS NULL');
+    expect(params[0]).toBe(USER_ID);
+  });
+
+  it('returns empty array when no pending opt-ins exist', async () => {
+    const results = await mcpServerChangelogRepository.listPendingOptInsForUser(USER_ID);
+    expect(results).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// acceptOptIn / rejectOptIn
+// ---------------------------------------------------------------------------
+
+describe('mcpServerChangelogRepository.acceptOptIn', () => {
+  it('returns found:true when the row is updated', async () => {
+    mockRows.push({ id: OPT_IN_ID });
+    const result = await mcpServerChangelogRepository.acceptOptIn(OPT_IN_ID);
+    expect(result.found).toBe(true);
+
+    const [sql] = mockQuery.mock.calls[0] as [string];
+    expect(sql).toContain('accepted_at = now()');
+  });
+
+  it('returns found:false when no row is updated', async () => {
+    const result = await mcpServerChangelogRepository.acceptOptIn(OPT_IN_ID);
+    expect(result.found).toBe(false);
+  });
+});
+
+describe('mcpServerChangelogRepository.rejectOptIn', () => {
+  it('returns found:true when the row is updated', async () => {
+    mockRows.push({ id: OPT_IN_ID });
+    const result = await mcpServerChangelogRepository.rejectOptIn(OPT_IN_ID);
+    expect(result.found).toBe(true);
+
+    const [sql] = mockQuery.mock.calls[0] as [string];
+    expect(sql).toContain('rejected_at = now()');
+  });
+
+  it('returns found:false when no row is updated', async () => {
+    const result = await mcpServerChangelogRepository.rejectOptIn(OPT_IN_ID);
+    expect(result.found).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasPendingOptIn
+// ---------------------------------------------------------------------------
+
+describe('mcpServerChangelogRepository.hasPendingOptIn', () => {
+  it('returns true when a pending row exists', async () => {
+    mockRows.push({ id: OPT_IN_ID });
+    const result = await mcpServerChangelogRepository.hasPendingOptIn(SERVER_ID, 'create_database');
+    expect(result).toBe(true);
+  });
+
+  it('returns false when no pending row exists', async () => {
+    const result = await mcpServerChangelogRepository.hasPendingOptIn(SERVER_ID, 'read_file');
+    expect(result).toBe(false);
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -120,6 +120,13 @@ export type {
   SparklinePoint,
 } from './repositories/index.js';
 export type { ForwardedSignalRow } from './repositories/index.js';
+
+export { mcpServerChangelogRepository } from './repositories/index.js';
+export type {
+  McpServerChangelogRow,
+  UpsertChangelogInput,
+  PendingSkillOptInRow,
+} from './repositories/index.js';
 export type { ConnectorCursorRow } from './repositories/index.js';
 export type { SessionRow } from './repositories/index.js';
 export type {

--- a/packages/db/src/migrations/033-mcp-server-changelogs.sql
+++ b/packages/db/src/migrations/033-mcp-server-changelogs.sql
@@ -1,0 +1,31 @@
+-- 033-mcp-server-changelogs.sql
+-- Stores the most recent changelog snapshot for each installed MCP server.
+-- One row per server. Updated on install, on list_tools refresh, and on the
+-- weekly worker sweep.
+--
+-- Issue #184 AC#2 — Capability changelog flow + new-skill opt-in.
+
+CREATE TABLE IF NOT EXISTS mcp_server_changelogs (
+  server_id UUID PRIMARY KEY REFERENCES mcp_servers(id) ON DELETE CASCADE,
+  current_version STRING,
+  raw_text STRING,
+  fetched_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen_skills JSONB NOT NULL DEFAULT '[]',
+  last_known_destructive_skills JSONB NOT NULL DEFAULT '[]'
+);
+
+-- Pending opt-in prompts for newly added destructive skills. The user must
+-- explicitly accept before the new skill becomes callable on this server.
+CREATE TABLE IF NOT EXISTS pending_skill_opt_ins (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  server_id UUID NOT NULL REFERENCES mcp_servers(id) ON DELETE CASCADE,
+  skill_name STRING NOT NULL,
+  changelog_version STRING,
+  detected_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  accepted_at TIMESTAMPTZ,
+  rejected_at TIMESTAMPTZ,
+  UNIQUE (server_id, skill_name)
+);
+
+CREATE INDEX IF NOT EXISTS pending_skill_opt_ins_pending_idx
+  ON pending_skill_opt_ins (server_id) WHERE accepted_at IS NULL AND rejected_at IS NULL;

--- a/packages/db/src/repositories/index.ts
+++ b/packages/db/src/repositories/index.ts
@@ -152,3 +152,10 @@ export type {
   MetricsBucketRow,
   SparklinePoint,
 } from './mcp-server-metrics-repository.js';
+
+export { mcpServerChangelogRepository } from './mcp-server-changelog-repository.js';
+export type {
+  McpServerChangelogRow,
+  UpsertChangelogInput,
+  PendingSkillOptInRow,
+} from './mcp-server-changelog-repository.js';

--- a/packages/db/src/repositories/mcp-server-changelog-repository.ts
+++ b/packages/db/src/repositories/mcp-server-changelog-repository.ts
@@ -1,0 +1,170 @@
+import { query } from '../connection.js';
+
+/**
+ * Repository for mcp_server_changelogs and pending_skill_opt_ins.
+ *
+ * Schema: packages/db/src/migrations/033-mcp-server-changelogs.sql
+ * Issue #184 AC#2 — Capability changelog flow + new-skill opt-in.
+ */
+
+export interface McpServerChangelogRow {
+  server_id: string;
+  current_version: string | null;
+  raw_text: string | null;
+  fetched_at: Date;
+  last_seen_skills: string[];
+  last_known_destructive_skills: string[];
+}
+
+export interface UpsertChangelogInput {
+  currentVersion?: string;
+  rawText?: string;
+  lastSeenSkills: string[];
+  lastKnownDestructiveSkills: string[];
+}
+
+export interface PendingSkillOptInRow {
+  id: string;
+  server_id: string;
+  skill_name: string;
+  changelog_version: string | null;
+  detected_at: Date;
+  accepted_at: Date | null;
+  rejected_at: Date | null;
+}
+
+export const mcpServerChangelogRepository = {
+  /**
+   * Upsert the changelog snapshot for a server.
+   * On conflict (same server_id), updates all fields atomically.
+   * Rate-limit enforcement (12h window) is the caller's responsibility
+   * via the fetched_at column.
+   */
+  async upsert(serverId: string, input: UpsertChangelogInput): Promise<void> {
+    await query(
+      `INSERT INTO mcp_server_changelogs
+         (server_id, current_version, raw_text, fetched_at,
+          last_seen_skills, last_known_destructive_skills)
+       VALUES ($1, $2, $3, now(), $4::jsonb, $5::jsonb)
+       ON CONFLICT (server_id) DO UPDATE SET
+         current_version              = EXCLUDED.current_version,
+         raw_text                     = EXCLUDED.raw_text,
+         fetched_at                   = EXCLUDED.fetched_at,
+         last_seen_skills             = EXCLUDED.last_seen_skills,
+         last_known_destructive_skills = EXCLUDED.last_known_destructive_skills`,
+      [
+        serverId,
+        input.currentVersion ?? null,
+        input.rawText ?? null,
+        JSON.stringify(input.lastSeenSkills),
+        JSON.stringify(input.lastKnownDestructiveSkills),
+      ],
+    );
+  },
+
+  /**
+   * Return the changelog row for a server, or null if none exists.
+   */
+  async getForServer(serverId: string): Promise<McpServerChangelogRow | null> {
+    const result = await query<McpServerChangelogRow>(
+      `SELECT server_id, current_version, raw_text, fetched_at,
+              last_seen_skills, last_known_destructive_skills
+       FROM mcp_server_changelogs
+       WHERE server_id = $1`,
+      [serverId],
+    );
+    return result.rows[0] ?? null;
+  },
+
+  /**
+   * Insert a pending opt-in row for a newly discovered destructive skill.
+   * ON CONFLICT DO NOTHING — idempotent; safe to call on every poll.
+   */
+  async addPendingOptIn(
+    serverId: string,
+    skillName: string,
+    changelogVersion?: string,
+  ): Promise<void> {
+    await query(
+      `INSERT INTO pending_skill_opt_ins (server_id, skill_name, changelog_version)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (server_id, skill_name) DO NOTHING`,
+      [serverId, skillName, changelogVersion ?? null],
+    );
+  },
+
+  /**
+   * List all unresolved opt-in prompts for a user.
+   * JOINs with mcp_servers to scope by user_id.
+   * Only returns rows where accepted_at IS NULL AND rejected_at IS NULL.
+   */
+  async listPendingOptInsForUser(
+    userId: string,
+  ): Promise<Array<PendingSkillOptInRow & { server_display_name: string; server_registry_id: string | null }>> {
+    const result = await query<
+      PendingSkillOptInRow & { server_display_name: string; server_registry_id: string | null }
+    >(
+      `SELECT p.id, p.server_id, p.skill_name, p.changelog_version,
+              p.detected_at, p.accepted_at, p.rejected_at,
+              ms.display_name AS server_display_name,
+              ms.registry_id  AS server_registry_id
+       FROM pending_skill_opt_ins p
+       JOIN mcp_servers ms ON ms.id = p.server_id
+       WHERE ms.user_id = $1
+         AND p.accepted_at IS NULL
+         AND p.rejected_at IS NULL
+       ORDER BY p.detected_at DESC`,
+      [userId],
+    );
+    return result.rows;
+  },
+
+  /**
+   * Accept an opt-in prompt. Sets accepted_at = now().
+   */
+  async acceptOptIn(id: string): Promise<{ found: boolean }> {
+    const result = await query<{ id: string }>(
+      `UPDATE pending_skill_opt_ins
+       SET accepted_at = now()
+       WHERE id = $1
+         AND accepted_at IS NULL
+         AND rejected_at IS NULL
+       RETURNING id`,
+      [id],
+    );
+    return { found: result.rows.length > 0 };
+  },
+
+  /**
+   * Reject an opt-in prompt. Sets rejected_at = now().
+   */
+  async rejectOptIn(id: string): Promise<{ found: boolean }> {
+    const result = await query<{ id: string }>(
+      `UPDATE pending_skill_opt_ins
+       SET rejected_at = now()
+       WHERE id = $1
+         AND accepted_at IS NULL
+         AND rejected_at IS NULL
+       RETURNING id`,
+      [id],
+    );
+    return { found: result.rows.length > 0 };
+  },
+
+  /**
+   * Check whether a given skill on a given server has an unaccepted
+   * pending opt-in (i.e. the hard rail — block execution until accepted).
+   */
+  async hasPendingOptIn(serverId: string, skillName: string): Promise<boolean> {
+    const result = await query<{ id: string }>(
+      `SELECT id FROM pending_skill_opt_ins
+       WHERE server_id = $1
+         AND skill_name = $2
+         AND accepted_at IS NULL
+         AND rejected_at IS NULL
+       LIMIT 1`,
+      [serverId, skillName],
+    );
+    return result.rows.length > 0;
+  },
+};

--- a/packages/mcp-host/src/__tests__/changelog.test.ts
+++ b/packages/mcp-host/src/__tests__/changelog.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CircuitBreaker } from '@skytwin/core';
+import { McpHost, isDestructiveSkill } from '../mcp-host.js';
+import type { McpServerConfig } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Fake MCP Client for changelog tests
+//
+// Extends the base fake with listResources + readResource support.
+// ---------------------------------------------------------------------------
+
+interface FakeResourceOpts {
+  resources?: Array<{ uri: string; name?: string }>;
+  resourceText?: string;
+  listResourcesThrows?: boolean;
+  readResourceThrows?: boolean;
+}
+
+function makeFakeChangelogClient(opts: FakeResourceOpts = {}) {
+  return {
+    async connect(_transport: unknown): Promise<void> {},
+    async close(): Promise<void> {},
+    async ping(): Promise<void> {},
+    async listTools(): Promise<{ tools: Array<{ name: string }> }> {
+      return { tools: [] };
+    },
+    async callTool(_params: unknown): Promise<unknown> {
+      return { ok: true };
+    },
+    async listResources(): Promise<{ resources: Array<{ uri: string; name?: string }> }> {
+      if (opts.listResourcesThrows) {
+        throw new Error('listResources not supported');
+      }
+      return { resources: opts.resources ?? [] };
+    },
+    async readResource(_params: { uri: string }): Promise<{
+      contents: Array<{ type: string; text: string }>;
+    }> {
+      if (opts.readResourceThrows) {
+        throw new Error('readResource failed');
+      }
+      return {
+        contents: [{ type: 'text', text: opts.resourceText ?? '' }],
+      };
+    },
+  };
+}
+
+type FakeChangelogClient = ReturnType<typeof makeFakeChangelogClient>;
+
+interface InternalServerEntry {
+  config: McpServerConfig;
+  handle: {
+    id: string;
+    status: 'starting' | 'running' | 'failed' | 'stopped';
+    startedAt?: Date;
+  };
+  client: FakeChangelogClient;
+  circuit: CircuitBreaker;
+  stop: () => void;
+}
+
+function injectFakeServer(host: McpHost, config: McpServerConfig, client: FakeChangelogClient): void {
+  const circuit = new CircuitBreaker(`mcp:${config.id}`, {
+    failureThreshold: 3,
+    resetTimeoutMs: 60_000,
+  });
+  const entry: InternalServerEntry = {
+    config,
+    handle: { id: config.id, status: 'running', startedAt: new Date() },
+    client,
+    circuit,
+    stop: () => {},
+  };
+  const internalServers = (host as unknown as { servers: Map<string, InternalServerEntry> })
+    .servers;
+  internalServers.set(config.id, entry);
+}
+
+const serverConfig: McpServerConfig = {
+  id: 'test-server',
+  transport: 'stdio',
+  command: 'node',
+  args: ['fake-server.js'],
+};
+
+// ---------------------------------------------------------------------------
+// fetchChangelog tests
+// ---------------------------------------------------------------------------
+
+describe('McpHost.fetchChangelog', () => {
+  let host: McpHost;
+
+  beforeEach(() => {
+    host = new McpHost();
+  });
+
+  it('returns null when the server is not installed', async () => {
+    const result = await host.fetchChangelog('nonexistent-server');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when listResources is not supported (throws)', async () => {
+    const client = makeFakeChangelogClient({ listResourcesThrows: true });
+    injectFakeServer(host, serverConfig, client);
+    const result = await host.fetchChangelog(serverConfig.id);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no changelog:// resource is present', async () => {
+    const client = makeFakeChangelogClient({
+      resources: [{ uri: 'memory://context', name: 'Memory' }],
+    });
+    injectFakeServer(host, serverConfig, client);
+    const result = await host.fetchChangelog(serverConfig.id);
+    expect(result).toBeNull();
+  });
+
+  it('returns rawText when a changelog:// resource is present', async () => {
+    const client = makeFakeChangelogClient({
+      resources: [{ uri: 'changelog://CHANGELOG.md', name: 'Changelog' }],
+      resourceText: '## v1.2.3\n\nAdded create_database tool.',
+    });
+    injectFakeServer(host, serverConfig, client);
+    const result = await host.fetchChangelog(serverConfig.id);
+    expect(result).not.toBeNull();
+    expect(result?.rawText).toContain('Added create_database tool');
+  });
+
+  it('extracts currentVersion from ## vX.Y.Z heading', async () => {
+    const client = makeFakeChangelogClient({
+      resources: [{ uri: 'changelog://CHANGELOG.md' }],
+      resourceText: '## v2.0.1\n\nBug fixes.',
+    });
+    injectFakeServer(host, serverConfig, client);
+    const result = await host.fetchChangelog(serverConfig.id);
+    expect(result?.currentVersion).toBe('2.0.1');
+  });
+
+  it('extracts currentVersion from # X.Y.Z heading (no v prefix)', async () => {
+    const client = makeFakeChangelogClient({
+      resources: [{ uri: 'changelog://CHANGELOG.md' }],
+      resourceText: '# 3.1.0\n\nNew features.',
+    });
+    injectFakeServer(host, serverConfig, client);
+    const result = await host.fetchChangelog(serverConfig.id);
+    expect(result?.currentVersion).toBe('3.1.0');
+  });
+
+  it('returns null when readResource throws', async () => {
+    const client = makeFakeChangelogClient({
+      resources: [{ uri: 'changelog://CHANGELOG.md' }],
+      readResourceThrows: true,
+    });
+    injectFakeServer(host, serverConfig, client);
+    const result = await host.fetchChangelog(serverConfig.id);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDestructiveSkill heuristic tests
+// ---------------------------------------------------------------------------
+
+describe('isDestructiveSkill', () => {
+  it('returns true for names containing "create"', () => {
+    expect(isDestructiveSkill('create_database')).toBe(true);
+    expect(isDestructiveSkill('batch_create_issues')).toBe(true);
+  });
+
+  it('returns true for names containing "delete"', () => {
+    expect(isDestructiveSkill('delete_file')).toBe(true);
+    expect(isDestructiveSkill('delete')).toBe(true);
+  });
+
+  it('returns true for names containing "update"', () => {
+    expect(isDestructiveSkill('update_record')).toBe(true);
+  });
+
+  it('returns true for names containing "send"', () => {
+    expect(isDestructiveSkill('send_email')).toBe(true);
+    expect(isDestructiveSkill('unsend_message')).toBe(true);
+  });
+
+  it('returns true for names containing "write"', () => {
+    expect(isDestructiveSkill('filesystem_write')).toBe(true);
+    expect(isDestructiveSkill('write_page')).toBe(true);
+  });
+
+  it('returns true for names containing "remove"', () => {
+    expect(isDestructiveSkill('remove_label')).toBe(true);
+  });
+
+  it('returns true for names containing "commit"', () => {
+    expect(isDestructiveSkill('git_commit')).toBe(true);
+  });
+
+  it('returns true for names containing "mutate"', () => {
+    expect(isDestructiveSkill('mutate_graph')).toBe(true);
+  });
+
+  it('returns false for read-only skill names', () => {
+    expect(isDestructiveSkill('read_file')).toBe(false);
+    expect(isDestructiveSkill('list_issues')).toBe(false);
+    expect(isDestructiveSkill('get_calendar_events')).toBe(false);
+    expect(isDestructiveSkill('search_emails')).toBe(false);
+    expect(isDestructiveSkill('describe_table')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isDestructiveSkill('CREATE_TABLE')).toBe(true);
+    expect(isDestructiveSkill('DELETE_RECORD')).toBe(true);
+    expect(isDestructiveSkill('Send_Message')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hard-rail opt-in check in execute
+// ---------------------------------------------------------------------------
+
+describe('McpHost execute hard-rail (pending opt-in)', () => {
+  it('blocks execution when checkPendingOptIn returns true for a destructive skill', async () => {
+    const checkPendingOptIn = vi.fn().mockResolvedValue(true);
+    const blockedHost = new McpHost({ checkPendingOptIn });
+
+    const client = makeFakeChangelogClient();
+    injectFakeServer(blockedHost, serverConfig, client);
+
+    const plan = {
+      id: 'plan-1',
+      decisionId: 'decision-1',
+      action: {} as never,
+      steps: [
+        {
+          id: 'step-1',
+          order: 1,
+          type: 'send_email',
+          description: 'test',
+          parameters: { _mcpServerId: serverConfig.id, _mcpToolName: 'send_email' },
+          timeout: 5000,
+        },
+      ],
+      rollbackSteps: [],
+      createdAt: new Date(),
+    };
+
+    const result = await blockedHost.execute(plan);
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('requires explicit opt-in');
+    expect(checkPendingOptIn).toHaveBeenCalledWith(serverConfig.id, 'send_email');
+  });
+
+  it('allows execution when checkPendingOptIn returns false', async () => {
+    const checkPendingOptIn = vi.fn().mockResolvedValue(false);
+
+    // We need a real client that can handle callTool
+    const fakeClient = {
+      async connect(_transport: unknown) {},
+      async close() {},
+      async ping() {},
+      async listTools() { return { tools: [] }; },
+      async callTool() { return { ok: true }; },
+      async listResources() { return { resources: [] }; },
+      async readResource() { return { contents: [] }; },
+    };
+
+    const allowedHost = new McpHost({ checkPendingOptIn });
+    const circuit = new CircuitBreaker(`mcp:${serverConfig.id}`, { failureThreshold: 3, resetTimeoutMs: 60_000 });
+    const entry = { config: serverConfig, handle: { id: serverConfig.id, status: 'running' as const }, client: fakeClient, circuit, stop: () => {} };
+    (allowedHost as unknown as { servers: Map<string, typeof entry> }).servers.set(serverConfig.id, entry);
+
+    const plan = {
+      id: 'plan-2',
+      decisionId: 'decision-2',
+      action: {} as never,
+      steps: [
+        {
+          id: 'step-2',
+          order: 1,
+          type: 'send_email',
+          description: 'test',
+          parameters: { _mcpServerId: serverConfig.id, _mcpToolName: 'send_email' },
+          timeout: 5000,
+        },
+      ],
+      rollbackSteps: [],
+      createdAt: new Date(),
+    };
+
+    const result = await allowedHost.execute(plan);
+    expect(result.status).toBe('completed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onChangelogFetch hook tests
+// ---------------------------------------------------------------------------
+
+describe('McpHost onChangelogFetch hook', () => {
+  it('fires onChangelogFetch after installServer succeeds', async () => {
+    const events: Array<{ serverId: string; rawText: string | null }> = [];
+
+    // We cannot do a real installServer in unit tests (needs real transport).
+    // Instead, test that the hook is wired by calling fetchChangelog directly
+    // and verifying emitChangelogFetch behavior via the hook option.
+    const client = makeFakeChangelogClient({
+      resources: [{ uri: 'changelog://CHANGELOG.md' }],
+      resourceText: '## v1.0.0\n\nInitial release.',
+    });
+
+    const hostWithHook = new McpHost({
+      onChangelogFetch: (event) => {
+        events.push({ serverId: event.serverId, rawText: event.rawText });
+      },
+    });
+
+    injectFakeServer(hostWithHook, serverConfig, client);
+
+    // Simulate what installServer does: call fetchChangelog and emitChangelogFetch
+    const changelog = await hostWithHook.fetchChangelog(serverConfig.id);
+    const emitFn = (hostWithHook as unknown as { emitChangelogFetch: (e: { serverId: string; rawText: string | null; currentVersion?: string }) => void }).emitChangelogFetch;
+    emitFn.call(hostWithHook, {
+      serverId: serverConfig.id,
+      rawText: changelog?.rawText ?? null,
+      currentVersion: changelog?.currentVersion,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.serverId).toBe(serverConfig.id);
+    expect(events[0]?.rawText).toContain('Initial release');
+  });
+
+  it('onChangelogFetch errors do not propagate', () => {
+    const hostWithThrowingHook = new McpHost({
+      onChangelogFetch: () => {
+        throw new Error('hook blew up');
+      },
+    });
+
+    const emitFn = (hostWithThrowingHook as unknown as { emitChangelogFetch: (e: { serverId: string; rawText: string | null }) => void }).emitChangelogFetch;
+    // Should not throw
+    expect(() => emitFn.call(hostWithThrowingHook, { serverId: 'x', rawText: null })).not.toThrow();
+  });
+});

--- a/packages/mcp-host/src/index.ts
+++ b/packages/mcp-host/src/index.ts
@@ -1,5 +1,9 @@
-export { McpHost } from './mcp-host.js';
-export type { McpHostOptions, McpHostToolCallEvent } from './mcp-host.js';
+export { McpHost, isDestructiveSkill } from './mcp-host.js';
+export type {
+  McpHostOptions,
+  McpHostToolCallEvent,
+  McpHostChangelogFetchEvent,
+} from './mcp-host.js';
 
 export type {
   McpTransport,

--- a/packages/mcp-host/src/mcp-host.ts
+++ b/packages/mcp-host/src/mcp-host.ts
@@ -65,17 +65,76 @@ export interface McpHostToolCallEvent {
   ts: Date;
 }
 
+/**
+ * Hook fired after a changelog fetch (at install time, on list_tools refresh,
+ * or weekly sweep). rawText is null when the server has no changelog:// resource.
+ * Failures inside the hook are swallowed so changelog fetches never block install.
+ */
+export interface McpHostChangelogFetchEvent {
+  serverId: string;
+  rawText: string | null;
+  currentVersion?: string;
+}
+
 export interface McpHostOptions {
   onToolCall?: (event: McpHostToolCallEvent) => void;
+  /** Optional hook fired after each changelog fetch. Errors are swallowed. */
+  onChangelogFetch?: (event: McpHostChangelogFetchEvent) => void;
+  /**
+   * Hard-rail hook (#184 AC#2): called before executing a tool to check
+   * whether the user has an unaccepted pending opt-in for this skill.
+   *
+   * If this returns true, the execution is blocked with a 'failed' result
+   * and an explanatory error message. Callers should inject this from the
+   * DB layer (mcpServerChangelogRepository.hasPendingOptIn). Omit in tests
+   * or contexts where the DB is not available.
+   *
+   * This is an async callback so the DB round-trip stays outside mcp-host.
+   */
+  checkPendingOptIn?: (serverId: string, skillName: string) => Promise<boolean>;
+}
+
+// ─── Destructive skill heuristic ─────────────────────────────────────────────
+// A skill is considered destructive if its name contains any of the following
+// verb prefixes. This is a conservative over-approximation — false positives
+// are safer than false negatives for opt-in gate purposes.
+const DESTRUCTIVE_PREFIXES = [
+  'create', 'delete', 'update', 'write', 'send', 'post',
+  'commit', 'push', 'merge', 'mutate', 'set', 'remove',
+] as const;
+
+/**
+ * Returns true if the skill name matches the destructive-skill heuristic.
+ *
+ * The check is case-insensitive and matches anywhere in the skill name so
+ * that compound names like `batch_create_issues` or `filesystem_write` are
+ * correctly flagged.
+ */
+export function isDestructiveSkill(skillName: string): boolean {
+  const lower = skillName.toLowerCase();
+  return DESTRUCTIVE_PREFIXES.some((prefix) => lower.includes(prefix));
+}
+
+// ─── Version-heading extraction ───────────────────────────────────────────────
+// Looks for `## v1.2.3` or `# 1.2.3` style headings in the changelog text.
+const VERSION_HEADING_RE = /^#{1,3}\s+v?([\d]+\.[\d]+(?:\.[\d]+)?(?:-[a-zA-Z0-9.]+)?)\b/m;
+
+function extractVersionFromChangelog(text: string): string | undefined {
+  const match = VERSION_HEADING_RE.exec(text);
+  return match?.[1] ?? undefined;
 }
 
 export class McpHost implements IronClawAdapter {
   private readonly servers = new Map<string, ServerEntry>();
   private readonly executions = new Map<string, McpExecutionLog>();
   private readonly onToolCall: ((event: McpHostToolCallEvent) => void) | undefined;
+  private readonly onChangelogFetch: ((event: McpHostChangelogFetchEvent) => void) | undefined;
+  private readonly checkPendingOptIn: ((serverId: string, skillName: string) => Promise<boolean>) | undefined;
 
   constructor(options: McpHostOptions = {}) {
     this.onToolCall = options.onToolCall;
+    this.onChangelogFetch = options.onChangelogFetch;
+    this.checkPendingOptIn = options.checkPendingOptIn;
   }
 
   private emitToolCall(event: McpHostToolCallEvent): void {
@@ -84,6 +143,15 @@ export class McpHost implements IronClawAdapter {
       this.onToolCall(event);
     } catch {
       // observability hook must never block execution
+    }
+  }
+
+  private emitChangelogFetch(event: McpHostChangelogFetchEvent): void {
+    if (!this.onChangelogFetch) return;
+    try {
+      this.onChangelogFetch(event);
+    } catch {
+      // changelog hook must never block execution
     }
   }
 
@@ -155,6 +223,19 @@ export class McpHost implements IronClawAdapter {
       handle.startedAt = new Date();
 
       this.servers.set(config.id, { config, handle, client, circuit, stop });
+
+      // Best-effort changelog fetch at install time (#184 AC#2).
+      // Errors are swallowed — a failing changelog fetch must never block install.
+      this.fetchChangelog(config.id).then((changelog) => {
+        this.emitChangelogFetch({
+          serverId: config.id,
+          rawText: changelog?.rawText ?? null,
+          currentVersion: changelog?.currentVersion,
+        });
+      }).catch(() => {
+        // Swallow — best effort
+      });
+
       return { success: true };
     } catch (err) {
       handle.status = 'failed';
@@ -208,6 +289,52 @@ export class McpHost implements IronClawAdapter {
       return { success: true, skills };
     } catch (err) {
       return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /**
+   * Fetch the upstream server's changelog via the `changelog://` MCP resource
+   * convention (issue #184 AC#2).
+   *
+   * 1. Calls client.listResources() to discover resources.
+   * 2. If a resource with URI starting with `changelog://` is found, reads it.
+   * 3. Extracts a heuristic version from the first `## vX.Y.Z` or `# X.Y.Z` heading.
+   * 4. Returns null (best-effort) if:
+   *    - The server is not installed.
+   *    - listResources is not supported (throws).
+   *    - No changelog:// resource is present.
+   *
+   * Rate-limit enforcement (12h cadence) is the caller's responsibility —
+   * this method always attempts the fetch when called.
+   */
+  async fetchChangelog(serverId: string): Promise<{ currentVersion?: string; rawText?: string } | null> {
+    const entry = this.servers.get(serverId);
+    if (!entry) return null;
+
+    let resources: Array<{ uri: string }>;
+    try {
+      const listResult = await entry.client.listResources();
+      resources = (listResult.resources ?? []) as Array<{ uri: string }>;
+    } catch {
+      // listResources not supported by this server — best effort, return null
+      return null;
+    }
+
+    const changelogResource = resources.find((r) => r.uri?.startsWith('changelog://'));
+    if (!changelogResource) return null;
+
+    try {
+      const readResult = await entry.client.readResource({ uri: changelogResource.uri });
+      // readResource returns { contents: Array<{ type, text? }> }
+      const contents = (readResult as { contents?: Array<{ type?: string; text?: string }> }).contents ?? [];
+      const textContent = contents.find((c) => c.type === 'text' || typeof c.text === 'string');
+      const rawText = textContent?.text ?? '';
+      if (!rawText) return null;
+
+      const currentVersion = extractVersionFromChangelog(rawText);
+      return { currentVersion, rawText };
+    } catch {
+      return null;
     }
   }
 
@@ -298,6 +425,24 @@ export class McpHost implements IronClawAdapter {
 
     log.serverId = serverId;
     log.toolName = toolName;
+
+    // Hard rail (#184 AC#2): block execution if the user has not yet opted in
+    // to this destructive skill. The checkPendingOptIn callback is injected
+    // from the API layer to avoid a DB dependency in mcp-host.
+    if (this.checkPendingOptIn && isDestructiveSkill(toolName)) {
+      let blocked = false;
+      try {
+        blocked = await this.checkPendingOptIn(serverId, toolName);
+      } catch {
+        // If the opt-in check itself fails, fail safe: block execution.
+        blocked = true;
+      }
+      if (blocked) {
+        log.status = 'failed';
+        log.error = `Skill '${toolName}' requires explicit opt-in before it can be executed. Accept the pending opt-in prompt in the Capabilities dashboard.`;
+        return errorResult(plan.id, startedAt, log.error);
+      }
+    }
 
     const entry = this.servers.get(serverId);
     if (!entry) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       '@skytwin/llm-client':
         specifier: workspace:*
         version: link:../../packages/llm-client
+      '@skytwin/mcp-host':
+        specifier: workspace:*
+        version: link:../../packages/mcp-host
       '@skytwin/observability':
         specifier: workspace:*
         version: link:../../packages/observability


### PR DESCRIPTION
## Summary

Closes the deferred AC#2 from #184 (capability changelog flow). Adds the missing piece of #184 that the original PR explicitly deferred: `changelog://` resource fetching, new-destructive-skill opt-in prompts, hard-rail execution block, and weekly worker sweep.

## What's in here

### Migration `033-mcp-server-changelogs.sql`

Two new tables:
- `mcp_server_changelogs` — one row per installed server; tracks `current_version`, `raw_text`, `fetched_at`, `last_seen_skills`, `last_known_destructive_skills`. Updated on install / `list_tools` refresh / weekly sweep.
- `pending_skill_opt_ins` — pending opt-in prompts. Unique on `(server_id, skill_name)`, partial index on unresolved rows.

### McpHost extensions

- `fetchChangelog(serverId)` — uses `client.listResources()` to find a `changelog://` URI; returns `{ rawText, currentVersion }` or null. Best-effort.
- `isDestructiveSkill(skillName)` — exported heuristic matching create/delete/update/write/send/post/commit/push/merge/mutate/set/remove.
- `onChangelogFetch` hook on `McpHostOptions` mirroring the `onToolCall` pattern.

### Hard rail

`checkPendingOptIn` callback (injected from apps/api so `@skytwin/mcp-host` stays free of a `@skytwin/db` dependency) blocks `execute()` for any destructive skill with an unresolved `pending_skill_opt_ins` row.

**Fail-safe**: if the check itself throws, `blocked = true` and execution is blocked. The user must explicitly accept via the dashboard.

### Worker job (7-day cadence)

`runChangelogPollJob`: iterates active servers, 12h per-server rate limit, diffs newly-added destructive skills against `last_known_destructive_skills`, writes opt-in prompts for new ones. Wired in `apps/worker/src/index.ts` alongside the existing metrics-rollup pattern (timestamp-gated, not cron).

### API routes

- `GET  /api/capabilities/:id/changelog` — ownership-checked
- `GET  /api/capabilities/pending-opt-ins` — per-user feed
- `POST /api/capabilities/pending-opt-ins/:id/accept`
- `POST /api/capabilities/pending-opt-ins/:id/reject`

All under `sessionAuth + requireOwnership`.

### Web UX

- `capability-detail.js` — new Changelog card (version badge + collapsible `raw_text`)
- `capabilities.js` — "New skills awaiting opt-in" section at the top of the capabilities page with Accept/Reject buttons. Reuses the existing `_capabilitiesListenerWired` singleton delegator.

## Reviewer notes

1. **`isDestructiveSkill` is intentionally over-inclusive** (e.g. `setTheme` would prompt). False positives are inconvenient; false negatives would let a destructive skill slip past — the threat model favors the inconvenience. List can be tightened post-launch when we see real-world false-positive rates.

2. **Opt-in is per-skill-name, per-server.** A renamed tool requires a new opt-in. This is intentional — renames could be silent malicious replacements.

3. **The opt-in check is fail-safe.** If the DB callback throws (e.g. transient outage), execution is blocked rather than allowed. Side effect: a DB outage temporarily blocks all destructive tool calls until the user retries; this is the correct posture.

4. **No new top-level deps.** All work uses existing Node + workspace primitives.

## Tests

- `@skytwin/mcp-host`: 21 new (50 total, 3 pre-existing skipped)
- `@skytwin/db`: 14 new (190 total, 15 pre-existing skipped)
- `@skytwin/api`: 11 new (375 total, 24 pre-existing skipped)
- `@skytwin/worker`: 6 new (48 total)
- Full workspace: **60/60** turbo tasks pass

## Test plan

- [x] `pnpm --filter @skytwin/mcp-host test` → 50 pass
- [x] `pnpm --filter @skytwin/db test` → 190 pass
- [x] `pnpm --filter @skytwin/api test` → 375 pass
- [x] `pnpm --filter @skytwin/worker test` → 48 pass
- [x] `pnpm build` → 30/30 packages clean
- [x] `pnpm test` → 60/60 turbo tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)