### PR TITLE
docs(CLAUDE.md): turbo parallel race on @skytwin/db dist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,26 @@ grep '<NAME>' packages/shared-types/dist/index.js
 
 This shows up most often after rebasing across changes to `packages/shared-types/src/index.ts`. CI is unaffected (fresh installs). Only the local worktree sees it.
 
+### Build gotcha: turbo parallel race on @skytwin/db dist
+
+If `pnpm build` fails on `@skytwin/api` with `Property 'X' does not exist on type {...}` for a method that's clearly in `packages/db/src/repositories/*.ts`, turbo's default parallel concurrency is racing on the `@skytwin/db` dist between dependent builds. Direct `pnpm --filter @skytwin/api build` succeeds because there's no race; full `pnpm build` fails because parallel writers stomp on each other's `.d.ts` output.
+
+Workaround:
+
+```bash
+pnpm build --concurrency=1   # serial build, ~10s slower but always correct
+```
+
+Or pre-build `@skytwin/db` to a stable state, then full build:
+
+```bash
+rm -rf packages/db/dist packages/db/tsconfig.tsbuildinfo \
+  && pnpm --filter @skytwin/db build \
+  && pnpm build
+```
+
+CI is unaffected (clean dist on every run).
+
 ## Package Descriptions
 
 | Package | Purpose |


### PR DESCRIPTION
## Summary

Documents the local turbo parallel-race build failure that bit me for ~6 hours during the overnight cascade.

## Root cause

Turbo's default parallel concurrency races on the `@skytwin/db` dist between dependent builds. Two parallel writers stomp on each other's `.d.ts` output, leaving an incomplete file that doesn't include all methods declared in source.

**Direct `pnpm --filter @skytwin/api build` succeeds** (no race — only one builder).

**Full `pnpm build` fails** with `Property 'X' does not exist on type {...}` for methods that are clearly in `packages/db/src/repositories/*.ts`.

## Workaround

```bash
pnpm build --concurrency=1   # serial, ~10s slower, always correct
```

Or pre-build `@skytwin/db` first:

```bash
rm -rf packages/db/dist packages/db/tsconfig.tsbuildinfo
pnpm --filter @skytwin/db build
pnpm build
```

CI is unaffected — clean dist on every run.

## What changed

Added a "Build gotcha: turbo parallel race on @skytwin/db dist" subsection to CLAUDE.md, right next to the existing "shared-types dist can go stale after rebases" gotcha. Same shape, same diagnosis pattern.

## Why this matters

Future sessions of `pnpm build` will hit the same wall. The fix isn't environmental — it's a turbo concurrency issue that anyone touching this repo on a fresh machine will run into. Documenting it next to the existing similar issue keeps the institutional knowledge in the right place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)