### PR TITLE
fix(copilot-sweep batch 2): DXT route hardening (#219 follow-up)

### DIFF
--- a/apps/api/src/__tests__/dxt-import-confirm-flow.test.ts
+++ b/apps/api/src/__tests__/dxt-import-confirm-flow.test.ts
@@ -20,11 +20,13 @@ const {
   mockMcpServerRepo: {
     getById: vi.fn(),
     getByUserAndRegistry: vi.fn(),
+    listSkillNamesForServer: vi.fn(async () => [] as string[]),
   },
   mockDxtExportRepo: {
     create: vi.fn(),
     findById: vi.fn(),
     listForUser: vi.fn(),
+    listMetadataForUser: vi.fn(),
   },
   mockDxtImportRepo: {
     create: vi.fn(),

--- a/apps/api/src/__tests__/dxt-routes.test.ts
+++ b/apps/api/src/__tests__/dxt-routes.test.ts
@@ -6,11 +6,13 @@ const { mockMcpServerRepo, mockDxtExportRepo, mockDxtImportRepo, mockProvenanceR
   mockMcpServerRepo: {
     getById: vi.fn(),
     getByUserAndRegistry: vi.fn(),
+    listSkillNamesForServer: vi.fn(async () => [] as string[]),
   },
   mockDxtExportRepo: {
     create: vi.fn(),
     findById: vi.fn(),
     listForUser: vi.fn(),
+    listMetadataForUser: vi.fn(),
   },
   mockDxtImportRepo: {
     create: vi.fn(),
@@ -148,8 +150,9 @@ describe('POST /api/dxt/export/:serverId', () => {
     expect(result.status).toBe(403);
   });
 
-  it('happy path: serializes, persists, returns blob', async () => {
+  it('happy path: serializes, persists, returns blob, AND uses serverId as sourceInstanceId + real skills', async () => {
     mockMcpServerRepo.getById.mockResolvedValueOnce(makeMcpServerRow());
+    mockMcpServerRepo.listSkillNamesForServer.mockResolvedValueOnce(['notion.create_page', 'notion.search']);
     const fakeRow = {
       id: EXPORT_ID,
       user_id: USER_ID,
@@ -177,19 +180,29 @@ describe('POST /api/dxt/export/:serverId', () => {
         sha256: expect.any(Buffer),
       }),
     );
+    expect(mockMcpServerRepo.listSkillNamesForServer).toHaveBeenCalledWith(SERVER_ID);
+  });
+
+  it('returns 400 when capability has no registry_id (cannot round-trip on import)', async () => {
+    mockMcpServerRepo.getById.mockResolvedValueOnce(makeMcpServerRow({ registry_id: null }));
+    const app = buildApp();
+    const result = await req(app, 'POST', `/api/dxt/export/${SERVER_ID}`);
+    expect(result.status).toBe(400);
+    const body = result.body as { error?: string };
+    expect(body.error).toMatch(/registry_id/);
   });
 });
 
 describe('GET /api/dxt/exports', () => {
-  it('returns metadata only (no blob bytes in response)', async () => {
-    mockDxtExportRepo.listForUser.mockResolvedValueOnce([
+  it('returns metadata only (no blob bytes in response) and never loads blobs from DB', async () => {
+    mockDxtExportRepo.listMetadataForUser.mockResolvedValueOnce([
       {
         id: EXPORT_ID,
         user_id: USER_ID,
         server_id: SERVER_ID,
         exported_at: new Date('2026-05-08T00:00:00Z'),
-        artifact_blob: Buffer.alloc(123),
         artifact_sha256: Buffer.alloc(32, 0xab),
+        blob_bytes: 123,
       },
     ]);
     const app = buildApp();
@@ -201,6 +214,9 @@ describe('GET /api/dxt/exports', () => {
     expect(body.exports[0]!['id']).toBe(EXPORT_ID);
     expect(body.exports[0]!['blobBytes']).toBe(123);
     expect(body.exports[0]).not.toHaveProperty('artifact_blob');
+    // Hard guarantee: do NOT call the blob-loading variant.
+    expect(mockDxtExportRepo.listForUser).not.toHaveBeenCalled();
+    expect(mockDxtExportRepo.listMetadataForUser).toHaveBeenCalledWith(USER_ID);
   });
 });
 
@@ -236,6 +252,24 @@ describe('POST /api/dxt/import', () => {
     expect(result.status).toBe(400);
     const body = result.body as { code?: string };
     expect(body.code).toBe('MAGIC_MISMATCH');
+  });
+
+  it('rejects blobs that contain non-base64 characters (regression: Buffer.from silently drops them)', async () => {
+    const app = buildApp();
+    // !@# are outside the base64 alphabet — silently stripped by Buffer.from
+    // unless we validate first.
+    const result = await req(app, 'POST', '/api/dxt/import', { blob: 'not!@#valid' });
+    expect(result.status).toBe(400);
+    const body = result.body as { error?: string };
+    expect(body.error).toMatch(/base64/);
+  });
+
+  it('rejects base64 strings whose length is not a multiple of 4', async () => {
+    const app = buildApp();
+    const result = await req(app, 'POST', '/api/dxt/import', { blob: 'AAA' });
+    expect(result.status).toBe(400);
+    const body = result.body as { error?: string };
+    expect(body.error).toMatch(/base64/);
   });
 
   it('happy path: round-trips export → import preview', async () => {

--- a/apps/api/src/routes/dxt.ts
+++ b/apps/api/src/routes/dxt.ts
@@ -15,7 +15,7 @@
 import { Router } from 'express';
 import type { Request } from 'express';
 import { mcpServerRepository, dxtExportRepository, dxtImportRepository, provenanceRepository, query } from '@skytwin/db';
-import type { McpServerRow, DxtExportRow } from '@skytwin/db';
+import type { McpServerRow, DxtExportMetadataRow } from '@skytwin/db';
 import { createLogger } from '@skytwin/core';
 import { serialize, deserialize, redactCommand } from '@skytwin/dxt';
 import type { DxtArtifactInput, DxtJsonPayload } from '@skytwin/dxt';
@@ -40,12 +40,21 @@ function getUserId(req: Request): string | undefined {
 
 /**
  * Build the DXT artifact input from an mcp_servers row.
- * Pulls the redacted args + transport details + per-app spend caps.
+ *
+ * `sourceInstanceId` is the originating MCP server row id (NOT the user id —
+ * passing the user there confused install-attribution on import).
+ *
+ * `skills` is the cached `list_tools()` set fetched from `mcp_server_skills`;
+ * the previous version always passed an empty array, so receivers couldn't
+ * see which tools the source had registered.
  */
 function buildArtifactInput(server: McpServerRow, sourceInstanceId: string, skills: string[]): DxtArtifactInput {
   const rawArgs = Array.isArray(server.args) ? (server.args as unknown[]).filter((a): a is string => typeof a === 'string') : [];
   const result: DxtArtifactInput = {
     sourceInstanceId,
+    // registry_id is required so the artifact identifies its capability by a
+    // stable id. display_name is unstable (rename-able) and isn't a valid
+    // import key — getByUserAndRegistry() only matches on registry_id.
     registryId: server.registry_id ?? server.display_name,
     transport: server.transport,
     skills,
@@ -98,7 +107,18 @@ export function createDxtRouter(): Router {
         return;
       }
 
-      const input = buildArtifactInput(server, userId, []);
+      // Reject export of capabilities without a stable registry_id — the
+      // import path can only round-trip rows it can re-resolve via
+      // getByUserAndRegistry, which keys on registry_id.
+      if (!server.registry_id) {
+        res.status(400).json({
+          error: 'Cannot export: this capability has no registry_id and cannot be re-imported safely',
+        });
+        return;
+      }
+
+      const skills = await mcpServerRepository.listSkillNamesForServer(serverId);
+      const input = buildArtifactInput(server, serverId, skills);
       const { blob, sha256 } = await serialize(input);
 
       const row = await dxtExportRepository.create({
@@ -134,13 +154,14 @@ export function createDxtRouter(): Router {
         return;
       }
 
-      const rows = await dxtExportRepository.listForUser(userId);
-      const exports = rows.map((r: DxtExportRow) => ({
+      // Metadata-only — never load full blobs into memory just to render the list.
+      const rows = await dxtExportRepository.listMetadataForUser(userId);
+      const exports = rows.map((r: DxtExportMetadataRow) => ({
         id: r.id,
         serverId: r.server_id,
         exportedAt: r.exported_at,
         sha256: r.artifact_sha256.toString('hex'),
-        blobBytes: r.artifact_blob.length,
+        blobBytes: r.blob_bytes,
       }));
 
       res.json({ exports });
@@ -206,11 +227,17 @@ export function createDxtRouter(): Router {
         return;
       }
 
-      let blob: Buffer;
-      try {
-        blob = Buffer.from(body.blob, 'base64');
-      } catch {
+      // Buffer.from(str, 'base64') silently drops invalid chars rather than
+      // throwing — the previous try/catch was unreachable. Validate the
+      // shape explicitly with a strict regex (RFC 4648 base64 alphabet,
+      // optional padding) before decoding.
+      if (!/^[A-Za-z0-9+/]+={0,2}$/.test(body.blob) || body.blob.length % 4 !== 0) {
         res.status(400).json({ error: 'blob must be valid base64' });
+        return;
+      }
+      const blob = Buffer.from(body.blob, 'base64');
+      if (blob.length === 0) {
+        res.status(400).json({ error: 'blob decoded to zero bytes' });
         return;
       }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -113,6 +113,7 @@ export type {
 export { dxtExportRepository } from './repositories/index.js';
 export type {
   DxtExportRow,
+  DxtExportMetadataRow,
   CreateDxtExportInput,
 } from './repositories/index.js';
 

--- a/packages/db/src/repositories/dxt-export-repository.ts
+++ b/packages/db/src/repositories/dxt-export-repository.ts
@@ -55,8 +55,9 @@ export const dxtExportRepository = {
 
   /**
    * List all exports for a user, newest first.
-   * Blob bytes are included — callers that need metadata-only should project
-   * away artifact_blob themselves.
+   * Blob bytes are included — for metadata-only listings (e.g. the
+   * `/api/dxt/exports` endpoint), prefer `listMetadataForUser` so we
+   * don't ship the full artifact bytes through Postgres → API → response.
    */
   async listForUser(userId: string): Promise<DxtExportRow[]> {
     const result = await query<DxtExportRow>(
@@ -68,4 +69,29 @@ export const dxtExportRepository = {
     );
     return result.rows;
   },
+
+  /**
+   * Metadata-only variant of listForUser — excludes artifact_blob and uses
+   * octet_length() for the byte count so blobs don't leave Postgres.
+   */
+  async listMetadataForUser(userId: string): Promise<DxtExportMetadataRow[]> {
+    const result = await query<DxtExportMetadataRow>(
+      `SELECT id, user_id, server_id, exported_at, artifact_sha256,
+              octet_length(artifact_blob)::INT AS blob_bytes
+       FROM dxt_exports
+       WHERE user_id = $1
+       ORDER BY exported_at DESC`,
+      [userId],
+    );
+    return result.rows;
+  },
 };
+
+export interface DxtExportMetadataRow {
+  id: string;
+  user_id: string;
+  server_id: string;
+  exported_at: Date;
+  artifact_sha256: Buffer;
+  blob_bytes: number;
+}

--- a/packages/db/src/repositories/index.ts
+++ b/packages/db/src/repositories/index.ts
@@ -163,6 +163,7 @@ export type {
 export { dxtExportRepository } from './dxt-export-repository.js';
 export type {
   DxtExportRow,
+  DxtExportMetadataRow,
   CreateDxtExportInput,
 } from './dxt-export-repository.js';
 

--- a/packages/db/src/repositories/mcp-server-repository.ts
+++ b/packages/db/src/repositories/mcp-server-repository.ts
@@ -55,6 +55,20 @@ export const mcpServerRepository = {
     return result.rows;
   },
 
+  /**
+   * Return the cached list_tools() skill names for a server. Used by the DXT
+   * exporter so the artifact records the skill set the user actually has,
+   * not an empty placeholder. Cheap query — only the names; full schemas
+   * stay in the table.
+   */
+  async listSkillNamesForServer(serverId: string): Promise<string[]> {
+    const result = await query<{ skill_name: string }>(
+      `SELECT skill_name FROM mcp_server_skills WHERE server_id = $1 ORDER BY skill_name`,
+      [serverId],
+    );
+    return result.rows.map((r) => r.skill_name);
+  },
+
   async listActive(): Promise<McpServerRow[]> {
     const result = await query<McpServerRow>(
       `SELECT * FROM mcp_servers WHERE status = 'active' ORDER BY last_active_at DESC`,


### PR DESCRIPTION
**Stacked on #226.** Land that first.

Six fixes for DXT export/import routes that didn't make batch 1.

## Changes
- buildArtifactInput uses serverId as sourceInstanceId (was userId).
- skills array now populated from \`mcp_server_skills\` (was always \`[]\`).
- Export rejected when registry_id is null (round-trip would fail on import).
- Explicit base64 validation (regex + length-mod-4 + zero-byte). Buffer.from
  silently drops invalid chars — the previous try/catch was unreachable.
- New \`listMetadataForUser\` repository method using \`octet_length\` so the
  list endpoint never loads full blobs.

## Test plan
- [x] All 400 api tests pass
- [x] New regression tests for non-base64 chars and length-mod-4
- [x] New "rejects null registry_id" test
- [x] /exports test asserts blob-loading variant is NEVER called

🤖 Generated with [Claude Code](https://claude.com/claude-code)