### PR TITLE
feat(#187 partial): @skytwin/embedded-llm — runtime + port scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Embedded LLM port scaffold (#187 partial)
+
+Scaffolds the runtime detection + port interfaces so the rest of the
+codebase can call into a future embedded-LLM implementation through a
+stable contract. Real llama.cpp / Whisper / Piper integrations are
+explicitly deferred — they require binary distribution and integration
+testing on real models.
+
+### Added — `@skytwin/embedded-llm`
+
+- `detectEmbeddedRuntimes()` — checks `which`/`where` for `llama-cli`,
+  `whisper-cli`, `piper`. Honors env vars (`SKYTWIN_LLAMACPP_BIN`,
+  `SKYTWIN_WHISPER_BIN`, `SKYTWIN_PIPER_BIN`) for explicit overrides.
+  Never spawns the binaries — existence-check only.
+- `EmbeddedTextPort` / `EmbeddedSttPort` / `EmbeddedTtsPort` interfaces
+  with `Null*` fallback impls. Calling `generate` / `transcribe` /
+  `synthesize` on a Null impl throws `NotAvailableError` with a typed
+  `runtime` field.
+- 22 tests across runtime-detector and null-ports.
+
+### Explicitly deferred
+
+- Real llama.cpp / Whisper / Piper integration — needs binaries
+- Model auto-download / auto-upgrade — needs CDN + cryptographic
+  verification of model artifacts
+- Speaker diarization, voice cloning, fine-tuning — out of scope for v1
+- Web UI for model management — needs the real backend first
+
+### Known interface gaps for the real-implementation PR
+
+- `generate()` returns `Promise<string>` (full completion) — no token
+  streaming. llama.cpp typically streams; the real PR may add an
+  overload or a separate `generateStream()` method.
+- `transcribe()` takes a raw `Buffer` — audio format implicit. Whisper
+  needs a known format; the real PR may add `opts.format`.
+- `synthesize()` returns a raw `Buffer` — audio mime type unspecified.
+  The real PR may return `{ audio: Buffer; mimeType: string }`.
+- No `init`/`dispose` lifecycle — model loading happens internally.
+  The real PR may add a `create(opts)` factory.
+
 ## [unreleased] — DXT export/import scaffold (#180 partial)
 
 The capability-transfer pipeline that `docs/dxt-transfer.md` (shipped in #211)

--- a/packages/embedded-llm/package.json
+++ b/packages/embedded-llm/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@skytwin/embedded-llm",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@skytwin/core": "workspace:*",
+    "@skytwin/shared-types": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.3.0"
+  }
+}

--- a/packages/embedded-llm/src/__tests__/null-ports.test.ts
+++ b/packages/embedded-llm/src/__tests__/null-ports.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { NotAvailableError } from '../errors.js';
+import { NullEmbeddedSttPort } from '../stt-port.js';
+import { NullEmbeddedTextPort } from '../text-port.js';
+import { NullEmbeddedTtsPort } from '../tts-port.js';
+
+describe('NullEmbeddedTextPort', () => {
+  it('reports capabilities.available as false', () => {
+    const port = new NullEmbeddedTextPort();
+    expect(port.capabilities.available).toBe(false);
+  });
+
+  it('reports null modelName and contextWindow', () => {
+    const port = new NullEmbeddedTextPort();
+    expect(port.capabilities.modelName).toBeNull();
+    expect(port.capabilities.contextWindow).toBeNull();
+  });
+
+  it('throws NotAvailableError with runtime=llama on generate()', async () => {
+    const port = new NullEmbeddedTextPort();
+    await expect(port.generate('hello')).rejects.toThrow(NotAvailableError);
+    await expect(port.generate('hello')).rejects.toMatchObject({ runtime: 'llama' });
+  });
+
+  it('throws NotAvailableError even when opts are provided', async () => {
+    const port = new NullEmbeddedTextPort();
+    await expect(port.generate('hello', { maxTokens: 128, temperature: 0.5 })).rejects.toThrow(
+      NotAvailableError,
+    );
+  });
+});
+
+describe('NullEmbeddedSttPort', () => {
+  it('reports capabilities.available as false', () => {
+    const port = new NullEmbeddedSttPort();
+    expect(port.capabilities.available).toBe(false);
+  });
+
+  it('reports an empty supportedFormats array', () => {
+    const port = new NullEmbeddedSttPort();
+    expect(port.capabilities.supportedFormats).toEqual([]);
+  });
+
+  it('throws NotAvailableError with runtime=whisper on transcribe()', async () => {
+    const port = new NullEmbeddedSttPort();
+    const audio = Buffer.from('fake-audio');
+    await expect(port.transcribe(audio)).rejects.toThrow(NotAvailableError);
+    await expect(port.transcribe(audio)).rejects.toMatchObject({ runtime: 'whisper' });
+  });
+
+  it('throws NotAvailableError when language opt is provided', async () => {
+    const port = new NullEmbeddedSttPort();
+    const audio = Buffer.from('fake-audio');
+    await expect(port.transcribe(audio, { language: 'en' })).rejects.toThrow(NotAvailableError);
+  });
+});
+
+describe('NullEmbeddedTtsPort', () => {
+  it('reports capabilities.available as false', () => {
+    const port = new NullEmbeddedTtsPort();
+    expect(port.capabilities.available).toBe(false);
+  });
+
+  it('reports an empty voices array', () => {
+    const port = new NullEmbeddedTtsPort();
+    expect(port.capabilities.voices).toEqual([]);
+  });
+
+  it('throws NotAvailableError with runtime=piper on synthesize()', async () => {
+    const port = new NullEmbeddedTtsPort();
+    await expect(port.synthesize('hello')).rejects.toThrow(NotAvailableError);
+    await expect(port.synthesize('hello')).rejects.toMatchObject({ runtime: 'piper' });
+  });
+
+  it('throws NotAvailableError when voice opt is provided', async () => {
+    const port = new NullEmbeddedTtsPort();
+    await expect(port.synthesize('hello', { voice: 'en_US-amy-medium' })).rejects.toThrow(
+      NotAvailableError,
+    );
+  });
+});
+
+describe('NotAvailableError', () => {
+  it('has the correct name and runtime field', () => {
+    const err = new NotAvailableError('llama');
+    expect(err.name).toBe('NotAvailableError');
+    expect(err.runtime).toBe('llama');
+    expect(err.message).toContain('llama');
+  });
+
+  it('is an instance of Error', () => {
+    const err = new NotAvailableError('piper');
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/packages/embedded-llm/src/__tests__/runtime-detector.test.ts
+++ b/packages/embedded-llm/src/__tests__/runtime-detector.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { detectEmbeddedRuntimes } from '../runtime-detector.js';
+
+// We mock child_process and fs so we never spawn real binaries.
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+const mockExecSync = vi.mocked(execSync);
+const mockExistsSync = vi.mocked(existsSync);
+
+function clearRuntimeEnvVars() {
+  delete process.env['SKYTWIN_LLAMACPP_BIN'];
+  delete process.env['SKYTWIN_WHISPER_BIN'];
+  delete process.env['SKYTWIN_PIPER_BIN'];
+  delete process.env['SKYTWIN_LLAMA_MODELS'];
+  delete process.env['SKYTWIN_WHISPER_MODELS'];
+  delete process.env['SKYTWIN_PIPER_MODELS'];
+}
+
+beforeEach(() => {
+  clearRuntimeEnvVars();
+  vi.resetAllMocks();
+});
+
+afterEach(() => {
+  clearRuntimeEnvVars();
+});
+
+describe('detectEmbeddedRuntimes', () => {
+  it('returns available:false for all runtimes when no binary is found in PATH and no env vars set', async () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
+
+    const result = await detectEmbeddedRuntimes();
+
+    expect(result.llamaCpp.available).toBe(false);
+    expect(result.llamaCpp.binaryPath).toBeNull();
+    expect(result.whisper.available).toBe(false);
+    expect(result.whisper.binaryPath).toBeNull();
+    expect(result.piper.available).toBe(false);
+    expect(result.piper.binaryPath).toBeNull();
+  });
+
+  it('prefers SKYTWIN_LLAMACPP_BIN env var over PATH lookup when the path exists', async () => {
+    process.env['SKYTWIN_LLAMACPP_BIN'] = '/opt/local/bin/llama-cli';
+    mockExistsSync.mockReturnValue(true);
+    // execSync should NOT be called for llama when env var is set and path exists.
+    mockExecSync.mockImplementation(() => {
+      throw new Error('should not be called');
+    });
+
+    const result = await detectEmbeddedRuntimes();
+
+    expect(result.llamaCpp.available).toBe(true);
+    expect(result.llamaCpp.binaryPath).toBe('/opt/local/bin/llama-cli');
+  });
+
+  it('returns available:false when SKYTWIN_LLAMACPP_BIN is set but path does not exist', async () => {
+    process.env['SKYTWIN_LLAMACPP_BIN'] = '/nonexistent/llama-cli';
+    mockExistsSync.mockReturnValue(false);
+    mockExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
+
+    const result = await detectEmbeddedRuntimes();
+
+    expect(result.llamaCpp.available).toBe(false);
+    expect(result.llamaCpp.binaryPath).toBeNull();
+  });
+
+  it('detects all three runtimes as available when all binaries are present in PATH', async () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes('llama-cli')) return Buffer.from('/usr/local/bin/llama-cli\n');
+      if (cmdStr.includes('whisper-cli')) return Buffer.from('/usr/local/bin/whisper-cli\n');
+      if (cmdStr.includes('piper')) return Buffer.from('/usr/local/bin/piper\n');
+      throw new Error('unknown');
+    });
+
+    const result = await detectEmbeddedRuntimes();
+
+    expect(result.llamaCpp.available).toBe(true);
+    expect(result.llamaCpp.binaryPath).toBe('/usr/local/bin/llama-cli');
+    expect(result.whisper.available).toBe(true);
+    expect(result.whisper.binaryPath).toBe('/usr/local/bin/whisper-cli');
+    expect(result.piper.available).toBe(true);
+    expect(result.piper.binaryPath).toBe('/usr/local/bin/piper');
+  });
+
+  it('handles partial detection (one available, two not)', async () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes('whisper-cli')) return Buffer.from('/usr/bin/whisper-cli\n');
+      throw new Error('not found');
+    });
+
+    const result = await detectEmbeddedRuntimes();
+
+    expect(result.llamaCpp.available).toBe(false);
+    expect(result.whisper.available).toBe(true);
+    expect(result.whisper.binaryPath).toBe('/usr/bin/whisper-cli');
+    expect(result.piper.available).toBe(false);
+  });
+
+  it('resolves model dirs from env vars independently of binary availability', async () => {
+    process.env['SKYTWIN_LLAMA_MODELS'] = '/models/llama';
+    process.env['SKYTWIN_WHISPER_MODELS'] = '/models/whisper';
+    process.env['SKYTWIN_PIPER_MODELS'] = '/models/piper';
+    mockExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
+
+    const result = await detectEmbeddedRuntimes();
+
+    expect(result.llamaCpp.modelDir).toBe('/models/llama');
+    expect(result.whisper.modelDir).toBe('/models/whisper');
+    expect(result.piper.modelDir).toBe('/models/piper');
+    // Available is still false — model dir alone doesn't make a runtime available.
+    expect(result.llamaCpp.available).toBe(false);
+  });
+
+  it('returns null modelDir when no model dir env var is set', async () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
+
+    const result = await detectEmbeddedRuntimes();
+
+    expect(result.llamaCpp.modelDir).toBeNull();
+    expect(result.whisper.modelDir).toBeNull();
+    expect(result.piper.modelDir).toBeNull();
+  });
+
+  it('uses SKYTWIN_WHISPER_BIN and SKYTWIN_PIPER_BIN env-var overrides', async () => {
+    process.env['SKYTWIN_WHISPER_BIN'] = '/custom/whisper-cli';
+    process.env['SKYTWIN_PIPER_BIN'] = '/custom/piper';
+    mockExistsSync.mockReturnValue(true);
+    mockExecSync.mockImplementation(() => {
+      throw new Error('should not be called for whisper or piper');
+    });
+
+    const result = await detectEmbeddedRuntimes();
+
+    expect(result.whisper.available).toBe(true);
+    expect(result.whisper.binaryPath).toBe('/custom/whisper-cli');
+    expect(result.piper.available).toBe(true);
+    expect(result.piper.binaryPath).toBe('/custom/piper');
+  });
+});

--- a/packages/embedded-llm/src/errors.ts
+++ b/packages/embedded-llm/src/errors.ts
@@ -1,0 +1,20 @@
+/**
+ * Thrown by Null* port implementations when callers invoke an operation on a
+ * runtime that is not available on this machine.
+ */
+export class NotAvailableError extends Error {
+  /**
+   * Identifies which embedded runtime is unavailable so callers can format
+   * user-facing messages accordingly.
+   */
+  readonly runtime: 'llama' | 'whisper' | 'piper';
+
+  constructor(runtime: 'llama' | 'whisper' | 'piper') {
+    super(
+      `Embedded runtime '${runtime}' is not available on this machine. ` +
+        'Install the corresponding binary and restart the application.',
+    );
+    this.name = 'NotAvailableError';
+    this.runtime = runtime;
+  }
+}

--- a/packages/embedded-llm/src/index.ts
+++ b/packages/embedded-llm/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * @skytwin/embedded-llm
+ *
+ * Runtime detection and port interfaces for embedded LLM/STT/TTS binaries
+ * (llama.cpp, Whisper-tiny, Piper). The Null* fallback implementations are
+ * the production defaults until the actual binaries are installed.
+ *
+ * See issue #187 for the full spec.
+ */
+
+export {
+  detectEmbeddedRuntimes,
+  type EmbeddedRuntimeInfo,
+  type EmbeddedRuntimeEntry,
+} from './runtime-detector.js';
+
+export { NotAvailableError } from './errors.js';
+
+export {
+  NullEmbeddedTextPort,
+  type EmbeddedTextPort,
+  type EmbeddedTextCapabilities,
+} from './text-port.js';
+
+export {
+  NullEmbeddedSttPort,
+  type EmbeddedSttPort,
+  type EmbeddedSttCapabilities,
+} from './stt-port.js';
+
+export {
+  NullEmbeddedTtsPort,
+  type EmbeddedTtsPort,
+  type EmbeddedTtsCapabilities,
+} from './tts-port.js';

--- a/packages/embedded-llm/src/runtime-detector.ts
+++ b/packages/embedded-llm/src/runtime-detector.ts
@@ -1,0 +1,93 @@
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+/**
+ * Capability information for a single embedded runtime.
+ */
+export interface EmbeddedRuntimeEntry {
+  available: boolean;
+  binaryPath: string | null;
+  modelDir: string | null;
+}
+
+/**
+ * Aggregated detection result for all supported embedded runtimes.
+ */
+export interface EmbeddedRuntimeInfo {
+  llamaCpp: EmbeddedRuntimeEntry;
+  whisper: EmbeddedRuntimeEntry;
+  piper: EmbeddedRuntimeEntry;
+}
+
+/**
+ * Resolves the binary path for a given CLI name, preferring an explicit env-var
+ * override. Returns null when neither the env var nor PATH lookup finds it.
+ *
+ * IMPORTANT: this function only checks for existence — it never spawns the binary.
+ */
+function resolveBinary(envVar: string, cliName: string): string | null {
+  const fromEnv = process.env[envVar];
+  if (fromEnv !== undefined && fromEnv !== '') {
+    return existsSync(fromEnv) ? fromEnv : null;
+  }
+
+  // Fall back to `which` (Unix) / `where` (Windows) for PATH lookup.
+  const cmd = process.platform === 'win32' ? `where ${cliName}` : `which ${cliName}`;
+  try {
+    const result = execSync(cmd, { stdio: 'pipe', timeout: 3000 })
+      .toString()
+      .trim()
+      .split('\n')[0];
+    return result !== undefined && result !== '' ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolves the model directory from an env var. Returns null when the var is
+ * unset or empty. Existence of the directory is not verified because the
+ * directory may be created lazily by the actual integration.
+ */
+function resolveModelDir(envVar: string): string | null {
+  const value = process.env[envVar];
+  return value !== undefined && value !== '' ? value : null;
+}
+
+/**
+ * Detects which embedded runtimes are available on the current machine.
+ *
+ * Detection strategy (per runtime):
+ *   1. If the corresponding SKYTWIN_*_BIN env var is set, use that path
+ *      (existence-checked via fs.existsSync).
+ *   2. Otherwise, run `which <cli>` (or `where` on Windows) to locate the
+ *      binary in PATH.
+ *   3. Model directories are taken from SKYTWIN_LLAMA_MODELS,
+ *      SKYTWIN_WHISPER_MODELS, and SKYTWIN_PIPER_MODELS env vars.
+ *
+ * Returns a Promise so future implementations can perform async detection
+ * (e.g. probing a socket) without breaking the contract.
+ */
+export async function detectEmbeddedRuntimes(): Promise<EmbeddedRuntimeInfo> {
+  const llamaBin = resolveBinary('SKYTWIN_LLAMACPP_BIN', 'llama-cli');
+  const whisperBin = resolveBinary('SKYTWIN_WHISPER_BIN', 'whisper-cli');
+  const piperBin = resolveBinary('SKYTWIN_PIPER_BIN', 'piper');
+
+  return {
+    llamaCpp: {
+      available: llamaBin !== null,
+      binaryPath: llamaBin,
+      modelDir: resolveModelDir('SKYTWIN_LLAMA_MODELS'),
+    },
+    whisper: {
+      available: whisperBin !== null,
+      binaryPath: whisperBin,
+      modelDir: resolveModelDir('SKYTWIN_WHISPER_MODELS'),
+    },
+    piper: {
+      available: piperBin !== null,
+      binaryPath: piperBin,
+      modelDir: resolveModelDir('SKYTWIN_PIPER_MODELS'),
+    },
+  };
+}

--- a/packages/embedded-llm/src/stt-port.ts
+++ b/packages/embedded-llm/src/stt-port.ts
@@ -1,0 +1,36 @@
+import { NotAvailableError } from './errors.js';
+
+/**
+ * Read-only capabilities advertised by an embedded speech-to-text runtime.
+ */
+export interface EmbeddedSttCapabilities {
+  readonly available: boolean;
+  readonly supportedFormats: string[];
+}
+
+/**
+ * Port interface for embedded speech-to-text (Whisper-tiny).
+ *
+ * Real implementations back this with the whisper-cli binary. The Null
+ * implementation is the current default — it allows the rest of the codebase
+ * to import and reference the port without requiring the binary to be present.
+ */
+export interface EmbeddedSttPort {
+  readonly capabilities: EmbeddedSttCapabilities;
+  transcribe(audio: Buffer, opts?: { language?: string }): Promise<string>;
+}
+
+/**
+ * No-op fallback used when the Whisper binary is absent.
+ * Every method call throws a typed NotAvailableError.
+ */
+export class NullEmbeddedSttPort implements EmbeddedSttPort {
+  readonly capabilities: EmbeddedSttCapabilities = {
+    available: false,
+    supportedFormats: [],
+  };
+
+  async transcribe(_audio: Buffer, _opts?: { language?: string }): Promise<string> {
+    throw new NotAvailableError('whisper');
+  }
+}

--- a/packages/embedded-llm/src/text-port.ts
+++ b/packages/embedded-llm/src/text-port.ts
@@ -1,0 +1,44 @@
+import { NotAvailableError } from './errors.js';
+
+/**
+ * Read-only capabilities advertised by an embedded text-generation runtime.
+ */
+export interface EmbeddedTextCapabilities {
+  readonly available: boolean;
+  readonly modelName: string | null;
+  readonly contextWindow: number | null;
+}
+
+/**
+ * Port interface for embedded text generation (llama.cpp).
+ *
+ * Real implementations back this with the llama-cli binary. The Null
+ * implementation is the current default — it allows the rest of the codebase
+ * to import and reference the port without requiring the binary to be present.
+ */
+export interface EmbeddedTextPort {
+  readonly capabilities: EmbeddedTextCapabilities;
+  generate(
+    prompt: string,
+    opts?: { maxTokens?: number; temperature?: number },
+  ): Promise<string>;
+}
+
+/**
+ * No-op fallback used when the llama.cpp binary is absent.
+ * Every method call throws a typed NotAvailableError.
+ */
+export class NullEmbeddedTextPort implements EmbeddedTextPort {
+  readonly capabilities: EmbeddedTextCapabilities = {
+    available: false,
+    modelName: null,
+    contextWindow: null,
+  };
+
+  async generate(
+    _prompt: string,
+    _opts?: { maxTokens?: number; temperature?: number },
+  ): Promise<string> {
+    throw new NotAvailableError('llama');
+  }
+}

--- a/packages/embedded-llm/src/tts-port.ts
+++ b/packages/embedded-llm/src/tts-port.ts
@@ -1,0 +1,36 @@
+import { NotAvailableError } from './errors.js';
+
+/**
+ * Read-only capabilities advertised by an embedded text-to-speech runtime.
+ */
+export interface EmbeddedTtsCapabilities {
+  readonly available: boolean;
+  readonly voices: string[];
+}
+
+/**
+ * Port interface for embedded text-to-speech (Piper).
+ *
+ * Real implementations back this with the piper binary. The Null
+ * implementation is the current default — it allows the rest of the codebase
+ * to import and reference the port without requiring the binary to be present.
+ */
+export interface EmbeddedTtsPort {
+  readonly capabilities: EmbeddedTtsCapabilities;
+  synthesize(text: string, opts?: { voice?: string }): Promise<Buffer>;
+}
+
+/**
+ * No-op fallback used when the Piper binary is absent.
+ * Every method call throws a typed NotAvailableError.
+ */
+export class NullEmbeddedTtsPort implements EmbeddedTtsPort {
+  readonly capabilities: EmbeddedTtsCapabilities = {
+    available: false,
+    voices: [],
+  };
+
+  async synthesize(_text: string, _opts?: { voice?: string }): Promise<Buffer> {
+    throw new NotAvailableError('piper');
+  }
+}

--- a/packages/embedded-llm/tsconfig.json
+++ b/packages/embedded-llm/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,25 @@ importers:
         specifier: ^1.3.0
         version: 1.6.1(@types/node@20.19.37)(lightningcss@1.32.0)(terser@5.46.2)
 
+  packages/embedded-llm:
+    dependencies:
+      '@skytwin/core':
+        specifier: workspace:*
+        version: link:../core
+      '@skytwin/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.3.0
+        version: 1.6.1(@types/node@20.19.37)(lightningcss@1.32.0)(terser@5.46.2)
+
   packages/evals:
     dependencies:
       '@skytwin/decision-engine':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
       "@skytwin/db": ["./packages/db/src"],
       "@skytwin/decision-engine": ["./packages/decision-engine/src"],
       "@skytwin/dxt": ["./packages/dxt/src"],
+      "@skytwin/embedded-llm": ["./packages/embedded-llm/src"],
       "@skytwin/evals": ["./packages/evals/src"],
       "@skytwin/execution-router": ["./packages/execution-router/src"],
       "@skytwin/explanations": ["./packages/explanations/src"],


### PR DESCRIPTION
## Summary

**SCAFFOLD ONLY** for #187. Ships the runtime detection + port interfaces so the rest of the codebase can call into a future embedded-LLM implementation through a stable contract. Real llama.cpp / Whisper / Piper integrations are explicitly deferred — they require binary distribution and integration testing on real models.

## What's in here

### `@skytwin/embedded-llm` (new package)

- **`detectEmbeddedRuntimes()`** — checks `which`/`where` for `llama-cli`, `whisper-cli`, `piper`. Honors env vars (`SKYTWIN_LLAMACPP_BIN`, `SKYTWIN_WHISPER_BIN`, `SKYTWIN_PIPER_BIN`) for explicit overrides. **Never spawns the binaries** — existence-check only.
- **`EmbeddedTextPort` / `EmbeddedSttPort` / `EmbeddedTtsPort`** interfaces with `Null*` fallback impls. Calling `generate` / `transcribe` / `synthesize` on a Null impl throws `NotAvailableError` with a typed `runtime: 'llama' | 'whisper' | 'piper'` field for downstream formatting.

### Tests (22)

- 8 runtime-detector tests (env-var override priority, missing binary, partial detection)
- 14 null-port tests (capabilities.available === false, calls throw, `NotAvailableError` shape)

## Hard constraints satisfied

- **No new top-level deps.** Node built-in `child_process` only.
- **NEVER spawns the binaries** — detection is `which`/`where` existence-check only.
- Strict TypeScript, no emojis, no PII in logs.
- Async detection (Promise return) so a future async impl doesn't break callers.
- `Capabilities` is read-only on the port — no mutation paths exposed.

## Explicitly deferred

- Real llama.cpp / Whisper / Piper integration — needs binaries
- Model auto-download / auto-upgrade — needs CDN + crypto verification
- Speaker diarization, voice cloning, fine-tuning — out of scope for v1
- Web UI for model management — needs real backend first

## Known interface gaps for the real-implementation PR

Documented in CHANGELOG so the real-impl PR can address them:

- `generate()` returns `Promise<string>` (full completion) — no token streaming
- `transcribe()` takes raw `Buffer` — audio format implicit
- `synthesize()` returns raw `Buffer` — audio mime type unspecified
- No `init`/`dispose` lifecycle — model loading happens internally

## Test plan

- [x] `pnpm --filter @skytwin/embedded-llm test` → 22/22 pass
- [x] `pnpm build --concurrency=1` → 34/34 packages clean
- [x] `pnpm test` → 68/68 turbo tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)