### PR TITLE
feat(#180 partial): DXT export/import scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — DXT export/import scaffold (#180 partial)
+
+The capability-transfer pipeline that `docs/dxt-transfer.md` (shipped in #211)
+described — implemented end-to-end except for the desktop drag-drop UI and
+the actual confirmed-install flow.
+
+### Added — `@skytwin/dxt`
+
+New package implementing the binary artifact format:
+
+- 4-byte magic `DXT1` + 4-byte version + 32-byte SHA-256 + 8-byte length + JSON payload
+- `serialize(input)` packs an `mcp_servers` row + skills into the binary form
+- `deserialize(blob)` returns a typed `DxtResult<T>` (no thrown exceptions
+  on user input — boundary contract)
+- `redactCommand(args)` masks any `--token=*` / `--api-key=*` / `--secret=*`
+  CLI argument before it reaches the artifact
+
+15 unit tests (round-trip, magic mismatch, version mismatch, length mismatch,
+SHA-256 tamper detection, redaction).
+
+### Added — `dxtExportRepository` (`@skytwin/db`)
+
+`create(input)`, `findById(id)`, `listForUser(userId)` against the
+existing `dxt_exports` table from migration 027.
+
+### Added — `apps/api/src/routes/dxt.ts`
+
+Four routes wired under `sessionAuth + requireOwnership`:
+
+- `POST /api/dxt/export/:serverId` — serialize + persist + return base64 blob
+- `GET  /api/dxt/exports` — metadata-only listing
+- `GET  /api/dxt/exports/:id/blob` — download `application/octet-stream`
+- `POST /api/dxt/import` — preview-only deserialization with detection of
+  whether the capability is already installed
+
+9 API integration tests (UUID validation, ownership checks, round-trip
+export → import, magic-mismatch on garbage, missing-blob 400).
+
+### Out of scope (deferred to environmental work)
+
+- Drag-drop UI on the desktop app — needs Electron testing
+- The actual install-from-DXT flow (preview only — explicit-confirm + install
+  step deferred)
+- Idle bridge from #180
+- Zero-trust container hooks from #180 / #183 AC#4
+
 ## [unreleased] — Always-on service: headless daemon scaffold (#191 partial)
 
 Code-bound subset of #191. Ships:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "@skytwin/core": "workspace:*",
     "@skytwin/db": "workspace:*",
     "@skytwin/decision-engine": "workspace:*",
+    "@skytwin/dxt": "workspace:*",
     "@skytwin/execution-router": "workspace:*",
     "@skytwin/explanations": "workspace:*",
     "@skytwin/ironclaw-adapter": "workspace:*",

--- a/apps/api/src/__tests__/dxt-routes.test.ts
+++ b/apps/api/src/__tests__/dxt-routes.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import type { Express } from 'express';
+
+const { mockMcpServerRepo, mockDxtExportRepo } = vi.hoisted(() => ({
+  mockMcpServerRepo: {
+    getById: vi.fn(),
+    getByUserAndRegistry: vi.fn(),
+  },
+  mockDxtExportRepo: {
+    create: vi.fn(),
+    findById: vi.fn(),
+    listForUser: vi.fn(),
+  },
+}));
+
+vi.mock('@skytwin/db', () => ({
+  mcpServerRepository: mockMcpServerRepo,
+  dxtExportRepository: mockDxtExportRepo,
+}));
+
+import { createDxtRouter } from '../routes/dxt.js';
+
+const USER_ID = 'ffffffff-eeee-dddd-cccc-111111111111';
+const SERVER_ID = 'aaaaaaaa-bbbb-cccc-dddd-222222222222';
+const EXPORT_ID = 'bbbbbbbb-cccc-dddd-eeee-333333333333';
+
+function buildApp(userId = USER_ID): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { user: { id: string } }).user = { id: userId };
+    next();
+  });
+  app.use('/api/dxt', createDxtRouter());
+  app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(500).json({ error: err.message });
+  });
+  return app;
+}
+
+async function req(
+  app: Express,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close();
+        reject(new Error('Could not determine port'));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      const options: RequestInit = { method, headers };
+      if (body !== undefined) {
+        options.body = JSON.stringify(body);
+      }
+      fetch(url, options)
+        .then(async (res) => {
+          const json = await res.json().catch(() => null);
+          server.close();
+          resolve({ status: res.status, body: json });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+function makeMcpServerRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: SERVER_ID,
+    user_id: USER_ID,
+    registry_id: 'notion-mcp',
+    display_name: 'Notion',
+    transport: 'stdio',
+    command: 'npx',
+    args: ['-y', '@notionhq/notion-mcp-server'],
+    env: {},
+    url: null,
+    oauth_provider: null,
+    oauth_token_id: null,
+    trust_tier: 'observer',
+    per_app_spend_per_action_cents: 100,
+    per_app_daily_spend_cents: 500,
+    per_app_monthly_spend_cents: 2000,
+    per_app_monthly_rollover: false,
+    per_app_irreversible_requires_approval: true,
+    zero_trust_mode: false,
+    status: 'active',
+    last_health_check_at: new Date(),
+    health_status: 'healthy',
+    last_active_at: new Date(),
+    installed_at: new Date(),
+    uninstalled_at: null,
+    auto_promote_paused_until: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /api/dxt/export/:serverId', () => {
+  it('returns 400 for invalid UUID', async () => {
+    const app = buildApp();
+    const result = await req(app, 'POST', '/api/dxt/export/not-a-uuid');
+    expect(result.status).toBe(400);
+  });
+
+  it('returns 404 when capability server not found', async () => {
+    mockMcpServerRepo.getById.mockResolvedValueOnce(null);
+    const app = buildApp();
+    const result = await req(app, 'POST', `/api/dxt/export/${SERVER_ID}`);
+    expect(result.status).toBe(404);
+  });
+
+  it('returns 403 when user does not own the server', async () => {
+    mockMcpServerRepo.getById.mockResolvedValueOnce(makeMcpServerRow({ user_id: 'someone-else' }));
+    const app = buildApp();
+    const result = await req(app, 'POST', `/api/dxt/export/${SERVER_ID}`);
+    expect(result.status).toBe(403);
+  });
+
+  it('happy path: serializes, persists, returns blob', async () => {
+    mockMcpServerRepo.getById.mockResolvedValueOnce(makeMcpServerRow());
+    const fakeRow = {
+      id: EXPORT_ID,
+      user_id: USER_ID,
+      server_id: SERVER_ID,
+      exported_at: new Date('2026-05-08T00:00:00Z'),
+      artifact_blob: Buffer.alloc(48),
+      artifact_sha256: Buffer.alloc(32),
+    };
+    mockDxtExportRepo.create.mockResolvedValueOnce(fakeRow);
+
+    const app = buildApp();
+    const result = await req(app, 'POST', `/api/dxt/export/${SERVER_ID}`);
+
+    expect(result.status).toBe(201);
+    const body = result.body as Record<string, unknown>;
+    expect(body['id']).toBe(EXPORT_ID);
+    expect(typeof body['blob']).toBe('string');
+    expect(typeof body['sha256']).toBe('string');
+
+    expect(mockDxtExportRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: USER_ID,
+        serverId: SERVER_ID,
+        blob: expect.any(Buffer),
+        sha256: expect.any(Buffer),
+      }),
+    );
+  });
+});
+
+describe('GET /api/dxt/exports', () => {
+  it('returns metadata only (no blob bytes in response)', async () => {
+    mockDxtExportRepo.listForUser.mockResolvedValueOnce([
+      {
+        id: EXPORT_ID,
+        user_id: USER_ID,
+        server_id: SERVER_ID,
+        exported_at: new Date('2026-05-08T00:00:00Z'),
+        artifact_blob: Buffer.alloc(123),
+        artifact_sha256: Buffer.alloc(32, 0xab),
+      },
+    ]);
+    const app = buildApp();
+    const result = await req(app, 'GET', '/api/dxt/exports');
+
+    expect(result.status).toBe(200);
+    const body = result.body as { exports: Array<Record<string, unknown>> };
+    expect(body.exports).toHaveLength(1);
+    expect(body.exports[0]!['id']).toBe(EXPORT_ID);
+    expect(body.exports[0]!['blobBytes']).toBe(123);
+    expect(body.exports[0]).not.toHaveProperty('artifact_blob');
+  });
+});
+
+describe('GET /api/dxt/exports/:id/blob', () => {
+  it('returns 403 when user does not own the export', async () => {
+    mockDxtExportRepo.findById.mockResolvedValueOnce({
+      id: EXPORT_ID,
+      user_id: 'someone-else',
+      server_id: SERVER_ID,
+      exported_at: new Date(),
+      artifact_blob: Buffer.alloc(48),
+      artifact_sha256: Buffer.alloc(32),
+    });
+    const app = buildApp();
+    const result = await req(app, 'GET', `/api/dxt/exports/${EXPORT_ID}/blob`);
+    expect(result.status).toBe(403);
+  });
+});
+
+describe('POST /api/dxt/import', () => {
+  it('returns 400 when blob is missing', async () => {
+    const app = buildApp();
+    const result = await req(app, 'POST', '/api/dxt/import', {});
+    expect(result.status).toBe(400);
+  });
+
+  it('returns 400 with a typed code when blob is garbage', async () => {
+    const app = buildApp();
+    // Build a 64-byte buffer that's longer than HEADER_LENGTH (48) so we reach
+    // the magic check rather than being rejected as TRUNCATED.
+    const garbage = Buffer.alloc(64, 0xff).toString('base64');
+    const result = await req(app, 'POST', '/api/dxt/import', { blob: garbage });
+    expect(result.status).toBe(400);
+    const body = result.body as { code?: string };
+    expect(body.code).toBe('MAGIC_MISMATCH');
+  });
+
+  it('happy path: round-trips export → import preview', async () => {
+    // Export first
+    mockMcpServerRepo.getById.mockResolvedValueOnce(makeMcpServerRow());
+    mockDxtExportRepo.create.mockImplementationOnce(async (input) => ({
+      id: EXPORT_ID,
+      user_id: input.userId,
+      server_id: input.serverId,
+      exported_at: new Date(),
+      artifact_blob: input.blob,
+      artifact_sha256: input.sha256,
+    }));
+    const app = buildApp();
+    const exportResult = await req(app, 'POST', `/api/dxt/export/${SERVER_ID}`);
+    expect(exportResult.status).toBe(201);
+    const blob = (exportResult.body as { blob: string }).blob;
+
+    // Now import preview
+    mockMcpServerRepo.getByUserAndRegistry.mockResolvedValueOnce(null);
+    const importResult = await req(app, 'POST', '/api/dxt/import', { blob });
+    expect(importResult.status).toBe(200);
+    const importBody = importResult.body as Record<string, unknown>;
+    expect(importBody['preview']).toBeDefined();
+    expect(importBody['alreadyInstalled']).toBe(false);
+    expect(typeof importBody['sha256']).toBe('string');
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -34,6 +34,7 @@ import { createTwinBriefingsRouter } from './routes/twin-briefings.js';
 import { createOnboardingRouter } from './routes/onboarding.js';
 import { createExternalAgentsRouter } from './routes/external-agents.js';
 import { createCredentialVaultRouter } from './routes/credential-vault.js';
+import { createDxtRouter } from './routes/dxt.js';
 import { getExecutionRouter } from './execution-setup.js';
 import { startMdnsAdvertisement, stopMdnsAdvertisement } from './mdns.js';
 import { closePool } from '@skytwin/db';
@@ -213,6 +214,7 @@ app.use('/api/twin-briefings', sessionAuth, requireOwnership, createTwinBriefing
 app.use('/api/onboarding', sessionAuth, requireOwnership, createOnboardingRouter());
 app.use('/api/external-agents', sessionAuth, requireOwnership, createExternalAgentsRouter());
 app.use('/api/credential-vault', sessionAuth, requireOwnership, createCredentialVaultRouter());
+app.use('/api/dxt', sessionAuth, requireOwnership, createDxtRouter());
 
 // Error handling middleware
 app.use(

--- a/apps/api/src/routes/dxt.ts
+++ b/apps/api/src/routes/dxt.ts
@@ -1,0 +1,241 @@
+/**
+ * dxt.ts — REST endpoints for DXT artifact export, list, download, import.
+ *
+ * Routes (all under sessionAuth + requireOwnership):
+ *   POST   /api/dxt/export/:serverId  — serialize an mcp_servers row, persist, return blob
+ *   GET    /api/dxt/exports           — list this user's exports (metadata only)
+ *   GET    /api/dxt/exports/:id/blob  — download the raw blob
+ *   POST   /api/dxt/import            — preview an artifact (no install)
+ */
+
+import { Router } from 'express';
+import type { Request } from 'express';
+import { mcpServerRepository, dxtExportRepository } from '@skytwin/db';
+import type { McpServerRow, DxtExportRow } from '@skytwin/db';
+import { createLogger } from '@skytwin/core';
+import { serialize, deserialize, redactCommand } from '@skytwin/dxt';
+import type { DxtArtifactInput, DxtJsonPayload } from '@skytwin/dxt';
+
+const log = createLogger('api:dxt');
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function getUserId(req: Request): string | undefined {
+  const asAny = req as unknown as { user?: { id?: string } };
+  const fromUser = asAny.user?.id;
+  const fromQuery = typeof req.query['userId'] === 'string' ? req.query['userId'] : undefined;
+  return fromUser ?? fromQuery;
+}
+
+/**
+ * Build the DXT artifact input from an mcp_servers row.
+ * Pulls the redacted args + transport details + per-app spend caps.
+ */
+function buildArtifactInput(server: McpServerRow, sourceInstanceId: string, skills: string[]): DxtArtifactInput {
+  const rawArgs = Array.isArray(server.args) ? (server.args as unknown[]).filter((a): a is string => typeof a === 'string') : [];
+  const result: DxtArtifactInput = {
+    sourceInstanceId,
+    registryId: server.registry_id ?? server.display_name,
+    transport: server.transport,
+    skills,
+  };
+  if (server.command !== null) result.command = server.command;
+  if (rawArgs.length > 0) result.args = redactCommand(rawArgs);
+  if (server.url !== null) result.url = server.url;
+  if (
+    server.per_app_spend_per_action_cents !== null
+    || server.per_app_daily_spend_cents !== null
+    || server.per_app_monthly_spend_cents !== null
+  ) {
+    const caps: { perActionCents?: number; dailyCents?: number; monthlyCents?: number } = {};
+    if (server.per_app_spend_per_action_cents !== null) caps.perActionCents = server.per_app_spend_per_action_cents;
+    if (server.per_app_daily_spend_cents !== null) caps.dailyCents = server.per_app_daily_spend_cents;
+    if (server.per_app_monthly_spend_cents !== null) caps.monthlyCents = server.per_app_monthly_spend_cents;
+    result.perAppSpendCaps = caps;
+  }
+  return result;
+}
+
+export function createDxtRouter(): Router {
+  const router = Router();
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // POST /export/:serverId
+  // Serialize a capability config as a DXT artifact.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.post('/export/:serverId', async (req, res, next) => {
+    try {
+      const { serverId } = req.params;
+      if (!serverId || !UUID_REGEX.test(serverId)) {
+        res.status(400).json({ error: 'serverId must be a UUID' });
+        return;
+      }
+
+      const userId = getUserId(req);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const server = await mcpServerRepository.getById(serverId);
+      if (!server) {
+        res.status(404).json({ error: 'Capability server not found' });
+        return;
+      }
+      if (server.user_id !== userId) {
+        res.status(403).json({ error: 'Forbidden: you do not own this capability server' });
+        return;
+      }
+
+      const input = buildArtifactInput(server, userId, []);
+      const { blob, sha256 } = await serialize(input);
+
+      const row = await dxtExportRepository.create({
+        userId,
+        serverId,
+        blob,
+        sha256,
+      });
+
+      log.info('DXT artifact exported', { userId, serverId, exportId: row.id, blobBytes: blob.length });
+
+      res.status(201).json({
+        id: row.id,
+        sha256: sha256.toString('hex'),
+        exportedAt: row.exported_at,
+        blob: blob.toString('base64'),
+        blobBytes: blob.length,
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GET /exports
+  // List metadata for this user's exports (no blob bytes).
+  // ─────────────────────────────────────────────────────────────────────────
+  router.get('/exports', async (req, res, next) => {
+    try {
+      const userId = getUserId(req);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const rows = await dxtExportRepository.listForUser(userId);
+      const exports = rows.map((r: DxtExportRow) => ({
+        id: r.id,
+        serverId: r.server_id,
+        exportedAt: r.exported_at,
+        sha256: r.artifact_sha256.toString('hex'),
+        blobBytes: r.artifact_blob.length,
+      }));
+
+      res.json({ exports });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GET /exports/:id/blob
+  // Download the raw artifact bytes as application/octet-stream.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.get('/exports/:id/blob', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      if (!id || !UUID_REGEX.test(id)) {
+        res.status(400).json({ error: 'id must be a UUID' });
+        return;
+      }
+
+      const userId = getUserId(req);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const row = await dxtExportRepository.findById(id);
+      if (!row) {
+        res.status(404).json({ error: 'Export not found' });
+        return;
+      }
+      if (row.user_id !== userId) {
+        res.status(403).json({ error: 'Forbidden: you do not own this export' });
+        return;
+      }
+
+      res.setHeader('Content-Type', 'application/octet-stream');
+      res.setHeader('Content-Disposition', `attachment; filename="capability-${id}.dxt"`);
+      res.send(row.artifact_blob);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // POST /import
+  // Body: { blob: base64String }
+  // Returns a parsed preview — does NOT install. The user must explicitly
+  // confirm via a separate flow (deferred to environmental UI work).
+  // ─────────────────────────────────────────────────────────────────────────
+  router.post('/import', async (req, res, next) => {
+    try {
+      const userId = getUserId(req);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const body = req.body as { blob?: unknown };
+      if (typeof body.blob !== 'string' || body.blob.length === 0) {
+        res.status(400).json({ error: 'blob (base64 string) is required in body' });
+        return;
+      }
+
+      let blob: Buffer;
+      try {
+        blob = Buffer.from(body.blob, 'base64');
+      } catch {
+        res.status(400).json({ error: 'blob must be valid base64' });
+        return;
+      }
+
+      const result = deserialize(blob);
+      if (!result.success) {
+        res.status(400).json({ error: result.error, code: result.code });
+        return;
+      }
+
+      const payload: DxtJsonPayload = result.data.payload;
+
+      // Detect if this capability is already installed for this user
+      let alreadyInstalled = false;
+      try {
+        const existing = await mcpServerRepository.getByUserAndRegistry(userId, payload.capability.registryId);
+        alreadyInstalled = existing !== null;
+      } catch {
+        // Best-effort lookup — swallow errors so import preview still works
+      }
+
+      log.info('DXT import preview', {
+        userId,
+        registryId: payload.capability.registryId,
+        sourceInstanceId: payload.sourceInstanceId,
+        alreadyInstalled,
+      });
+
+      res.json({
+        preview: payload,
+        alreadyInstalled,
+        sha256: result.data.computedSha256.toString('hex'),
+        note: 'This is a preview only. Confirmation + install flow lands in #180 environmental work.',
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -110,6 +110,12 @@ export type {
   CreateExternalAgentTokenInput,
 } from './repositories/index.js';
 
+export { dxtExportRepository } from './repositories/index.js';
+export type {
+  DxtExportRow,
+  CreateDxtExportInput,
+} from './repositories/index.js';
+
 export { mcpServerMetricsRepository } from './repositories/index.js';
 
 export { credentialVaultMetaRepository } from './repositories/index.js';

--- a/packages/db/src/repositories/dxt-export-repository.ts
+++ b/packages/db/src/repositories/dxt-export-repository.ts
@@ -1,0 +1,71 @@
+import { query } from '../connection.js';
+
+export interface DxtExportRow {
+  id: string;
+  user_id: string;
+  server_id: string;
+  exported_at: Date;
+  artifact_blob: Buffer;
+  artifact_sha256: Buffer;
+}
+
+export interface CreateDxtExportInput {
+  userId: string;
+  serverId: string;
+  blob: Buffer;
+  sha256: Buffer;
+}
+
+/**
+ * Repository for dxt_exports.
+ *
+ * Each row stores one packed DXT binary artifact keyed by (user_id, server_id,
+ * exported_at). Blobs are stored as raw bytes and never mutated after insert.
+ */
+export const dxtExportRepository = {
+  /**
+   * Persist a new DXT artifact to the database.
+   * Returns the inserted row including its generated id and exported_at.
+   */
+  async create(input: CreateDxtExportInput): Promise<DxtExportRow> {
+    const result = await query<DxtExportRow>(
+      `INSERT INTO dxt_exports (user_id, server_id, artifact_blob, artifact_sha256)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id, user_id, server_id, exported_at, artifact_blob, artifact_sha256`,
+      [input.userId, input.serverId, input.blob, input.sha256],
+    );
+    const row = result.rows[0];
+    if (!row) throw new Error('dxt_exports insert returned no row');
+    return row;
+  },
+
+  /**
+   * Find a single export row by its id.
+   * Returns null if not found.
+   */
+  async findById(id: string): Promise<DxtExportRow | null> {
+    const result = await query<DxtExportRow>(
+      `SELECT id, user_id, server_id, exported_at, artifact_blob, artifact_sha256
+       FROM dxt_exports
+       WHERE id = $1`,
+      [id],
+    );
+    return result.rows[0] ?? null;
+  },
+
+  /**
+   * List all exports for a user, newest first.
+   * Blob bytes are included — callers that need metadata-only should project
+   * away artifact_blob themselves.
+   */
+  async listForUser(userId: string): Promise<DxtExportRow[]> {
+    const result = await query<DxtExportRow>(
+      `SELECT id, user_id, server_id, exported_at, artifact_blob, artifact_sha256
+       FROM dxt_exports
+       WHERE user_id = $1
+       ORDER BY exported_at DESC`,
+      [userId],
+    );
+    return result.rows;
+  },
+};

--- a/packages/db/src/repositories/index.ts
+++ b/packages/db/src/repositories/index.ts
@@ -159,3 +159,9 @@ export type {
   UpsertChangelogInput,
   PendingSkillOptInRow,
 } from './mcp-server-changelog-repository.js';
+
+export { dxtExportRepository } from './dxt-export-repository.js';
+export type {
+  DxtExportRow,
+  CreateDxtExportInput,
+} from './dxt-export-repository.js';

--- a/packages/dxt/package.json
+++ b/packages/dxt/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@skytwin/dxt",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@skytwin/core": "workspace:*",
+    "@skytwin/shared-types": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.3.0"
+  }
+}

--- a/packages/dxt/src/__tests__/roundtrip.test.ts
+++ b/packages/dxt/src/__tests__/roundtrip.test.ts
@@ -1,0 +1,123 @@
+/**
+ * roundtrip.test.ts — Encode/decode round-trip tests for the DXT format.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { serialize } from '../serialize.js';
+import { deserialize } from '../deserialize.js';
+import { DXT_MAGIC, DXT_VERSION, HEADER_LENGTH } from '../format.js';
+import type { DxtArtifactInput } from '../types.js';
+
+const MINIMAL_INPUT: DxtArtifactInput = {
+  sourceInstanceId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  registryId: '@modelcontextprotocol/server-filesystem',
+  transport: 'stdio',
+  command: 'node',
+  args: ['dist/index.js', '--root=/home/user'],
+  skills: ['read_file', 'write_file', 'list_dir'],
+};
+
+describe('DXT round-trip', () => {
+  it('deserializes a serialized artifact back to the original payload', async () => {
+    const { blob } = await serialize(MINIMAL_INPUT);
+    const result = deserialize(blob);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return; // narrowing
+
+    const { payload } = result.data;
+    expect(payload.schemaVersion).toBe(1);
+    expect(payload.sourceInstanceId).toBe(MINIMAL_INPUT.sourceInstanceId);
+    expect(payload.capability.registryId).toBe(MINIMAL_INPUT.registryId);
+    expect(payload.capability.transport).toBe('stdio');
+    expect(payload.capability.skills).toEqual(MINIMAL_INPUT.skills);
+  });
+
+  it('binary starts with the correct magic header "DXT1"', async () => {
+    const { blob } = await serialize(MINIMAL_INPUT);
+
+    expect(blob.subarray(0, 4)).toEqual(DXT_MAGIC);
+  });
+
+  it('binary encodes version 1 at bytes 4-7', async () => {
+    const { blob } = await serialize(MINIMAL_INPUT);
+
+    expect(blob.readUInt32BE(4)).toBe(DXT_VERSION);
+  });
+
+  it('serialize sha256 return value matches the sha256 embedded in the blob', async () => {
+    const { blob, sha256 } = await serialize(MINIMAL_INPUT);
+
+    // Sha256 lives at offset 8, length 32
+    const embeddedHash = blob.subarray(8, 40);
+    expect(sha256).toEqual(embeddedHash);
+  });
+
+  it('preserves optional fields (promptOverrides, recipeRefs, perAppSpendCaps)', async () => {
+    const input: DxtArtifactInput = {
+      ...MINIMAL_INPUT,
+      perAppSpendCaps: { perActionCents: 50, dailyCents: 1000 },
+      promptOverrides: [{ slug: 'summarize', version: 2, body: 'Summarize briefly.' }],
+      recipeRefs: ['developer-pack'],
+    };
+
+    const { blob } = await serialize(input);
+    const result = deserialize(blob);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const { payload } = result.data;
+    expect(payload.perAppSpendCaps?.perActionCents).toBe(50);
+    expect(payload.promptOverrides?.[0]?.slug).toBe('summarize');
+    expect(payload.recipeRefs).toEqual(['developer-pack']);
+  });
+
+  it('redacts --token= arg before serialization', async () => {
+    const input: DxtArtifactInput = {
+      ...MINIMAL_INPUT,
+      args: ['--token=sk-supersecret', '--port=3000'],
+    };
+
+    const { blob } = await serialize(input);
+    const result = deserialize(blob);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const { payload } = result.data;
+    const args = payload.capability.args ?? [];
+    expect(args).not.toContain('--token=sk-supersecret');
+    expect(args[0]).toBe('--token=<redacted>');
+    expect(args[1]).toBe('--port=3000');
+    // Secret must not appear anywhere in the raw blob bytes
+    expect(blob.toString('utf8')).not.toContain('sk-supersecret');
+  });
+
+  it('round-trips an http-transport server (no command/args)', async () => {
+    const input: DxtArtifactInput = {
+      sourceInstanceId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      registryId: '@example/http-server',
+      transport: 'http',
+      url: 'https://mcp.example.com/v1',
+      skills: ['do_thing'],
+    };
+
+    const { blob } = await serialize(input);
+    const result = deserialize(blob);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data.payload.capability.transport).toBe('http');
+    expect(result.data.payload.capability.url).toBe('https://mcp.example.com/v1');
+    expect(result.data.payload.capability.command).toBeUndefined();
+  });
+
+  it('blob length equals HEADER_LENGTH + json payload byte length', async () => {
+    const { blob } = await serialize(MINIMAL_INPUT);
+
+    const declaredLen = blob.readUInt32BE(44); // low 32 bits of the length field at offset 40
+    expect(blob.length).toBe(HEADER_LENGTH + declaredLen);
+  });
+});

--- a/packages/dxt/src/__tests__/tamper.test.ts
+++ b/packages/dxt/src/__tests__/tamper.test.ts
@@ -1,0 +1,104 @@
+/**
+ * tamper.test.ts — Tamper-detection tests for the DXT format.
+ *
+ * Modifying any byte of the JSON payload must cause deserialize() to
+ * return { success: false, code: 'SHA256_MISMATCH' }.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { serialize } from '../serialize.js';
+import { deserialize } from '../deserialize.js';
+import { HEADER_LENGTH } from '../format.js';
+import type { DxtArtifactInput } from '../types.js';
+
+const BASE_INPUT: DxtArtifactInput = {
+  sourceInstanceId: 'ffffffff-0000-0000-0000-000000000001',
+  registryId: '@skytwin/test-server',
+  transport: 'stdio',
+  command: 'node',
+  args: ['server.js'],
+  skills: ['ping'],
+};
+
+describe('DXT tamper detection', () => {
+  it('rejects a blob with a single flipped bit in the payload', async () => {
+    const { blob } = await serialize(BASE_INPUT);
+
+    // Flip the first byte of the JSON payload
+    const tampered = Buffer.from(blob);
+    tampered[HEADER_LENGTH] = tampered[HEADER_LENGTH]! ^ 0x01;
+
+    const result = deserialize(tampered);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe('SHA256_MISMATCH');
+  });
+
+  it('rejects a blob with a flipped byte near the end of the payload', async () => {
+    const { blob } = await serialize(BASE_INPUT);
+
+    const tampered = Buffer.from(blob);
+    // Flip the last byte
+    tampered[tampered.length - 1] = tampered[tampered.length - 1]! ^ 0xff;
+
+    const result = deserialize(tampered);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe('SHA256_MISMATCH');
+  });
+
+  it('rejects a blob with wrong magic header', async () => {
+    const { blob } = await serialize(BASE_INPUT);
+
+    const tampered = Buffer.from(blob);
+    // Overwrite magic "DXT1" with "XXXX"
+    tampered.write('XXXX', 0, 'ascii');
+
+    const result = deserialize(tampered);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe('MAGIC_MISMATCH');
+  });
+
+  it('rejects a blob with an unsupported version number', async () => {
+    const { blob } = await serialize(BASE_INPUT);
+
+    const tampered = Buffer.from(blob);
+    // Overwrite version uint32 BE at offset 4 with 99
+    tampered.writeUInt32BE(99, 4);
+
+    const result = deserialize(tampered);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe('UNSUPPORTED_VERSION');
+  });
+
+  it('rejects a truncated blob (shorter than HEADER_LENGTH)', async () => {
+    const tinyBlob = Buffer.alloc(10);
+
+    const result = deserialize(tinyBlob);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe('TRUNCATED');
+  });
+
+  it('rejects a blob where declared length does not match actual payload', async () => {
+    const { blob } = await serialize(BASE_INPUT);
+
+    const tampered = Buffer.from(blob);
+    // Inflate the declared length by 1 without adding a byte
+    const currentLen = tampered.readUInt32BE(44);
+    tampered.writeUInt32BE(currentLen + 1, 44);
+
+    const result = deserialize(tampered);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe('LENGTH_MISMATCH');
+  });
+
+  it('a valid artifact deserializes successfully (control)', async () => {
+    const { blob } = await serialize(BASE_INPUT);
+    const result = deserialize(blob);
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/dxt/src/deserialize.ts
+++ b/packages/dxt/src/deserialize.ts
@@ -1,0 +1,148 @@
+/**
+ * deserialize.ts — Unpack and verify a DXT binary artifact.
+ *
+ * Returns a typed DxtResult so the API layer can produce a 400 (user error)
+ * rather than a 500 (server crash) when given a malformed blob.
+ *
+ * Verification steps:
+ *   1. Buffer must be at least HEADER_LENGTH bytes (48).
+ *   2. First 4 bytes must match DXT_MAGIC ("DXT1").
+ *   3. Version uint32 BE must equal DXT_VERSION (1).
+ *   4. Declared payload length (uint64 BE) must match actual remaining bytes.
+ *   5. SHA-256 of the payload must match the 32-byte hash in the header.
+ *   6. Payload must be valid UTF-8 JSON that satisfies the schema.
+ */
+
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { DXT_MAGIC, DXT_VERSION, HEADER_LENGTH } from './format.js';
+import type {
+  DxtArtifactContents,
+  DxtJsonPayload,
+  DxtResult,
+} from './types.js';
+
+/**
+ * Parse and verify a DXT binary blob.
+ *
+ * Never throws on user-supplied data — all failure modes are returned as
+ * `{ success: false, error, code }`.
+ *
+ * @param blob - Raw bytes of the .dxt artifact.
+ * @returns Typed result containing the parsed payload and computed SHA-256.
+ */
+export function deserialize(
+  blob: Buffer,
+): DxtResult<DxtArtifactContents> {
+  // ── 1. Minimum length ──────────────────────────────────────────────────────
+  if (blob.length < HEADER_LENGTH) {
+    return {
+      success: false,
+      error: `Artifact is too short: ${blob.length} bytes (minimum ${HEADER_LENGTH})`,
+      code: 'TRUNCATED',
+    };
+  }
+
+  let offset = 0;
+
+  // ── 2. Magic ───────────────────────────────────────────────────────────────
+  const magic = blob.subarray(offset, offset + 4);
+  offset += 4;
+
+  if (!magic.equals(DXT_MAGIC)) {
+    return {
+      success: false,
+      error: `Magic mismatch: expected "DXT1", got "${magic.toString('ascii')}"`,
+      code: 'MAGIC_MISMATCH',
+    };
+  }
+
+  // ── 3. Version ─────────────────────────────────────────────────────────────
+  const version = blob.readUInt32BE(offset);
+  offset += 4;
+
+  if (version !== DXT_VERSION) {
+    return {
+      success: false,
+      error: `Unsupported DXT version: ${version} (this library supports version ${DXT_VERSION})`,
+      code: 'UNSUPPORTED_VERSION',
+    };
+  }
+
+  // ── 4. SHA-256 header ──────────────────────────────────────────────────────
+  const headerSha256 = blob.subarray(offset, offset + 32);
+  offset += 32;
+
+  // ── 5. Payload length ──────────────────────────────────────────────────────
+  // Two uint32 BE words = uint64 BE. High word must be zero for sane sizes.
+  const lenHigh = blob.readUInt32BE(offset);
+  const lenLow = blob.readUInt32BE(offset + 4);
+  offset += 8;
+
+  if (lenHigh !== 0) {
+    return {
+      success: false,
+      error: 'Declared payload length exceeds safe integer range',
+      code: 'LENGTH_MISMATCH',
+    };
+  }
+
+  const declaredLen = lenLow;
+  const remaining = blob.length - HEADER_LENGTH;
+
+  if (remaining !== declaredLen) {
+    return {
+      success: false,
+      error: `Payload length mismatch: header declares ${declaredLen} bytes, artifact has ${remaining} bytes`,
+      code: 'LENGTH_MISMATCH',
+    };
+  }
+
+  // ── 6. Extract payload ─────────────────────────────────────────────────────
+  const jsonBytes = blob.subarray(offset, offset + declaredLen);
+
+  // ── 7. SHA-256 verification ────────────────────────────────────────────────
+  const computedSha256 = createHash('sha256').update(jsonBytes).digest();
+
+  // Use timingSafeEqual to prevent timing attacks against the hash comparison.
+  if (!timingSafeEqual(headerSha256, computedSha256)) {
+    return {
+      success: false,
+      error: 'SHA-256 mismatch: artifact has been tampered with or is corrupted',
+      code: 'SHA256_MISMATCH',
+    };
+  }
+
+  // ── 8. JSON parse ──────────────────────────────────────────────────────────
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonBytes.toString('utf8'));
+  } catch {
+    return {
+      success: false,
+      error: 'Payload is not valid JSON',
+      code: 'PARSE_ERROR',
+    };
+  }
+
+  // Basic structural validation — we only need enough to prevent crashes
+  // upstream. Full schema validation is the caller's responsibility.
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    (parsed as Record<string, unknown>)['schemaVersion'] !== 1
+  ) {
+    return {
+      success: false,
+      error: 'Payload does not match DxtJsonPayload schema (schemaVersion must be 1)',
+      code: 'PARSE_ERROR',
+    };
+  }
+
+  return {
+    success: true,
+    data: {
+      payload: parsed as DxtJsonPayload,
+      computedSha256,
+    },
+  };
+}

--- a/packages/dxt/src/format.ts
+++ b/packages/dxt/src/format.ts
@@ -1,0 +1,67 @@
+/**
+ * format.ts — DXT artifact format constants and helpers.
+ *
+ * Binary layout of a .dxt file:
+ *
+ *   Offset   Length   Description
+ *   ------   ------   -----------
+ *   0        4        Magic: ASCII "DXT1"
+ *   4        4        Version: uint32 big-endian (currently 1)
+ *   8        32       SHA-256 over the JSON payload (raw bytes)
+ *   40       8        JSON payload length: uint64 big-endian (bytes)
+ *   48       N        JSON payload (UTF-8)
+ *
+ * Total header: 48 bytes.
+ *
+ * Privacy note: command strings can contain secrets such as
+ * "--token=<value>" passed as CLI args to stdio MCP servers.
+ * Call redactCommand() on args before including them in a DxtJsonPayload.
+ */
+
+/** Four-byte magic identifier. All DXT artifacts must begin with these bytes. */
+export const DXT_MAGIC = Buffer.from('DXT1', 'ascii');
+
+/** Current format version. Increment when the binary layout changes. */
+export const DXT_VERSION = 1;
+
+/** Byte length of the fixed header (magic + version + sha256 + length field). */
+export const HEADER_LENGTH = 4 + 4 + 32 + 8; // 48 bytes
+
+/**
+ * Patterns matching CLI argument names known to carry secrets.
+ * Arguments whose name matches any of these patterns are masked before
+ * the payload is serialised to disk.
+ */
+const SECRET_ARG_PATTERNS: RegExp[] = [
+  /^--token=/i,
+  /^--api-key=/i,
+  /^--secret=/i,
+  /^--apikey=/i,
+  /^--access-token=/i,
+  /^--auth-token=/i,
+];
+
+/**
+ * Redact secret-looking CLI arguments so they are never written into a DXT
+ * artifact.
+ *
+ * Example:
+ *   redactCommand(['--token=sk-abc123', '--port=3000'])
+ *   => ['--token=<redacted>', '--port=3000']
+ *
+ * @param args - The raw args array from the mcp_servers row.
+ * @returns A new array with any secret argument values replaced by "<redacted>".
+ */
+export function redactCommand(args: string[]): string[] {
+  return args.map((arg) => {
+    for (const pattern of SECRET_ARG_PATTERNS) {
+      if (pattern.test(arg)) {
+        const eqIdx = arg.indexOf('=');
+        if (eqIdx !== -1) {
+          return `${arg.slice(0, eqIdx + 1)}<redacted>`;
+        }
+      }
+    }
+    return arg;
+  });
+}

--- a/packages/dxt/src/index.ts
+++ b/packages/dxt/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @skytwin/dxt — DXT artifact serialization, deserialization, and format types.
+ *
+ * A DXT (Desktop eXtension Transfer) artifact is a packed binary file that
+ * carries MCP server capability configuration between SkyTwin instances.
+ *
+ * Usage:
+ *   import { serialize, deserialize, redactCommand } from '@skytwin/dxt';
+ */
+
+export { serialize } from './serialize.js';
+export { deserialize } from './deserialize.js';
+export { redactCommand, DXT_MAGIC, DXT_VERSION, HEADER_LENGTH } from './format.js';
+export type {
+  DxtJsonPayload,
+  DxtArtifactInput,
+  DxtArtifactContents,
+  DxtResult,
+  DxtErrorCode,
+} from './types.js';

--- a/packages/dxt/src/serialize.ts
+++ b/packages/dxt/src/serialize.ts
@@ -1,0 +1,79 @@
+/**
+ * serialize.ts — Pack a DxtArtifactInput into the DXT binary format.
+ *
+ * The packed format is:
+ *   [4 bytes magic][4 bytes version][32 bytes sha256][8 bytes len][N bytes json]
+ *
+ * Secret CLI args (--token=, --api-key=, --secret=, etc.) are redacted via
+ * redactCommand() before the JSON payload is produced, so they are never
+ * written to disk or to the dxt_exports table.
+ */
+
+import { createHash } from 'node:crypto';
+import { DXT_MAGIC, DXT_VERSION, HEADER_LENGTH, redactCommand } from './format.js';
+import type { DxtArtifactInput, DxtJsonPayload } from './types.js';
+
+/**
+ * Serialize a capability config into a packed DXT binary artifact.
+ *
+ * @param input - Capability configuration to pack.
+ * @returns `blob` — the full binary artifact ready for storage/download,
+ *          `sha256` — the 32-byte SHA-256 of the JSON payload (also embedded in the blob).
+ */
+export async function serialize(
+  input: DxtArtifactInput,
+): Promise<{ blob: Buffer; sha256: Buffer }> {
+  const redactedArgs =
+    input.args !== undefined ? redactCommand(input.args) : undefined;
+
+  const payload: DxtJsonPayload = {
+    schemaVersion: 1,
+    exportedAt: new Date().toISOString(),
+    sourceInstanceId: input.sourceInstanceId,
+    capability: {
+      registryId: input.registryId,
+      transport: input.transport,
+      ...(input.command !== undefined ? { command: input.command } : {}),
+      ...(redactedArgs !== undefined ? { args: redactedArgs } : {}),
+      ...(input.url !== undefined ? { url: input.url } : {}),
+      skills: input.skills,
+    },
+    ...(input.autonomyOverrides !== undefined
+      ? { autonomyOverrides: input.autonomyOverrides }
+      : {}),
+    ...(input.perAppSpendCaps !== undefined
+      ? { perAppSpendCaps: input.perAppSpendCaps }
+      : {}),
+    ...(input.promptOverrides !== undefined
+      ? { promptOverrides: input.promptOverrides }
+      : {}),
+    ...(input.recipeRefs !== undefined ? { recipeRefs: input.recipeRefs } : {}),
+  };
+
+  const jsonBytes = Buffer.from(JSON.stringify(payload), 'utf8');
+  const sha256 = createHash('sha256').update(jsonBytes).digest();
+
+  // Build header: magic(4) + version(4) + sha256(32) + length(8)
+  const header = Buffer.allocUnsafe(HEADER_LENGTH);
+  let offset = 0;
+
+  DXT_MAGIC.copy(header, offset);
+  offset += 4;
+
+  header.writeUInt32BE(DXT_VERSION, offset);
+  offset += 4;
+
+  sha256.copy(header, offset);
+  offset += 32;
+
+  // Write uint64 BE as two uint32 BE words (high and low).
+  // JavaScript's Buffer.writeBigUInt64BE is available in Node 10+, but we
+  // use the two-word approach to stay compatible with the BigInt-free path.
+  const len = jsonBytes.length;
+  header.writeUInt32BE(0, offset); // high 32 bits — payload will never exceed 4 GB
+  header.writeUInt32BE(len, offset + 4);
+  offset += 8;
+
+  const blob = Buffer.concat([header, jsonBytes]);
+  return { blob, sha256 };
+}

--- a/packages/dxt/src/types.ts
+++ b/packages/dxt/src/types.ts
@@ -1,0 +1,76 @@
+/**
+ * types.ts — Public types for the DXT artifact format.
+ *
+ * DXT (Desktop eXtension Transfer) artifacts carry MCP server capability
+ * configuration between SkyTwin instances. They contain no OAuth tokens,
+ * no twin profile data, and no memory contents.
+ */
+
+/** JSON payload carried inside every DXT binary artifact. */
+export interface DxtJsonPayload {
+  schemaVersion: 1;
+  /** ISO 8601 timestamp of when the artifact was produced. */
+  exportedAt: string;
+  /** UUID identifying the source SkyTwin install. */
+  sourceInstanceId: string;
+  capability: {
+    registryId: string;
+    transport: 'stdio' | 'http' | 'sse';
+    /** For stdio transport: the command to execute. */
+    command?: string;
+    /** For stdio transport: arguments passed to the command. */
+    args?: string[];
+    /** For http/sse transport: the server URL. */
+    url?: string;
+    /** Tool names declared by this server. */
+    skills: string[];
+  };
+  autonomyOverrides?: Record<string, unknown>;
+  perAppSpendCaps?: {
+    perActionCents?: number;
+    dailyCents?: number;
+    monthlyCents?: number;
+  };
+  promptOverrides?: Array<{ slug: string; version: number; body: string }>;
+  /** Recipe slugs the capability was installed from (if any). */
+  recipeRefs?: string[];
+}
+
+/** Input to serialize() — mirrors the mcp_servers row plus skills. */
+export interface DxtArtifactInput {
+  sourceInstanceId: string;
+  registryId: string;
+  transport: 'stdio' | 'http' | 'sse';
+  command?: string;
+  args?: string[];
+  url?: string;
+  skills: string[];
+  autonomyOverrides?: Record<string, unknown>;
+  perAppSpendCaps?: {
+    perActionCents?: number;
+    dailyCents?: number;
+    monthlyCents?: number;
+  };
+  promptOverrides?: Array<{ slug: string; version: number; body: string }>;
+  recipeRefs?: string[];
+}
+
+/** Result of deserialize() on a valid artifact. */
+export interface DxtArtifactContents {
+  payload: DxtJsonPayload;
+  /** SHA-256 of the JSON payload as stored in the artifact header. */
+  computedSha256: Buffer;
+}
+
+/** Typed result for operations that can fail with user-visible errors. */
+export type DxtResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; code: DxtErrorCode };
+
+export type DxtErrorCode =
+  | 'MAGIC_MISMATCH'
+  | 'UNSUPPORTED_VERSION'
+  | 'LENGTH_MISMATCH'
+  | 'SHA256_MISMATCH'
+  | 'PARSE_ERROR'
+  | 'TRUNCATED';

--- a/packages/dxt/tsconfig.json
+++ b/packages/dxt/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@skytwin/decision-engine':
         specifier: workspace:*
         version: link:../../packages/decision-engine
+      '@skytwin/dxt':
+        specifier: workspace:*
+        version: link:../../packages/dxt
       '@skytwin/execution-router':
         specifier: workspace:*
         version: link:../../packages/execution-router
@@ -454,6 +457,25 @@ importers:
       vitest:
         specifier: ^1.3.0
         version: 1.6.1(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2)
+
+  packages/dxt:
+    dependencies:
+      '@skytwin/core':
+        specifier: workspace:*
+        version: link:../core
+      '@skytwin/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.3.0
+        version: 1.6.1(@types/node@20.19.37)(lightningcss@1.32.0)(terser@5.46.2)
 
   packages/evals:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
       "@skytwin/credential-vault": ["./packages/credential-vault/src"],
       "@skytwin/db": ["./packages/db/src"],
       "@skytwin/decision-engine": ["./packages/decision-engine/src"],
+      "@skytwin/dxt": ["./packages/dxt/src"],
       "@skytwin/evals": ["./packages/evals/src"],
       "@skytwin/execution-router": ["./packages/execution-router/src"],
       "@skytwin/explanations": ["./packages/explanations/src"],


### PR DESCRIPTION
## Summary

Code-bound subset of #180. Implements the capability-transfer pipeline that `docs/dxt-transfer.md` (shipped in #211) described — end-to-end except for the desktop drag-drop UI and the actual confirmed-install flow.

## What's in here

### `@skytwin/dxt` (new package)

Binary artifact format:

- **Header** (48 bytes): 4-byte magic `DXT1` + 4-byte version + 32-byte SHA-256 + 8-byte length
- **Payload**: UTF-8 JSON describing the capability (registry id, transport, command/args/url, skills, autonomy overrides, per-app spend caps, prompt overrides, recipe refs)

Functions:

- `serialize(input)` packs an `mcp_servers` row + skills
- `deserialize(blob)` returns a typed `DxtResult<T>` — **never throws on user input** (boundary contract). Tamper detection via SHA-256 + magic + version + length checks
- `redactCommand(args)` — masks `--token=*` / `--api-key=*` / `--secret=*` / `--apikey=*` / `--access-token=*` / `--auth-token=*` CLI args **before** they reach the artifact

15 unit tests (round-trip, magic mismatch, version mismatch, length mismatch, SHA-256 tamper, redaction).

### `dxtExportRepository` (@skytwin/db)

`create(input)`, `findById(id)`, `listForUser(userId)` against the existing `dxt_exports` table from migration 027.

### Four API routes (sessionAuth + requireOwnership)

- `POST /api/dxt/export/:serverId` — serialize + persist + return base64 blob
- `GET  /api/dxt/exports` — metadata-only listing
- `GET  /api/dxt/exports/:id/blob` — download `application/octet-stream`
- `POST /api/dxt/import` — **preview-only** deserialization with detection of whether the capability is already installed

Import is preview-only — explicit confirm + install flow is deferred so the user always reviews the parsed payload before any state changes.

## Hard rails

- PII never serialised: `redactCommand` runs on every export
- All mutating paths ownership-checked
- Tamper detection on every import (SHA-256 over JSON payload, verified before parse)
- Import never modifies state — preview only
- `deserialize` is typed-result, never throws on garbage input

## Out of scope (deferred to environmental work)

- Drag-drop UI on the desktop app — needs Electron testing
- The actual install-from-DXT flow (preview only here — explicit confirm + install step needs UI)
- Idle bridge from #180
- Zero-trust container hooks from #180 / #183 AC#4

## Tests

- `@skytwin/dxt`: 15 (round-trip + tamper)
- `@skytwin/api`: 387 (was 367, +9 new for `dxt-routes.test.ts`, +11 from connectors with the lazy-migration counter test from #217)

## Test plan

- [x] `pnpm --filter @skytwin/dxt test` → 15/15
- [x] `pnpm --filter @skytwin/api test` → 387 passing
- [x] Direct `pnpm --filter @skytwin/dxt build` → clean
- [x] Direct `pnpm --filter @skytwin/api build` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)