### PR TITLE
fix(#183): observability hook for silent lazy-migration failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Lazy credential-vault migration: observability hook (#183 follow-up)
+
+The fire-and-forget `_lazyMigrate` path in `DbTokenStore.getToken` previously
+swallowed migration errors silently — a flaky DB could leave a user un-migrated
+indefinitely with no visible signal.
+
+### Changed — `packages/connectors/src/oauth/db-token-store.ts`
+
+The `.catch()` arm of the lazy-migration `Promise` now:
+
+- Increments `lazyMigrationFailureCounter.count` (exported counter that
+  downstream observability tooling can poll).
+- Logs a `warn` line with `userId`, `provider`, `rowId`, and the error message.
+  Plaintext tokens / passphrases / keys are NEVER logged.
+
+The caller still receives the plaintext value (backward compat), so a single
+failure does not block the user; but persistent failures are now visible.
+
+1 new regression test asserts the counter increments and the
+`lazyMigrationFailureCounter` export works.
+
 ## [unreleased] — memory-gbrain + memory-hybrid scaffolding (#197 partial scaffold for v1.0.5)
 
 SKELETON only. No live gbrain integration is included in this entry.

--- a/packages/connectors/src/__tests__/db-token-store-vault.test.ts
+++ b/packages/connectors/src/__tests__/db-token-store-vault.test.ts
@@ -190,6 +190,39 @@ describe('DbTokenStore — lazy vault migration', () => {
       'credentials unavailable',
     );
   });
+
+  it('lazyMigrationFailureCounter increments when updateEncrypted throws (observability hook)', async () => {
+    const { lazyMigrationFailureCounter } = await import('../oauth/db-token-store.js');
+    const startingCount = lazyMigrationFailureCounter.count;
+
+    const cache = createMockKeyCache(key);
+    store.setKeyCache(cache);
+
+    repo.getToken.mockResolvedValueOnce({
+      id: 'row-id-fail',
+      access_token: 'ya29.plaintext',
+      refresh_token: '1//plaintext-refresh',
+      expires_at: EXPIRES_AT,
+      scopes: [],
+      encrypted_access_token: null,
+      encrypted_refresh_token: null,
+      encryption_iv: null,
+      encryption_tag: null,
+      encryption_key_version: 1,
+    });
+
+    repo.updateEncrypted.mockRejectedValueOnce(new Error('DB connection lost'));
+
+    // The caller still gets the plaintext (Case 2 returns before the fire-and-forget resolves)
+    const result = await store.getToken('user-1', 'google');
+    expect(result).not.toBeNull();
+    expect(result!.accessToken).toBe('ya29.plaintext');
+
+    // Wait for the fire-and-forget catch to fire
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(lazyMigrationFailureCounter.count).toBe(startingCount + 1);
+  });
 });
 
 describe('DbTokenStore — key derivation integration', () => {

--- a/packages/connectors/src/oauth/db-token-store.ts
+++ b/packages/connectors/src/oauth/db-token-store.ts
@@ -3,6 +3,16 @@ import type { OAuthTokenStore } from './token-store.js';
 import type { GoogleOAuthConfig } from './google-oauth.js';
 import { refreshAccessToken } from './google-oauth.js';
 import { encrypt, decrypt, IV_LENGTH, TAG_LENGTH } from '@skytwin/credential-vault';
+import { createLogger } from '@skytwin/core';
+
+const log = createLogger('connectors:db-token-store');
+
+/**
+ * Counter for lazy-migration failures, exposed for observability tests.
+ * Each failed migration attempt increments this; downstream observability
+ * tooling can read the value periodically. NEVER reset in production.
+ */
+export const lazyMigrationFailureCounter = { count: 0 };
 
 /**
  * Packed ciphertext format: [IV (12 bytes)] + [tag (16 bytes)] + [ciphertext]
@@ -152,15 +162,24 @@ export class DbTokenStore implements OAuthTokenStore {
     // Case 2: plaintext present AND vault is unlocked → lazy migrate
     if (row.access_token && row.refresh_token && key !== null) {
       if (row.id && this.repo.updateEncrypted) {
-        // Fire-and-forget migration — do not block the caller
+        // Fire-and-forget migration — do not block the caller. Failures are
+        // surfaced via createLogger.warn AND a counter so downstream
+        // observability can detect a stuck migration loop.
+        const rowId = row.id;
         this._lazyMigrate(
-          row.id,
+          rowId,
           row.access_token,
           row.refresh_token,
           row.encryption_key_version ?? 1,
           key,
-        ).catch(() => {
-          // Migration failure is non-fatal — plaintext still works
+        ).catch((err: unknown) => {
+          lazyMigrationFailureCounter.count += 1;
+          log.warn('Lazy credential-vault migration failed', {
+            userId,
+            provider,
+            rowId,
+            error: err instanceof Error ? err.message : String(err),
+          });
         });
       }
       return {


### PR DESCRIPTION
## Summary

Closes the deferred follow-up flagged in #212: the fire-and-forget `_lazyMigrate` catch in `DbTokenStore.getToken` used to swallow errors silently. A flaky DB could leave a user un-migrated indefinitely with no visible signal.

## What changed

- **`lazyMigrationFailureCounter`** (exported) — a `{ count: number }` counter incremented on each migration failure. Downstream observability tooling can poll it; a sustained increase signals "users stuck in plaintext-and-vault-unlocked state."
- **`log.warn` on every failure** — with `userId`, `provider`, `rowId`, and `error.message`. Plaintext tokens, passphrases, and derived keys are NEVER logged.

The caller still receives the plaintext value (Case 2 returns before the fire-and-forget resolves), so a single failure doesn't block the user — persistent failures are just no longer invisible.

## Tests

1 new regression test in `db-token-store-vault.test.ts` asserts that `updateEncrypted` throwing increments the counter.

- `@skytwin/connectors`: 76 (75 + 1 new)
- Full workspace: **64/64 turbo tasks pass**

## Test plan

- [x] `pnpm --filter @skytwin/connectors test` → 76/76 pass
- [x] `pnpm build` → 32/32 packages clean
- [x] `pnpm test` → 64/64 turbo tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)