### PR TITLE
feat(#179 partial): mobile Capabilities + Briefing screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Mobile Capabilities + Briefing screens (#179 partial)
+
+Read-only mobile UX for Capabilities + Briefing. Voice STT/TTS, push
+notifications, deep-linking, and full offline support all need real
+device testing — those are deferred.
+
+### Ships
+
+- `apps/mobile/src/screens/CapabilitiesScreen.tsx` — installed capabilities
+  list with name, status badge, last-active timestamp, zero-trust indicator,
+  pull-to-refresh. Pending suggestions at top with Snooze / Dismiss
+  (Install redirects to web). Tap row → detail.
+- `apps/mobile/src/screens/CapabilityDetailScreen.tsx` — skills, monthly
+  spend meter, zero-trust badge, "View provenance" link via `Linking`.
+  Read-only — no inline edit forms.
+- `apps/mobile/src/screens/BriefingScreen.tsx` — today's headline, key
+  signals, pending-approvals count, pull-to-refresh.
+- `apps/mobile/src/services/api-client.ts` — `fetchCapabilities`,
+  `fetchCapabilityDetail`, `fetchTwinBriefing` + 7 new types.
+- `apps/mobile/src/App.tsx` — Briefing + Capabilities tabs added to the
+  bottom tab bar (now 5 tabs). Capability detail is a sub-page inside the
+  Capabilities tab (state-driven, resets on tab switch — avoids nested
+  navigators).
+- 36 new unit tests in `capabilities-briefing.test.ts`.
+
+### Defers (out of scope this session)
+
+- Voice STT/TTS — needs device microphone + speakers
+- Push notifications — needs APNs/FCM credentials
+- Deep-linking web → mobile — needs URL scheme registration
+- Full offline support — needs sync engine work
+- Install / activate from mobile — management stays on web
+
 ## [unreleased] — DXT install confirm flow (#180 follow-up)
 
 Closes the backend half of the DXT import flow. `POST /api/dxt/import` now

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -12,6 +12,9 @@ import { WelcomeScreen } from './screens/WelcomeScreen';
 import { ApprovalsScreen } from './screens/ApprovalsScreen';
 import { DashboardScreen } from './screens/DashboardScreen';
 import { SettingsScreen } from './screens/SettingsScreen';
+import { CapabilitiesScreen } from './screens/CapabilitiesScreen';
+import { CapabilityDetailScreen } from './screens/CapabilityDetailScreen';
+import { BriefingScreen } from './screens/BriefingScreen';
 
 // -- Navigation types --
 
@@ -39,31 +42,91 @@ const SkyTwinTheme = {
 
 // -- Bottom tab bar --
 
+// Tab type now includes Capabilities and Briefing.
+type MainTab = 'approvals' | 'briefing' | 'capabilities' | 'dashboard' | 'settings';
+
 function MainWithTabs({ onDisconnect }: { onDisconnect: () => void }): React.JSX.Element {
-  const [activeTab, setActiveTab] = useState<'approvals' | 'dashboard' | 'settings'>('approvals');
+  const [activeTab, setActiveTab] = useState<MainTab>('approvals');
+  // When a capability row is tapped we push a detail "sub-page" within the
+  // Capabilities tab without leaving the tab bar or introducing a nested
+  // navigator. This keeps the nav stack simple for v1.
+  const [selectedCapabilityId, setSelectedCapabilityId] = useState<string | null>(null);
+
+  const handleSelectCapability = useCallback((serverId: string) => {
+    setSelectedCapabilityId(serverId);
+  }, []);
+
+  const handleBackFromDetail = useCallback(() => {
+    setSelectedCapabilityId(null);
+  }, []);
+
+  const handleOpenApprovals = useCallback(() => {
+    setActiveTab('approvals');
+  }, []);
+
+  const renderContent = (): React.JSX.Element => {
+    switch (activeTab) {
+      case 'approvals':
+        return <ApprovalsScreen />;
+      case 'briefing':
+        return <BriefingScreen onOpenApprovals={handleOpenApprovals} />;
+      case 'capabilities':
+        if (selectedCapabilityId !== null) {
+          return (
+            <CapabilityDetailScreen
+              serverId={selectedCapabilityId}
+              onBack={handleBackFromDetail}
+            />
+          );
+        }
+        return <CapabilitiesScreen onSelectCapability={handleSelectCapability} />;
+      case 'dashboard':
+        return <DashboardScreen />;
+      case 'settings':
+        return <SettingsScreen onDisconnect={onDisconnect} />;
+    }
+  };
+
+  // Reset detail view when switching away from Capabilities tab so that
+  // returning later shows the list, not a stale detail page.
+  const handleTabPress = useCallback(
+    (tab: MainTab) => {
+      if (tab !== 'capabilities') {
+        setSelectedCapabilityId(null);
+      }
+      setActiveTab(tab);
+    },
+    [],
+  );
 
   return (
     <View style={styles.tabContainer}>
-      <View style={styles.tabContent}>
-        {activeTab === 'approvals' && <ApprovalsScreen />}
-        {activeTab === 'dashboard' && <DashboardScreen />}
-        {activeTab === 'settings' && <SettingsScreen onDisconnect={onDisconnect} />}
-      </View>
+      <View style={styles.tabContent}>{renderContent()}</View>
       <View style={styles.tabBar}>
         <TabButton
           label="Approvals"
           active={activeTab === 'approvals'}
-          onPress={() => setActiveTab('approvals')}
+          onPress={() => handleTabPress('approvals')}
+        />
+        <TabButton
+          label="Briefing"
+          active={activeTab === 'briefing'}
+          onPress={() => handleTabPress('briefing')}
+        />
+        <TabButton
+          label="Capabilities"
+          active={activeTab === 'capabilities'}
+          onPress={() => handleTabPress('capabilities')}
         />
         <TabButton
           label="Dashboard"
           active={activeTab === 'dashboard'}
-          onPress={() => setActiveTab('dashboard')}
+          onPress={() => handleTabPress('dashboard')}
         />
         <TabButton
           label="Settings"
           active={activeTab === 'settings'}
-          onPress={() => setActiveTab('settings')}
+          onPress={() => handleTabPress('settings')}
         />
       </View>
     </View>

--- a/apps/mobile/src/__tests__/capabilities-briefing.test.ts
+++ b/apps/mobile/src/__tests__/capabilities-briefing.test.ts
@@ -1,0 +1,663 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit tests for CapabilitiesScreen, BriefingScreen, and the API client
+ * extensions added in #179 (partial).
+ *
+ * React Native / Expo modules are not available in a plain Node/vitest
+ * environment, so these tests validate the pure logic layers:
+ *  - API client method URL construction and response shaping
+ *  - Screen state logic (loading, empty state, populated state) modelled as
+ *    plain functions extracted from the render flow
+ */
+
+// ────────────────────────────────────────────────
+// Mock fetch
+// ────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// ────────────────────────────────────────────────
+// Inline test client mirroring the real SkyTwinApiClient
+// (avoids React Native import resolution issues in Node/vitest)
+// ────────────────────────────────────────────────
+
+interface CapabilitySkill {
+  name: string;
+  description: string;
+  riskLevel: string;
+}
+
+interface InstalledCapability {
+  id: string;
+  name: string;
+  status: string;
+  lastActiveAt: string | null;
+  zeroTrustMode: boolean;
+  spendCapMonthlyUsd: number | null;
+  skills: CapabilitySkill[];
+}
+
+interface CapabilitySuggestion {
+  id: string;
+  registryId: string;
+  name: string;
+  reason: string;
+  category: string;
+}
+
+interface CapabilitiesPayload {
+  installed: InstalledCapability[];
+  suggestions: CapabilitySuggestion[];
+  dormant: InstalledCapability[];
+}
+
+interface CapabilityDetail {
+  id: string;
+  name: string;
+  status: string;
+  lastActiveAt: string | null;
+  zeroTrustMode: boolean;
+  spendCapMonthlyUsd: number | null;
+  spendUsedMonthUsd: number | null;
+  skills: CapabilitySkill[];
+  provenanceUrl: string | null;
+}
+
+interface TwinBriefing {
+  id: string;
+  cadence: 'daily' | 'weekly';
+  headline: string;
+  keySignals: string[];
+  pendingApprovalsCount: number;
+  generatedAt: string;
+  readAt: string | null;
+  proseMarkdown: string;
+}
+
+interface TwinBriefingPayload {
+  briefing: TwinBriefing | null;
+  unreadCount: number;
+}
+
+type ApiResult<T> = { success: true; data: T } | { success: false; error: string; statusCode?: number };
+
+class TestApiClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly timeoutMs: number;
+
+  constructor(baseUrl: string, token: string, timeoutMs = 10_000) {
+    this.baseUrl = baseUrl.replace(/\/+$/, '');
+    this.token = token;
+    this.timeoutMs = timeoutMs;
+  }
+
+  async fetchCapabilities(userId: string): Promise<ApiResult<CapabilitiesPayload>> {
+    return this.get<CapabilitiesPayload>(
+      `/api/capabilities/${encodeURIComponent(userId)}`,
+    );
+  }
+
+  async fetchCapabilityDetail(
+    userId: string,
+    serverId: string,
+  ): Promise<ApiResult<CapabilityDetail>> {
+    return this.get<CapabilityDetail>(
+      `/api/capabilities/${encodeURIComponent(userId)}/${encodeURIComponent(serverId)}`,
+    );
+  }
+
+  async fetchTwinBriefing(userId: string): Promise<ApiResult<TwinBriefingPayload>> {
+    return this.get<TwinBriefingPayload>(
+      `/api/briefing/${encodeURIComponent(userId)}/latest`,
+    );
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+  }
+
+  private async get<T>(path: string): Promise<ApiResult<T>> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await fetch(`${this.baseUrl}${path}`, {
+        method: 'GET',
+        headers: this.headers(),
+        signal: controller.signal,
+      });
+      const data: unknown = await response.json();
+      if (!response.ok) {
+        const errorMsg =
+          typeof data === 'object' && data !== null && 'error' in data
+            ? String((data as Record<string, unknown>)['error'])
+            : `HTTP ${response.status}`;
+        return { success: false, error: errorMsg, statusCode: response.status };
+      }
+      return { success: true, data: data as T };
+    } catch (err: unknown) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        return { success: false, error: 'Request timed out' };
+      }
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      return { success: false, error: message };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+// ────────────────────────────────────────────────
+// API client — capabilities call shape
+// ────────────────────────────────────────────────
+
+describe('API client fetchCapabilities', () => {
+  let client: TestApiClient;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    client = new TestApiClient('http://192.168.1.50:3100', 'sess-token');
+  });
+
+  it('calls the correct capabilities endpoint', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ installed: [], suggestions: [], dormant: [] }),
+    });
+    await client.fetchCapabilities('user-1');
+    const [url] = mockFetch.mock.calls[0] as [string, unknown];
+    expect(url).toBe('http://192.168.1.50:3100/api/capabilities/user-1');
+  });
+
+  it('encodes userId with special characters', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ installed: [], suggestions: [], dormant: [] }),
+    });
+    await client.fetchCapabilities('user@example.com');
+    const [url] = mockFetch.mock.calls[0] as [string, unknown];
+    expect(url).toContain('user%40example.com');
+    expect(url).not.toContain('@');
+  });
+
+  it('returns installed list on success', async () => {
+    const installed: InstalledCapability[] = [
+      {
+        id: 'cap-1',
+        name: 'Calendar Assistant',
+        status: 'running',
+        lastActiveAt: '2026-05-08T10:00:00Z',
+        zeroTrustMode: false,
+        spendCapMonthlyUsd: null,
+        skills: [{ name: 'create_event', description: 'Creates calendar events', riskLevel: 'low' }],
+      },
+    ];
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ installed, suggestions: [], dormant: [] }),
+    });
+    const result = await client.fetchCapabilities('u1');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.installed).toHaveLength(1);
+      expect(result.data.installed[0]?.name).toBe('Calendar Assistant');
+      expect(result.data.suggestions).toHaveLength(0);
+    }
+  });
+
+  it('returns suggestions when present', async () => {
+    const suggestions: CapabilitySuggestion[] = [
+      { id: 'sug-1', registryId: 'reg-a', name: 'GitHub', reason: 'You use Git frequently', category: 'developer' },
+    ];
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ installed: [], suggestions, dormant: [] }),
+    });
+    const result = await client.fetchCapabilities('u1');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.suggestions).toHaveLength(1);
+      expect(result.data.suggestions[0]?.name).toBe('GitHub');
+    }
+  });
+
+  it('returns error result on 404', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: 'User not found' }),
+    });
+    const result = await client.fetchCapabilities('no-such-user');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe('User not found');
+      expect(result.statusCode).toBe(404);
+    }
+  });
+
+  it('calls capability detail endpoint with correct path', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 'cap-1',
+        name: 'Github',
+        status: 'running',
+        lastActiveAt: null,
+        zeroTrustMode: true,
+        spendCapMonthlyUsd: 10.0,
+        spendUsedMonthUsd: 3.5,
+        skills: [],
+        provenanceUrl: null,
+      }),
+    });
+    await client.fetchCapabilityDetail('user-1', 'cap-1');
+    const [url] = mockFetch.mock.calls[0] as [string, unknown];
+    expect(url).toBe('http://192.168.1.50:3100/api/capabilities/user-1/cap-1');
+  });
+});
+
+// ────────────────────────────────────────────────
+// API client — briefing call shape
+// ────────────────────────────────────────────────
+
+describe('API client fetchTwinBriefing', () => {
+  let client: TestApiClient;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    client = new TestApiClient('http://192.168.1.50:3100', 'sess-token');
+  });
+
+  it('calls the correct briefing endpoint', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ briefing: null, unreadCount: 0 }),
+    });
+    await client.fetchTwinBriefing('user-1');
+    const [url] = mockFetch.mock.calls[0] as [string, unknown];
+    expect(url).toBe('http://192.168.1.50:3100/api/briefing/user-1/latest');
+  });
+
+  it('encodes userId in briefing endpoint', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ briefing: null, unreadCount: 0 }),
+    });
+    await client.fetchTwinBriefing('user@domain.io');
+    const [url] = mockFetch.mock.calls[0] as [string, unknown];
+    expect(url).toContain('user%40domain.io');
+  });
+
+  it('returns briefing payload on success', async () => {
+    const briefing: TwinBriefing = {
+      id: 'br-1',
+      cadence: 'daily',
+      headline: 'Three meetings and a long email thread',
+      keySignals: ['Calendar conflict at 2pm', 'Unread thread from Alice'],
+      pendingApprovalsCount: 2,
+      generatedAt: '2026-05-08T08:00:00Z',
+      readAt: null,
+      proseMarkdown: '## Today\n...',
+    };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ briefing, unreadCount: 1 }),
+    });
+    const result = await client.fetchTwinBriefing('u1');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.briefing).not.toBeNull();
+      expect(result.data.briefing?.headline).toBe('Three meetings and a long email thread');
+      expect(result.data.briefing?.keySignals).toHaveLength(2);
+      expect(result.data.briefing?.pendingApprovalsCount).toBe(2);
+      expect(result.data.unreadCount).toBe(1);
+    }
+  });
+
+  it('handles null briefing (no briefing generated yet)', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ briefing: null, unreadCount: 0 }),
+    });
+    const result = await client.fetchTwinBriefing('u1');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.briefing).toBeNull();
+      expect(result.data.unreadCount).toBe(0);
+    }
+  });
+
+  it('returns error result on 500', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'Internal server error' }),
+    });
+    const result = await client.fetchTwinBriefing('u1');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.statusCode).toBe(500);
+    }
+  });
+});
+
+// ────────────────────────────────────────────────
+// CapabilitiesScreen — list rendering logic
+// ────────────────────────────────────────────────
+
+describe('CapabilitiesScreen state logic', () => {
+  // Model the state machine that the component drives:
+  // given raw API data, what does the screen display?
+
+  interface ScreenState {
+    loading: boolean;
+    installed: InstalledCapability[];
+    suggestions: CapabilitySuggestion[];
+    dormant: InstalledCapability[];
+    error: string | null;
+  }
+
+  function buildState(overrides: Partial<ScreenState> = {}): ScreenState {
+    return {
+      loading: false,
+      installed: [],
+      suggestions: [],
+      dormant: [],
+      error: null,
+      ...overrides,
+    };
+  }
+
+  function isEmptyInstalled(state: ScreenState): boolean {
+    return !state.loading && state.installed.length === 0 && state.error === null;
+  }
+
+  function hasInstalledList(state: ScreenState): boolean {
+    return !state.loading && state.installed.length > 0;
+  }
+
+  function hasSuggestions(state: ScreenState): boolean {
+    return state.suggestions.length > 0;
+  }
+
+  it('renders empty state when installed list is empty', () => {
+    const state = buildState({ installed: [] });
+    expect(isEmptyInstalled(state)).toBe(true);
+    expect(hasInstalledList(state)).toBe(false);
+  });
+
+  it('renders installed list when capabilities present', () => {
+    const state = buildState({
+      installed: [
+        {
+          id: 'cap-1',
+          name: 'GitHub',
+          status: 'running',
+          lastActiveAt: null,
+          zeroTrustMode: false,
+          spendCapMonthlyUsd: null,
+          skills: [],
+        },
+        {
+          id: 'cap-2',
+          name: 'Slack',
+          status: 'stopped',
+          lastActiveAt: '2026-05-07T12:00:00Z',
+          zeroTrustMode: true,
+          spendCapMonthlyUsd: 5,
+          skills: [],
+        },
+      ],
+    });
+    expect(hasInstalledList(state)).toBe(true);
+    expect(isEmptyInstalled(state)).toBe(false);
+    expect(state.installed).toHaveLength(2);
+  });
+
+  it('shows suggestions section only when suggestions exist', () => {
+    const emptyState = buildState({ suggestions: [] });
+    const withSuggestions = buildState({
+      suggestions: [
+        { id: 's1', registryId: 'r1', name: 'Jira', reason: 'You manage tickets', category: 'developer' },
+      ],
+    });
+    expect(hasSuggestions(emptyState)).toBe(false);
+    expect(hasSuggestions(withSuggestions)).toBe(true);
+  });
+
+  it('dismissing a suggestion removes it from the list', () => {
+    let state = buildState({
+      suggestions: [
+        { id: 's1', registryId: 'r1', name: 'Jira', reason: 'Reason', category: 'developer' },
+        { id: 's2', registryId: 'r2', name: 'Linear', reason: 'Reason', category: 'developer' },
+      ],
+    });
+    // Simulate dismiss handler
+    state = { ...state, suggestions: state.suggestions.filter((s) => s.id !== 's1') };
+    expect(state.suggestions).toHaveLength(1);
+    expect(state.suggestions[0]?.id).toBe('s2');
+  });
+
+  it('shows error when API returns error', () => {
+    const state = buildState({ error: 'Network error: SkyTwin not reachable' });
+    expect(state.error).not.toBeNull();
+    expect(isEmptyInstalled(state)).toBe(false); // Error hides empty-state
+  });
+
+  it('loading state prevents list render', () => {
+    const state = buildState({ loading: true });
+    expect(isEmptyInstalled(state)).toBe(false);
+    expect(hasInstalledList(state)).toBe(false);
+  });
+});
+
+// ────────────────────────────────────────────────
+// BriefingScreen — rendering logic
+// ────────────────────────────────────────────────
+
+describe('BriefingScreen state logic', () => {
+  interface BriefingScreenState {
+    loading: boolean;
+    briefing: TwinBriefing | null;
+    unreadCount: number;
+    error: string | null;
+  }
+
+  function buildBriefingState(overrides: Partial<BriefingScreenState> = {}): BriefingScreenState {
+    return {
+      loading: false,
+      briefing: null,
+      unreadCount: 0,
+      error: null,
+      ...overrides,
+    };
+  }
+
+  function shouldShowEmpty(state: BriefingScreenState): boolean {
+    return !state.loading && state.briefing === null && state.error === null;
+  }
+
+  function shouldShowBriefing(state: BriefingScreenState): boolean {
+    return !state.loading && state.briefing !== null;
+  }
+
+  function shouldShowUnreadBadge(state: BriefingScreenState): boolean {
+    return state.unreadCount > 0;
+  }
+
+  function shouldShowApprovalsPrompt(state: BriefingScreenState): boolean {
+    return (state.briefing?.pendingApprovalsCount ?? 0) > 0;
+  }
+
+  it('shows empty state when no briefing generated yet', () => {
+    const state = buildBriefingState({ briefing: null });
+    expect(shouldShowEmpty(state)).toBe(true);
+    expect(shouldShowBriefing(state)).toBe(false);
+  });
+
+  it('shows briefing content when briefing is present', () => {
+    const briefing: TwinBriefing = {
+      id: 'br-1',
+      cadence: 'daily',
+      headline: 'A productive day ahead',
+      keySignals: ['Meeting at 2pm', 'Invoice due tomorrow'],
+      pendingApprovalsCount: 0,
+      generatedAt: '2026-05-08T08:00:00Z',
+      readAt: null,
+      proseMarkdown: '',
+    };
+    const state = buildBriefingState({ briefing });
+    expect(shouldShowBriefing(state)).toBe(true);
+    expect(shouldShowEmpty(state)).toBe(false);
+  });
+
+  it('shows loading state during fetch', () => {
+    const state = buildBriefingState({ loading: true });
+    expect(shouldShowEmpty(state)).toBe(false);
+    expect(shouldShowBriefing(state)).toBe(false);
+  });
+
+  it('shows unread badge when unreadCount > 0', () => {
+    const state = buildBriefingState({ unreadCount: 3 });
+    expect(shouldShowUnreadBadge(state)).toBe(true);
+    const zeroState = buildBriefingState({ unreadCount: 0 });
+    expect(shouldShowUnreadBadge(zeroState)).toBe(false);
+  });
+
+  it('shows approvals prompt when pendingApprovalsCount > 0', () => {
+    const briefing: TwinBriefing = {
+      id: 'br-2',
+      cadence: 'daily',
+      headline: 'Busy day',
+      keySignals: [],
+      pendingApprovalsCount: 4,
+      generatedAt: '2026-05-08T08:00:00Z',
+      readAt: null,
+      proseMarkdown: '',
+    };
+    const state = buildBriefingState({ briefing });
+    expect(shouldShowApprovalsPrompt(state)).toBe(true);
+  });
+
+  it('hides approvals prompt when zero pending', () => {
+    const briefing: TwinBriefing = {
+      id: 'br-3',
+      cadence: 'daily',
+      headline: 'All caught up',
+      keySignals: [],
+      pendingApprovalsCount: 0,
+      generatedAt: '2026-05-08T08:00:00Z',
+      readAt: null,
+      proseMarkdown: '',
+    };
+    const state = buildBriefingState({ briefing });
+    expect(shouldShowApprovalsPrompt(state)).toBe(false);
+  });
+});
+
+// ────────────────────────────────────────────────
+// Relative time formatting
+// ────────────────────────────────────────────────
+
+describe('relative time formatting', () => {
+  function formatRelativeTime(isoString: string, nowIso: string): string {
+    const date = new Date(isoString);
+    const now = new Date(nowIso);
+    const diffMs = now.getTime() - date.getTime();
+    const diffMinutes = Math.floor(diffMs / 60_000);
+    if (diffMinutes < 1) return 'just now';
+    if (diffMinutes < 60) return `${diffMinutes}m ago`;
+    const diffHours = Math.floor(diffMinutes / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays < 7) return `${diffDays}d ago`;
+    return date.toLocaleDateString();
+  }
+
+  const NOW = '2026-05-08T12:00:00Z';
+
+  it('shows "just now" for times under a minute ago', () => {
+    expect(formatRelativeTime('2026-05-08T11:59:30Z', NOW)).toBe('just now');
+  });
+
+  it('shows minutes for times under an hour', () => {
+    expect(formatRelativeTime('2026-05-08T11:45:00Z', NOW)).toBe('15m ago');
+  });
+
+  it('shows hours for times under a day', () => {
+    expect(formatRelativeTime('2026-05-08T08:00:00Z', NOW)).toBe('4h ago');
+  });
+
+  it('shows days for times under a week', () => {
+    expect(formatRelativeTime('2026-05-05T12:00:00Z', NOW)).toBe('3d ago');
+  });
+
+  it('shows locale date for times over a week ago', () => {
+    const result = formatRelativeTime('2026-04-01T12:00:00Z', NOW);
+    // Just check it's not one of the relative formats
+    expect(result).not.toContain('ago');
+    expect(result).not.toBe('just now');
+  });
+});
+
+// ────────────────────────────────────────────────
+// Spend meter percentage calculation
+// ────────────────────────────────────────────────
+
+describe('spend meter percentage calculation', () => {
+  function spendPercent(used: number, cap: number): number {
+    return cap > 0 ? Math.min(used / cap, 1) : 0;
+  }
+
+  it('returns 0 when nothing used', () => {
+    expect(spendPercent(0, 10)).toBe(0);
+  });
+
+  it('returns 0.5 at half cap', () => {
+    expect(spendPercent(5, 10)).toBe(0.5);
+  });
+
+  it('caps at 1.0 when over cap', () => {
+    expect(spendPercent(15, 10)).toBe(1);
+  });
+
+  it('returns 0 when cap is 0 (avoid division by zero)', () => {
+    expect(spendPercent(5, 0)).toBe(0);
+  });
+});
+
+// ────────────────────────────────────────────────
+// Capability status badge color
+// ────────────────────────────────────────────────
+
+describe('capability status badge colors', () => {
+  const STATUS_COLORS: Record<string, string> = {
+    running: '#2ecc71',
+    stopped: '#f39c12',
+    error: '#e74c3c',
+    dormant: '#888',
+  };
+
+  it('running is green', () => {
+    expect(STATUS_COLORS['running']).toBe('#2ecc71');
+  });
+
+  it('stopped is orange', () => {
+    expect(STATUS_COLORS['stopped']).toBe('#f39c12');
+  });
+
+  it('error is red', () => {
+    expect(STATUS_COLORS['error']).toBe('#e74c3c');
+  });
+
+  it('unknown status falls back to grey', () => {
+    const color = STATUS_COLORS['unknown'] ?? '#888';
+    expect(color).toBe('#888');
+  });
+});

--- a/apps/mobile/src/screens/BriefingScreen.tsx
+++ b/apps/mobile/src/screens/BriefingScreen.tsx
@@ -1,0 +1,420 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  RefreshControl,
+  TouchableOpacity,
+} from 'react-native';
+import {
+  SkyTwinApiClient,
+  type TwinBriefing,
+} from '../services/api-client';
+import { getSession } from '../services/session-store';
+
+// -- State --
+
+interface BriefingState {
+  loading: boolean;
+  briefing: TwinBriefing | null;
+  unreadCount: number;
+  error: string | null;
+}
+
+/**
+ * Twin Briefing screen.
+ *
+ * Shows the most recent daily briefing: headline, key signals list,
+ * and pending-approvals count. Pull-to-refresh. Tapping the approvals
+ * count is a prompt to switch to the Approvals tab — actual navigation
+ * is handled via the onOpenApprovals callback so this screen stays
+ * decoupled from the tab bar.
+ */
+export function BriefingScreen({
+  onOpenApprovals,
+}: {
+  onOpenApprovals?: () => void;
+}): React.JSX.Element {
+  const [state, setState] = useState<BriefingState>({
+    loading: true,
+    briefing: null,
+    unreadCount: 0,
+    error: null,
+  });
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    const session = await getSession();
+    if (!session) {
+      setState((prev) => ({ ...prev, loading: false, error: 'No session found' }));
+      return;
+    }
+
+    const client = new SkyTwinApiClient(session.baseUrl, session.token);
+    const result = await client.fetchTwinBriefing(session.userId);
+
+    if (result.success) {
+      setState({
+        loading: false,
+        briefing: result.data.briefing,
+        unreadCount: result.data.unreadCount,
+        error: null,
+      });
+    } else {
+      setState((prev) => ({ ...prev, loading: false, error: result.error }));
+    }
+  }, []);
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchData();
+    setRefreshing(false);
+  }, [fetchData]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  if (state.loading) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.loadingText}>Loading briefing...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={handleRefresh}
+          tintColor="#4a90d9"
+          colors={['#4a90d9']}
+        />
+      }
+    >
+      {state.error ? (
+        <View style={styles.errorBanner}>
+          <Text style={styles.errorText}>{state.error}</Text>
+          <TouchableOpacity onPress={handleRefresh}>
+            <Text style={styles.retryText}>Retry</Text>
+          </TouchableOpacity>
+        </View>
+      ) : null}
+
+      {state.unreadCount > 0 && (
+        <View style={styles.unreadBadge}>
+          <Text style={styles.unreadBadgeText}>
+            {state.unreadCount} unread briefing{state.unreadCount !== 1 ? 's' : ''}
+          </Text>
+        </View>
+      )}
+
+      {state.briefing ? (
+        <BriefingContent
+          briefing={state.briefing}
+          onOpenApprovals={onOpenApprovals}
+        />
+      ) : (
+        <View style={styles.emptyCard}>
+          <Text style={styles.emptyTitle}>No briefing yet</Text>
+          <Text style={styles.emptySubtitle}>
+            Your twin will generate a daily briefing once it has enough signal data.
+          </Text>
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+// -- Sub-components --
+
+function BriefingContent({
+  briefing,
+  onOpenApprovals,
+}: {
+  briefing: TwinBriefing;
+  onOpenApprovals?: () => void;
+}): React.JSX.Element {
+  const isUnread = briefing.readAt === null;
+  const generatedLabel = formatRelativeTime(briefing.generatedAt);
+
+  return (
+    <>
+      {/* Headline card */}
+      <View style={styles.headlineCard}>
+        <View style={styles.headlineHeader}>
+          <Text style={styles.headlineCadence}>
+            {briefing.cadence === 'daily' ? 'Daily' : 'Weekly'} briefing
+          </Text>
+          {isUnread && (
+            <View style={styles.newBadge}>
+              <Text style={styles.newBadgeText}>New</Text>
+            </View>
+          )}
+        </View>
+        <Text style={styles.headlineText}>{briefing.headline}</Text>
+        <Text style={styles.generatedAt}>Generated {generatedLabel}</Text>
+      </View>
+
+      {/* Pending approvals count */}
+      {briefing.pendingApprovalsCount > 0 && (
+        <TouchableOpacity
+          style={styles.approvalsPrompt}
+          onPress={onOpenApprovals}
+          accessibilityRole="button"
+          accessibilityLabel={`${briefing.pendingApprovalsCount} pending approvals, tap to review`}
+        >
+          <View style={styles.approvalsPromptLeft}>
+            <View style={styles.approvalsCountBubble}>
+              <Text style={styles.approvalsCountText}>
+                {briefing.pendingApprovalsCount}
+              </Text>
+            </View>
+            <View>
+              <Text style={styles.approvalsPromptTitle}>Pending approvals</Text>
+              <Text style={styles.approvalsPromptSubtitle}>Tap to review</Text>
+            </View>
+          </View>
+          <Text style={styles.approvalsChevron}>›</Text>
+        </TouchableOpacity>
+      )}
+
+      {/* Key signals */}
+      {briefing.keySignals.length > 0 && (
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Key signals</Text>
+          {briefing.keySignals.map((signal, index) => (
+            <SignalRow key={index} signal={signal} index={index} />
+          ))}
+        </View>
+      )}
+    </>
+  );
+}
+
+function SignalRow({
+  signal,
+  index,
+}: {
+  signal: string;
+  index: number;
+}): React.JSX.Element {
+  return (
+    <View style={styles.signalRow}>
+      <Text style={styles.signalBullet}>{index + 1}</Text>
+      <Text style={styles.signalText}>{signal}</Text>
+    </View>
+  );
+}
+
+// -- Helpers --
+
+function formatRelativeTime(isoString: string): string {
+  const date = new Date(isoString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / 60_000);
+  if (diffMinutes < 1) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+// -- Styles --
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  centered: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loadingText: {
+    color: '#a0a0b8',
+    fontSize: 16,
+  },
+  errorBanner: {
+    backgroundColor: '#3a1a1a',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  errorText: {
+    color: '#e74c3c',
+    fontSize: 13,
+    flex: 1,
+    marginRight: 12,
+  },
+  retryText: {
+    color: '#4a90d9',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  unreadBadge: {
+    backgroundColor: '#1a3a5a',
+    borderRadius: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    alignSelf: 'flex-start',
+    marginBottom: 16,
+  },
+  unreadBadgeText: {
+    color: '#4a90d9',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  emptyCard: {
+    backgroundColor: '#2a2a40',
+    borderRadius: 12,
+    padding: 32,
+    alignItems: 'center',
+  },
+  emptyTitle: {
+    color: '#e0e0f0',
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  emptySubtitle: {
+    color: '#a0a0b8',
+    fontSize: 13,
+    textAlign: 'center',
+    lineHeight: 19,
+  },
+  headlineCard: {
+    backgroundColor: '#2a2a40',
+    borderRadius: 12,
+    padding: 18,
+    marginBottom: 16,
+  },
+  headlineHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  headlineCadence: {
+    color: '#a0a0b8',
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  newBadge: {
+    backgroundColor: '#1a3a5a',
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  newBadgeText: {
+    color: '#4a90d9',
+    fontSize: 11,
+    fontWeight: '600',
+  },
+  headlineText: {
+    color: '#e0e0f0',
+    fontSize: 18,
+    fontWeight: '700',
+    lineHeight: 26,
+    marginBottom: 10,
+  },
+  generatedAt: {
+    color: '#888',
+    fontSize: 12,
+  },
+  approvalsPrompt: {
+    backgroundColor: '#2a2a40',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#e74c3c',
+    padding: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 16,
+  },
+  approvalsPromptLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  approvalsCountBubble: {
+    backgroundColor: '#e74c3c',
+    borderRadius: 14,
+    width: 28,
+    height: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+  },
+  approvalsCountText: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  approvalsPromptTitle: {
+    color: '#e0e0f0',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  approvalsPromptSubtitle: {
+    color: '#a0a0b8',
+    fontSize: 12,
+  },
+  approvalsChevron: {
+    color: '#a0a0b8',
+    fontSize: 24,
+    fontWeight: '300',
+  },
+  section: {
+    marginBottom: 24,
+  },
+  sectionTitle: {
+    color: '#a0a0b8',
+    fontSize: 13,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    marginBottom: 10,
+  },
+  signalRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    backgroundColor: '#2a2a40',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 6,
+  },
+  signalBullet: {
+    color: '#4a90d9',
+    fontSize: 13,
+    fontWeight: '700',
+    width: 20,
+    lineHeight: 19,
+  },
+  signalText: {
+    color: '#c0c0d0',
+    fontSize: 13,
+    lineHeight: 19,
+    flex: 1,
+  },
+});

--- a/apps/mobile/src/screens/CapabilitiesScreen.tsx
+++ b/apps/mobile/src/screens/CapabilitiesScreen.tsx
@@ -1,0 +1,466 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  RefreshControl,
+  TouchableOpacity,
+} from 'react-native';
+import {
+  SkyTwinApiClient,
+  type InstalledCapability,
+  type CapabilitySuggestion,
+} from '../services/api-client';
+import { getSession } from '../services/session-store';
+
+// -- Props --
+
+interface CapabilitiesScreenProps {
+  onSelectCapability: (serverId: string) => void;
+}
+
+// -- Local state --
+
+interface CapabilitiesState {
+  loading: boolean;
+  installed: InstalledCapability[];
+  suggestions: CapabilitySuggestion[];
+  dormant: InstalledCapability[];
+  error: string | null;
+}
+
+// -- Status badge colors --
+
+const STATUS_COLORS: Record<string, string> = {
+  running: '#2ecc71',
+  stopped: '#f39c12',
+  error: '#e74c3c',
+  dormant: '#888',
+};
+
+/**
+ * Capabilities list screen.
+ *
+ * Shows installed MCP capabilities with status badges and last-active timestamps.
+ * Pending suggestions appear at the top with Install / Snooze / Dismiss actions.
+ * Pull-to-refresh. Tap a row to open CapabilityDetailScreen.
+ */
+export function CapabilitiesScreen({
+  onSelectCapability,
+}: CapabilitiesScreenProps): React.JSX.Element {
+  const [state, setState] = useState<CapabilitiesState>({
+    loading: true,
+    installed: [],
+    suggestions: [],
+    dormant: [],
+    error: null,
+  });
+  const [refreshing, setRefreshing] = useState(false);
+  // Track which suggestion actions are in-flight to prevent double-taps
+  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
+
+  const fetchData = useCallback(async () => {
+    const session = await getSession();
+    if (!session) {
+      setState((prev) => ({ ...prev, loading: false, error: 'No session found' }));
+      return;
+    }
+
+    const client = new SkyTwinApiClient(session.baseUrl, session.token);
+    const result = await client.fetchCapabilities(session.userId);
+
+    if (result.success) {
+      setState({
+        loading: false,
+        installed: result.data.installed,
+        suggestions: result.data.suggestions,
+        dormant: result.data.dormant,
+        error: null,
+      });
+    } else {
+      setState((prev) => ({ ...prev, loading: false, error: result.error }));
+    }
+  }, []);
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchData();
+    setRefreshing(false);
+  }, [fetchData]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Suggestion actions are read-only stubs on mobile — full management lives on web.
+  // We dismiss/snooze locally (remove from list) and log the id only.
+  const handleDismissSuggestion = useCallback((id: string) => {
+    if (pendingIds.has(id)) return;
+    setPendingIds((prev) => new Set(prev).add(id));
+    console.log('[capabilities] dismiss suggestion:', id);
+    setState((prev) => ({
+      ...prev,
+      suggestions: prev.suggestions.filter((s) => s.id !== id),
+    }));
+    setPendingIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  }, [pendingIds]);
+
+  const handleSnoozeSuggestion = useCallback((id: string) => {
+    if (pendingIds.has(id)) return;
+    console.log('[capabilities] snooze suggestion:', id);
+    setState((prev) => ({
+      ...prev,
+      suggestions: prev.suggestions.filter((s) => s.id !== id),
+    }));
+  }, [pendingIds]);
+
+  if (state.loading) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.loadingText}>Loading capabilities...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={handleRefresh}
+          tintColor="#4a90d9"
+          colors={['#4a90d9']}
+        />
+      }
+    >
+      {state.error ? (
+        <View style={styles.errorBanner}>
+          <Text style={styles.errorText}>{state.error}</Text>
+          <TouchableOpacity onPress={handleRefresh}>
+            <Text style={styles.retryText}>Retry</Text>
+          </TouchableOpacity>
+        </View>
+      ) : null}
+
+      {state.suggestions.length > 0 && (
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Suggested for you</Text>
+          {state.suggestions.map((s) => (
+            <SuggestionCard
+              key={s.id}
+              suggestion={s}
+              onDismiss={handleDismissSuggestion}
+              onSnooze={handleSnoozeSuggestion}
+            />
+          ))}
+        </View>
+      )}
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>
+          Installed{state.installed.length > 0 ? ` (${state.installed.length})` : ''}
+        </Text>
+        {state.installed.length === 0 ? (
+          <View style={styles.emptyCard}>
+            <Text style={styles.emptyText}>No capabilities installed yet</Text>
+          </View>
+        ) : (
+          state.installed.map((cap) => (
+            <CapabilityRow
+              key={cap.id}
+              capability={cap}
+              onPress={onSelectCapability}
+            />
+          ))
+        )}
+      </View>
+
+      {state.dormant.length > 0 && (
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Dormant ({state.dormant.length})</Text>
+          {state.dormant.map((cap) => (
+            <CapabilityRow
+              key={cap.id}
+              capability={cap}
+              onPress={onSelectCapability}
+            />
+          ))}
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+// -- Sub-components --
+
+function CapabilityRow({
+  capability,
+  onPress,
+}: {
+  capability: InstalledCapability;
+  onPress: (id: string) => void;
+}): React.JSX.Element {
+  const statusColor = STATUS_COLORS[capability.status] ?? '#888';
+  const lastActive = capability.lastActiveAt
+    ? formatRelativeTime(capability.lastActiveAt)
+    : 'Never active';
+
+  return (
+    <TouchableOpacity
+      style={styles.capabilityCard}
+      onPress={() => onPress(capability.id)}
+      accessibilityRole="button"
+      accessibilityLabel={`${capability.name}, status ${capability.status}`}
+    >
+      <View style={styles.capabilityHeader}>
+        <View style={styles.capabilityMeta}>
+          <Text style={styles.capabilityName}>{capability.name}</Text>
+          <Text style={styles.capabilityLastActive}>{lastActive}</Text>
+        </View>
+        <View style={[styles.statusBadge, { backgroundColor: statusColor }]}>
+          <Text style={styles.statusBadgeText}>{capability.status}</Text>
+        </View>
+      </View>
+      {capability.zeroTrustMode && (
+        <View style={styles.zeroTrustBadge}>
+          <Text style={styles.zeroTrustText}>Zero-trust</Text>
+        </View>
+      )}
+      <Text style={styles.skillCount}>
+        {capability.skills.length} skill{capability.skills.length !== 1 ? 's' : ''}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+function SuggestionCard({
+  suggestion,
+  onDismiss,
+  onSnooze,
+}: {
+  suggestion: CapabilitySuggestion;
+  onDismiss: (id: string) => void;
+  onSnooze: (id: string) => void;
+}): React.JSX.Element {
+  return (
+    <View style={styles.suggestionCard}>
+      <Text style={styles.suggestionName}>{suggestion.name}</Text>
+      <Text style={styles.suggestionReason}>{suggestion.reason}</Text>
+      <View style={styles.suggestionActions}>
+        <TouchableOpacity
+          style={[styles.suggestionButton, styles.suggestionButtonSnooze]}
+          onPress={() => onSnooze(suggestion.id)}
+          accessibilityRole="button"
+          accessibilityLabel={`Snooze ${suggestion.name} suggestion`}
+        >
+          <Text style={styles.suggestionButtonText}>Snooze</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.suggestionButton, styles.suggestionButtonDismiss]}
+          onPress={() => onDismiss(suggestion.id)}
+          accessibilityRole="button"
+          accessibilityLabel={`Dismiss ${suggestion.name} suggestion`}
+        >
+          <Text style={styles.suggestionButtonText}>Dismiss</Text>
+        </TouchableOpacity>
+        <View style={[styles.suggestionButton, styles.suggestionButtonInstall]}>
+          <Text style={styles.suggestionButtonInstallText}>Install via web</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+// -- Helpers --
+
+function formatRelativeTime(isoString: string): string {
+  const date = new Date(isoString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / 60_000);
+  if (diffMinutes < 1) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+// -- Styles --
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  centered: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loadingText: {
+    color: '#a0a0b8',
+    fontSize: 16,
+  },
+  errorBanner: {
+    backgroundColor: '#3a1a1a',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  errorText: {
+    color: '#e74c3c',
+    fontSize: 13,
+    flex: 1,
+    marginRight: 12,
+  },
+  retryText: {
+    color: '#4a90d9',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  section: {
+    marginBottom: 24,
+  },
+  sectionTitle: {
+    color: '#a0a0b8',
+    fontSize: 13,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    marginBottom: 10,
+  },
+  emptyCard: {
+    backgroundColor: '#2a2a40',
+    borderRadius: 10,
+    padding: 24,
+    alignItems: 'center',
+  },
+  emptyText: {
+    color: '#a0a0b8',
+    fontSize: 14,
+  },
+  capabilityCard: {
+    backgroundColor: '#2a2a40',
+    borderRadius: 10,
+    padding: 14,
+    marginBottom: 8,
+  },
+  capabilityHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 6,
+  },
+  capabilityMeta: {
+    flex: 1,
+    marginRight: 10,
+  },
+  capabilityName: {
+    color: '#e0e0f0',
+    fontSize: 15,
+    fontWeight: '600',
+    marginBottom: 2,
+  },
+  capabilityLastActive: {
+    color: '#888',
+    fontSize: 12,
+  },
+  statusBadge: {
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  statusBadgeText: {
+    color: '#fff',
+    fontSize: 11,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+  },
+  zeroTrustBadge: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#2a1a3a',
+    borderRadius: 4,
+    borderWidth: 1,
+    borderColor: '#6a3a9a',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    marginBottom: 4,
+  },
+  zeroTrustText: {
+    color: '#9a6ac0',
+    fontSize: 11,
+    fontWeight: '500',
+  },
+  skillCount: {
+    color: '#a0a0b8',
+    fontSize: 12,
+  },
+  suggestionCard: {
+    backgroundColor: '#1e2a3a',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#2a4a6a',
+    padding: 14,
+    marginBottom: 8,
+  },
+  suggestionName: {
+    color: '#e0e0f0',
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  suggestionReason: {
+    color: '#a0c0e0',
+    fontSize: 13,
+    lineHeight: 18,
+    marginBottom: 10,
+  },
+  suggestionActions: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  suggestionButton: {
+    borderRadius: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  suggestionButtonSnooze: {
+    backgroundColor: '#2a2a40',
+  },
+  suggestionButtonDismiss: {
+    backgroundColor: '#3a2a2a',
+  },
+  suggestionButtonInstall: {
+    backgroundColor: '#1a3a5a',
+    borderWidth: 1,
+    borderColor: '#2a5a8a',
+  },
+  suggestionButtonText: {
+    color: '#c0c0d0',
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  suggestionButtonInstallText: {
+    color: '#4a90d9',
+    fontSize: 12,
+    fontWeight: '500',
+  },
+});

--- a/apps/mobile/src/screens/CapabilityDetailScreen.tsx
+++ b/apps/mobile/src/screens/CapabilityDetailScreen.tsx
@@ -1,0 +1,512 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  RefreshControl,
+  TouchableOpacity,
+  Linking,
+} from 'react-native';
+import {
+  SkyTwinApiClient,
+  type CapabilityDetail,
+  type CapabilitySkill,
+} from '../services/api-client';
+import { getSession } from '../services/session-store';
+
+// -- Props --
+
+interface CapabilityDetailScreenProps {
+  serverId: string;
+  onBack: () => void;
+}
+
+// -- State --
+
+interface DetailState {
+  loading: boolean;
+  detail: CapabilityDetail | null;
+  error: string | null;
+  baseUrl: string | null;
+}
+
+// -- Status badge colors --
+
+const STATUS_COLORS: Record<string, string> = {
+  running: '#2ecc71',
+  stopped: '#f39c12',
+  error: '#e74c3c',
+  dormant: '#888',
+};
+
+/**
+ * Capability detail screen.
+ *
+ * Shows skill list, monthly spend meter (if cap configured),
+ * zero-trust status badge, and a "View provenance" button that
+ * opens the web graph in the system browser.
+ *
+ * Read-only for v1 — no inline edit forms. Full management is on the web.
+ */
+export function CapabilityDetailScreen({
+  serverId,
+  onBack,
+}: CapabilityDetailScreenProps): React.JSX.Element {
+  const [state, setState] = useState<DetailState>({
+    loading: true,
+    detail: null,
+    error: null,
+    baseUrl: null,
+  });
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    const session = await getSession();
+    if (!session) {
+      setState((prev) => ({ ...prev, loading: false, error: 'No session found' }));
+      return;
+    }
+
+    const client = new SkyTwinApiClient(session.baseUrl, session.token);
+    const result = await client.fetchCapabilityDetail(session.userId, serverId);
+
+    if (result.success) {
+      setState({
+        loading: false,
+        detail: result.data,
+        error: null,
+        baseUrl: session.baseUrl,
+      });
+    } else {
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: result.error,
+        baseUrl: session.baseUrl,
+      }));
+    }
+  }, [serverId]);
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchData();
+    setRefreshing(false);
+  }, [fetchData]);
+
+  const handleViewProvenance = useCallback(async () => {
+    const baseUrl = state.baseUrl ?? '';
+    const url = `${baseUrl}/web/#/capabilities/${encodeURIComponent(serverId)}`;
+    console.log('[capability-detail] opening provenance url for server:', serverId);
+    const canOpen = await Linking.canOpenURL(url);
+    if (canOpen) {
+      await Linking.openURL(url);
+    }
+  }, [state.baseUrl, serverId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  if (state.loading) {
+    return (
+      <View style={styles.centered}>
+        <TouchableOpacity onPress={onBack} style={styles.backButton}>
+          <Text style={styles.backButtonText}>Back</Text>
+        </TouchableOpacity>
+        <Text style={styles.loadingText}>Loading...</Text>
+      </View>
+    );
+  }
+
+  if (!state.detail) {
+    return (
+      <View style={styles.centered}>
+        <TouchableOpacity onPress={onBack} style={styles.backButton}>
+          <Text style={styles.backButtonText}>Back</Text>
+        </TouchableOpacity>
+        <Text style={styles.errorText}>{state.error ?? 'Capability not found'}</Text>
+      </View>
+    );
+  }
+
+  const { detail } = state;
+  const statusColor = STATUS_COLORS[detail.status] ?? '#888';
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={handleRefresh}
+          tintColor="#4a90d9"
+          colors={['#4a90d9']}
+        />
+      }
+    >
+      <View style={styles.navBar}>
+        <TouchableOpacity onPress={onBack} accessibilityRole="button" accessibilityLabel="Back">
+          <Text style={styles.backButtonText}>Back</Text>
+        </TouchableOpacity>
+      </View>
+
+      {state.error ? (
+        <View style={styles.errorBanner}>
+          <Text style={styles.errorBannerText}>{state.error}</Text>
+        </View>
+      ) : null}
+
+      {/* Header card */}
+      <View style={styles.headerCard}>
+        <View style={styles.headerRow}>
+          <Text style={styles.capabilityName}>{detail.name}</Text>
+          <View style={[styles.statusBadge, { backgroundColor: statusColor }]}>
+            <Text style={styles.statusBadgeText}>{detail.status}</Text>
+          </View>
+        </View>
+
+        {detail.zeroTrustMode && (
+          <View style={styles.zeroTrustBadge}>
+            <Text style={styles.zeroTrustText}>Zero-trust mode enabled</Text>
+          </View>
+        )}
+
+        {detail.lastActiveAt && (
+          <Text style={styles.lastActiveText}>
+            Last active: {formatRelativeTime(detail.lastActiveAt)}
+          </Text>
+        )}
+      </View>
+
+      {/* Spend meter */}
+      {detail.spendCapMonthlyUsd !== null && (
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Monthly Spend</Text>
+          <View style={styles.spendCard}>
+            <View style={styles.spendRow}>
+              <Text style={styles.spendLabel}>Used this month</Text>
+              <Text style={styles.spendValue}>
+                ${(detail.spendUsedMonthUsd ?? 0).toFixed(2)}
+              </Text>
+            </View>
+            <View style={styles.spendRow}>
+              <Text style={styles.spendLabel}>Monthly cap</Text>
+              <Text style={styles.spendValue}>
+                ${detail.spendCapMonthlyUsd.toFixed(2)}
+              </Text>
+            </View>
+            <SpendMeter
+              used={detail.spendUsedMonthUsd ?? 0}
+              cap={detail.spendCapMonthlyUsd}
+            />
+          </View>
+        </View>
+      )}
+
+      {/* Skills list */}
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>
+          Skills ({detail.skills.length})
+        </Text>
+        {detail.skills.length === 0 ? (
+          <View style={styles.emptyCard}>
+            <Text style={styles.emptyText}>No skills registered</Text>
+          </View>
+        ) : (
+          detail.skills.map((skill, index) => (
+            <SkillRow key={index} skill={skill} />
+          ))
+        )}
+      </View>
+
+      {/* Provenance link */}
+      <TouchableOpacity
+        style={styles.provenanceButton}
+        onPress={handleViewProvenance}
+        accessibilityRole="button"
+        accessibilityLabel="View provenance in browser"
+      >
+        <Text style={styles.provenanceButtonText}>View provenance</Text>
+        <Text style={styles.provenanceButtonSubtext}>Opens web dashboard</Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+}
+
+// -- Sub-components --
+
+function SpendMeter({ used, cap }: { used: number; cap: number }): React.JSX.Element {
+  const pct = cap > 0 ? Math.min(used / cap, 1) : 0;
+  const barColor = pct > 0.8 ? '#e74c3c' : pct > 0.5 ? '#f39c12' : '#2ecc71';
+
+  return (
+    <View style={styles.spendMeter}>
+      <View style={styles.spendMeterTrack}>
+        <View
+          style={[
+            styles.spendMeterFill,
+            { width: `${pct * 100}%` as `${number}%`, backgroundColor: barColor },
+          ]}
+        />
+      </View>
+      <Text style={styles.spendMeterLabel}>{Math.round(pct * 100)}% used</Text>
+    </View>
+  );
+}
+
+const RISK_COLORS: Record<string, string> = {
+  low: '#2ecc71',
+  medium: '#f39c12',
+  high: '#e74c3c',
+  critical: '#8e44ad',
+};
+
+function SkillRow({ skill }: { skill: CapabilitySkill }): React.JSX.Element {
+  const riskColor = RISK_COLORS[skill.riskLevel] ?? '#888';
+  return (
+    <View style={styles.skillCard}>
+      <View style={styles.skillHeader}>
+        <Text style={styles.skillName}>{skill.name}</Text>
+        <View style={[styles.riskBadge, { backgroundColor: riskColor }]}>
+          <Text style={styles.riskBadgeText}>{skill.riskLevel}</Text>
+        </View>
+      </View>
+      {skill.description ? (
+        <Text style={styles.skillDescription}>{skill.description}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+// -- Helpers --
+
+function formatRelativeTime(isoString: string): string {
+  const date = new Date(isoString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / 60_000);
+  if (diffMinutes < 1) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+// -- Styles --
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  centered: {
+    flex: 1,
+    backgroundColor: '#1a1a2e',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  navBar: {
+    marginBottom: 16,
+  },
+  backButton: {
+    marginBottom: 16,
+  },
+  backButtonText: {
+    color: '#4a90d9',
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  loadingText: {
+    color: '#a0a0b8',
+    fontSize: 16,
+    marginTop: 12,
+  },
+  errorText: {
+    color: '#e74c3c',
+    fontSize: 14,
+    textAlign: 'center',
+    marginTop: 12,
+    paddingHorizontal: 24,
+  },
+  errorBanner: {
+    backgroundColor: '#3a1a1a',
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    marginBottom: 16,
+  },
+  errorBannerText: {
+    color: '#e74c3c',
+    fontSize: 13,
+  },
+  headerCard: {
+    backgroundColor: '#2a2a40',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 24,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 8,
+  },
+  capabilityName: {
+    color: '#e0e0f0',
+    fontSize: 20,
+    fontWeight: '700',
+    flex: 1,
+    marginRight: 10,
+  },
+  statusBadge: {
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  statusBadgeText: {
+    color: '#fff',
+    fontSize: 11,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+  },
+  zeroTrustBadge: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#2a1a3a',
+    borderRadius: 4,
+    borderWidth: 1,
+    borderColor: '#6a3a9a',
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    marginBottom: 8,
+  },
+  zeroTrustText: {
+    color: '#9a6ac0',
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  lastActiveText: {
+    color: '#888',
+    fontSize: 12,
+  },
+  section: {
+    marginBottom: 24,
+  },
+  sectionTitle: {
+    color: '#a0a0b8',
+    fontSize: 13,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    marginBottom: 10,
+  },
+  emptyCard: {
+    backgroundColor: '#2a2a40',
+    borderRadius: 10,
+    padding: 24,
+    alignItems: 'center',
+  },
+  emptyText: {
+    color: '#a0a0b8',
+    fontSize: 14,
+  },
+  spendCard: {
+    backgroundColor: '#2a2a40',
+    borderRadius: 12,
+    padding: 16,
+  },
+  spendRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  spendLabel: {
+    color: '#a0a0b8',
+    fontSize: 14,
+  },
+  spendValue: {
+    color: '#e0e0f0',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  spendMeter: {
+    marginTop: 12,
+  },
+  spendMeterTrack: {
+    height: 6,
+    backgroundColor: '#3a3a54',
+    borderRadius: 3,
+    overflow: 'hidden',
+  },
+  spendMeterFill: {
+    height: '100%',
+    borderRadius: 3,
+  },
+  spendMeterLabel: {
+    color: '#888',
+    fontSize: 11,
+    marginTop: 4,
+    textAlign: 'right',
+  },
+  skillCard: {
+    backgroundColor: '#2a2a40',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 6,
+  },
+  skillHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  skillName: {
+    color: '#e0e0f0',
+    fontSize: 14,
+    fontWeight: '500',
+    flex: 1,
+    marginRight: 8,
+  },
+  riskBadge: {
+    borderRadius: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  riskBadgeText: {
+    color: '#fff',
+    fontSize: 10,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+  },
+  skillDescription: {
+    color: '#a0a0b8',
+    fontSize: 12,
+    lineHeight: 17,
+  },
+  provenanceButton: {
+    backgroundColor: '#2a2a40',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#3a3a54',
+    padding: 16,
+    alignItems: 'center',
+  },
+  provenanceButtonText: {
+    color: '#4a90d9',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  provenanceButtonSubtext: {
+    color: '#888',
+    fontSize: 12,
+    marginTop: 2,
+  },
+});

--- a/apps/mobile/src/services/api-client.ts
+++ b/apps/mobile/src/services/api-client.ts
@@ -56,6 +56,68 @@ export interface TwinProfile {
   confidenceScores: Record<string, unknown>;
 }
 
+// -- Capabilities types --
+
+export interface CapabilitySkill {
+  name: string;
+  description: string;
+  riskLevel: string;
+}
+
+export interface InstalledCapability {
+  id: string;
+  name: string;
+  status: 'running' | 'stopped' | 'error' | 'dormant';
+  lastActiveAt: string | null;
+  zeroTrustMode: boolean;
+  spendCapMonthlyUsd: number | null;
+  skills: CapabilitySkill[];
+}
+
+export interface CapabilitySuggestion {
+  id: string;
+  registryId: string;
+  name: string;
+  reason: string;
+  category: string;
+}
+
+export interface CapabilitiesPayload {
+  installed: InstalledCapability[];
+  suggestions: CapabilitySuggestion[];
+  dormant: InstalledCapability[];
+}
+
+export interface CapabilityDetail {
+  id: string;
+  name: string;
+  status: string;
+  lastActiveAt: string | null;
+  zeroTrustMode: boolean;
+  spendCapMonthlyUsd: number | null;
+  spendUsedMonthUsd: number | null;
+  skills: CapabilitySkill[];
+  provenanceUrl: string | null;
+}
+
+// -- Briefing types --
+
+export interface TwinBriefing {
+  id: string;
+  cadence: 'daily' | 'weekly';
+  headline: string;
+  keySignals: string[];
+  pendingApprovalsCount: number;
+  generatedAt: string;
+  readAt: string | null;
+  proseMarkdown: string;
+}
+
+export interface TwinBriefingPayload {
+  briefing: TwinBriefing | null;
+  unreadCount: number;
+}
+
 export interface ApprovalResponse {
   requestId: string;
   action: string;
@@ -153,6 +215,36 @@ export class SkyTwinApiClient {
    */
   async getTwinProfile(userId: string): Promise<ApiResult<TwinProfile>> {
     return this.get<TwinProfile>(`/api/twin/${encodeURIComponent(userId)}`);
+  }
+
+  /**
+   * Fetch installed capabilities plus pending suggestions for a user.
+   */
+  async fetchCapabilities(userId: string): Promise<ApiResult<CapabilitiesPayload>> {
+    return this.get<CapabilitiesPayload>(
+      `/api/capabilities/${encodeURIComponent(userId)}`,
+    );
+  }
+
+  /**
+   * Fetch detailed information for a single capability (server + skills + policy).
+   */
+  async fetchCapabilityDetail(
+    userId: string,
+    serverId: string,
+  ): Promise<ApiResult<CapabilityDetail>> {
+    return this.get<CapabilityDetail>(
+      `/api/capabilities/${encodeURIComponent(userId)}/${encodeURIComponent(serverId)}`,
+    );
+  }
+
+  /**
+   * Fetch the most recent twin briefing and count of unread briefings.
+   */
+  async fetchTwinBriefing(userId: string): Promise<ApiResult<TwinBriefingPayload>> {
+    return this.get<TwinBriefingPayload>(
+      `/api/briefing/${encodeURIComponent(userId)}/latest`,
+    );
   }
 
   // -- Internal helpers --


### PR DESCRIPTION
## Summary

Code-bound subset of #179. Voice STT/TTS, push notifications, QR pairing UX changes, and full offline support all need real device testing — those are deferred to a session with iOS/Android hardware. This PR ships read-only mobile screens for Capabilities + Briefing plus the API client integration.

## Screens

- **`CapabilitiesScreen`** — list of installed capabilities with status badge, last-active timestamp, pull-to-refresh, pending suggestions at top with Install / Snooze / Dismiss buttons. Tap → CapabilityDetail.
- **`CapabilityDetailScreen`** — server detail with skills list, monthly spend meter (if cap configured), zero-trust status badge, and a "View provenance" button that opens a webview to the web's `/provenance` route. **Read-only on mobile for v1**; edits stay on web.
- **`BriefingScreen`** — twin briefing view with today's headline, key signals, pending approvals count → tap to web fallback. Pull-to-refresh.

## API client extensions

`apps/mobile/src/services/api-client.ts`:
- `fetchCapabilities(userId)` → installed list + suggestions
- `fetchCapabilityDetail(userId, serverId)` → server + skills + policy
- `fetchTwinBriefing(userId)` → most recent briefing + unread count

## Navigation

Extended the existing hand-rolled tab bar in `App.tsx` to include Briefing and Capabilities. Capability detail renders as a sub-page inside the Capabilities tab (state-driven, resets on tab switch). Avoids nested navigators which would make Android hardware back ambiguous.

## Tests

36 new in `capabilities-briefing.test.ts`. Mobile suite: 152 pass, 2 pre-existing skipped. Full turbo: 68/68 pass.

## Out of scope

- Voice STT/TTS — needs device microphone + speakers
- Push notifications — needs APNs/FCM credentials
- Deep-linking from web → mobile — needs URL scheme registration
- Full offline support — needs sync engine work
- Install-from-mobile — defer; mobile is a viewer + approver, not an editor

## No new top-level deps

No `expo-av`, no `expo-notifications`. Standard `RefreshControl` from React Native for pull-to-refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)