### PR TITLE
fix(#183): MetricsCollector full-drain for missed-tick recovery

### DIFF
--- a/packages/observability/src/__tests__/metrics-collector.test.ts
+++ b/packages/observability/src/__tests__/metrics-collector.test.ts
@@ -65,8 +65,7 @@ describe('MetricsCollector', () => {
     collector.record(makeRecord('alpha', { ts: now }));
     collector.record(makeRecord('beta', { ts: now }));
 
-    const since = new Date(now.getTime() - 1000);
-    const byServer = collector.drainAll(since);
+    const byServer = collector.drainAll();
 
     expect(byServer.size).toBe(2);
     expect(byServer.get('alpha')).toHaveLength(2);
@@ -74,18 +73,19 @@ describe('MetricsCollector', () => {
     expect(collector.size()).toBe(0);
   });
 
-  it('drainAll retains entries older than since', () => {
+  it('drainAll drains records of every age — older records are NOT retained', () => {
+    // Regression: records older than (now - 60s) used to be left in the buffer
+    // indefinitely. Now drainAll takes everything; the rollup service buckets
+    // them by their actual minute via writeBucket's ON CONFLICT accumulation.
     const old = new Date(Date.now() - 120_000);
     const recent = new Date();
     collector.record(makeRecord('server-1', { ts: old }));
     collector.record(makeRecord('server-1', { ts: recent }));
 
-    const since = new Date(Date.now() - 60_000);
-    const byServer = collector.drainAll(since);
+    const byServer = collector.drainAll();
 
-    expect(byServer.get('server-1')).toHaveLength(1);
-    // old entry stays in buffer
-    expect(collector.size()).toBe(1);
+    expect(byServer.get('server-1')).toHaveLength(2);
+    expect(collector.size()).toBe(0);
   });
 
   it('exports threshold constants with expected ranges', () => {

--- a/packages/observability/src/__tests__/metrics-rollup-service.test.ts
+++ b/packages/observability/src/__tests__/metrics-rollup-service.test.ts
@@ -94,4 +94,26 @@ describe('MetricsRollupService', () => {
     expect(written).toBe(1);
     expect(callCount).toBe(2); // both were attempted
   });
+
+  it('missed-tick recovery: records spanning multiple minutes write per-minute buckets', async () => {
+    // Regression: previously a missed rollup tick left old records stranded
+    // in the buffer because drainAll filtered by `since = now - 60s`.
+    const now = Date.now();
+    const oldMinute = new Date(now - 180_000); // 3 minutes ago
+    const recentMinute = new Date(now - 30_000); // 30 seconds ago
+
+    collector.record({ serverId: 'srv-1', skillName: 'a', latencyMs: 100, success: true, spendCents: 0, ts: oldMinute });
+    collector.record({ serverId: 'srv-1', skillName: 'b', latencyMs: 200, success: true, spendCents: 0, ts: oldMinute });
+    collector.record({ serverId: 'srv-1', skillName: 'c', latencyMs: 50,  success: true, spendCents: 0, ts: recentMinute });
+
+    const written = await service.rollup();
+
+    // 1 server but 2 distinct minutes → 2 bucket rows
+    expect(written).toBe(2);
+    const calls = (repo.writeBucket as ReturnType<typeof vi.fn>).mock.calls as Array<[WriteBucketInput]>;
+    const bucketStartTimes = calls.map((c) => c[0].bucketStartedAt.getTime());
+    expect(new Set(bucketStartTimes).size).toBe(2);
+    // Buffer is fully drained
+    expect(collector.size()).toBe(0);
+  });
 });

--- a/packages/observability/src/metrics-collector.ts
+++ b/packages/observability/src/metrics-collector.ts
@@ -80,31 +80,28 @@ export class MetricsCollector {
   }
 
   /**
-   * Drain ALL entries since `since`, grouped by serverId.
-   * Removes drained entries from the buffer.
+   * Drain ALL entries, grouped by serverId.
+   * Removes ALL drained entries from the buffer.
+   *
+   * Records older than the rollup tick interval still need to be drained —
+   * leaving them in the buffer means they never reach the DB on a missed tick
+   * (e.g. transient DB outage). The repository's writeBucket performs
+   * `ON CONFLICT ... ACCUMULATE`, so late-arriving records for an already-
+   * written bucket safely add to the existing row.
    */
-  drainAll(since: Date): Map<string, ToolCallRecord[]> {
+  drainAll(): Map<string, ToolCallRecord[]> {
     const byServer = new Map<string, ToolCallRecord[]>();
-    const retained: ToolCallRecord[] = [];
 
     for (const entry of this.buffer) {
-      if (entry.ts >= since) {
-        let bucket = byServer.get(entry.serverId);
-        if (!bucket) {
-          bucket = [];
-          byServer.set(entry.serverId, bucket);
-        }
-        bucket.push(entry);
-      } else {
-        retained.push(entry);
+      let bucket = byServer.get(entry.serverId);
+      if (!bucket) {
+        bucket = [];
+        byServer.set(entry.serverId, bucket);
       }
+      bucket.push(entry);
     }
 
     this.buffer.length = 0;
-    for (const e of retained) {
-      this.buffer.push(e);
-    }
-
     return byServer;
   }
 

--- a/packages/observability/src/metrics-rollup-service.ts
+++ b/packages/observability/src/metrics-rollup-service.ts
@@ -22,14 +22,19 @@ export class MetricsRollupService {
   ) {}
 
   /**
-   * Flush all buffered tool call records into 1-minute DB buckets.
+   * Flush all buffered tool call records into 1-minute DB buckets, grouped
+   * by (serverId, minute) so records that span multiple minutes — including
+   * older records left over from a missed rollup tick — bucket correctly.
    * Typically called by the worker job every 60s.
    *
-   * Returns the number of distinct server buckets written.
+   * The repository upserts on (server_id, bucket_started_at, bucket_duration)
+   * with ON CONFLICT accumulation, so late-arriving records for an already-
+   * written bucket safely add to the existing row.
+   *
+   * Returns the number of distinct (serverId, minute) buckets written.
    */
   async rollup(): Promise<number> {
-    const since = new Date(Date.now() - 60 * 1000);
-    const byServer = this.collector.drainAll(since);
+    const byServer = this.collector.drainAll();
 
     if (byServer.size === 0) {
       return 0;
@@ -37,29 +42,44 @@ export class MetricsRollupService {
 
     let written = 0;
     for (const [serverId, records] of byServer) {
-      try {
-        const bucket = aggregateRecords(records);
-        const bucketStartedAt = roundToMinute(records[0]?.ts ?? new Date());
+      // Group this server's records by the minute they fall into so that a
+      // single rollup() call can write multiple buckets for the same server
+      // (e.g. on missed-tick recovery the buffer holds 2+ minutes of data).
+      const byMinute = new Map<number, ToolCallRecord[]>();
+      for (const record of records) {
+        const minuteKey = roundToMinute(record.ts).getTime();
+        let bucket = byMinute.get(minuteKey);
+        if (!bucket) {
+          bucket = [];
+          byMinute.set(minuteKey, bucket);
+        }
+        bucket.push(record);
+      }
 
-        await this.repository.writeBucket({
-          serverId,
-          bucketStartedAt,
-          bucketDuration: BUCKET_DURATION,
-          invocationsTotal: bucket.total,
-          invocationsFailed: bucket.failed,
-          latencyP50Ms: bucket.p50,
-          latencyP95Ms: bucket.p95,
-          latencyP99Ms: bucket.p99,
-          bytesIn: 0,
-          bytesOut: 0,
-          spendCents: bucket.spendCents,
-        });
-        written++;
-      } catch (err) {
-        log.warn('Failed to write metrics bucket', {
-          serverId,
-          error: err instanceof Error ? err.message : String(err),
-        });
+      for (const [minuteKey, minuteRecords] of byMinute) {
+        try {
+          const bucket = aggregateRecords(minuteRecords);
+          await this.repository.writeBucket({
+            serverId,
+            bucketStartedAt: new Date(minuteKey),
+            bucketDuration: BUCKET_DURATION,
+            invocationsTotal: bucket.total,
+            invocationsFailed: bucket.failed,
+            latencyP50Ms: bucket.p50,
+            latencyP95Ms: bucket.p95,
+            latencyP99Ms: bucket.p99,
+            bytesIn: 0,
+            bytesOut: 0,
+            spendCents: bucket.spendCents,
+          });
+          written++;
+        } catch (err) {
+          log.warn('Failed to write metrics bucket', {
+            serverId,
+            bucketStartedAt: new Date(minuteKey).toISOString(),
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Bug found in #210 self-review: `drainAll()` filtered records by `since = now - 60s`, so any record older than 60 seconds at rollup time stayed in the in-memory buffer **forever**. A missed rollup tick (transient DB outage, process pause, slow query) silently dropped older records — they'd never reach `mcp_server_metrics`.

This was flagged as a known follow-up in the original PR; this is the fix.

## Fix

- `drainAll()` now drains EVERY record regardless of age. The `since` parameter is gone.
- `MetricsRollupService` groups drained records by `(serverId, minute)` using `roundToMinute(record.ts)`, so a single `rollup()` call writes multiple buckets for the same server when the buffer holds 2+ minutes of data.
- `writeBucket` already does `ON CONFLICT` accumulation on `(server_id, bucket_started_at, bucket_duration)`, so late-arriving records for an already-written bucket safely add to the existing row — no duplicates, no lost data.

## Tests

- Updated the existing "drainAll retains older records" test → it now asserts the **opposite** (regression test for the bug; older records ARE drained).
- New "missed-tick recovery" test: 3 records spanning 2 minutes for one server → 2 distinct bucket rows written, buffer fully drained.
- Full workspace: **60/60 turbo tasks pass**.

## Test plan

- [x] `pnpm --filter @skytwin/observability test` → 13/13 pass
- [x] `pnpm build` → 30/30 packages clean
- [x] `pnpm test` → 60/60 turbo tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)