### PR TITLE
fix(copilot-sweep batch 3): credential vault rotation polish (#212/#214 follow-up)

### DIFF
--- a/apps/api/src/__tests__/credential-vault-routes.test.ts
+++ b/apps/api/src/__tests__/credential-vault-routes.test.ts
@@ -498,6 +498,59 @@ describe('POST /api/credential-vault/rotate', () => {
     expect(mockKeyCache.set).toHaveBeenCalledWith(USER_ID, expect.any(Buffer));
   });
 
+  it('rotates access-only rows (no refresh token) without skipping them', async () => {
+    const { encrypt: rEncrypt } = await import('@skytwin/credential-vault');
+    const passphrase = 'correct-current-passphrase-xyz';
+    const meta = await buildMetaRow(passphrase);
+    const { passphrase_salt } = meta;
+    const { deriveKey: realDeriveKey } = await import('@skytwin/credential-vault');
+    const oldKey = await realDeriveKey(passphrase, passphrase_salt);
+    const atResult = rEncrypt('access-only-token', oldKey);
+    const packedAt = Buffer.concat([atResult.iv, atResult.tag, atResult.ciphertext]);
+
+    const accessOnlyRow = {
+      id: 'access-only-row',
+      user_id: USER_ID,
+      provider: 'github',
+      account_email: 'test@example.com',
+      account_provider_id: null,
+      access_token: null,
+      refresh_token: null,
+      expires_at: new Date(),
+      scopes: ['repo'],
+      created_at: new Date(),
+      updated_at: new Date(),
+      encrypted_access_token: packedAt,
+      encrypted_refresh_token: null, // <-- the case Copilot caught
+      encryption_iv: null,
+      encryption_tag: null,
+      encryption_key_version: 1,
+    };
+
+    mockVaultMetaRepo.getForUser.mockResolvedValueOnce(meta);
+    mockOAuthRepo.listEncryptedForUser.mockResolvedValueOnce([accessOnlyRow]);
+    mockOAuthRepo.rotateEncrypted.mockResolvedValueOnce(undefined);
+    mockVaultMetaRepo.rotatePassphrase.mockResolvedValueOnce(2);
+
+    const res = await req(buildApp(), 'POST', '/api/credential-vault/rotate', {
+      currentPassphrase: passphrase,
+      newPassphrase: 'new-valid-passphrase-here',
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as Record<string, unknown>;
+    expect(body['tokensReencrypted']).toBe(1);
+    // rotateEncrypted called with encryptedRefreshToken === null (not skipped)
+    expect(mockOAuthRepo.rotateEncrypted).toHaveBeenCalledWith(
+      'access-only-row',
+      expect.objectContaining({
+        encryptedAccessToken: expect.any(Buffer),
+        encryptedRefreshToken: null,
+      }),
+      expect.anything(),
+    );
+  });
+
   it('returns 500 and rolls back when re-encryption throws mid-transaction', async () => {
     const passphrase = 'correct-current-passphrase-xyz';
     const meta = await buildMetaRow(passphrase);

--- a/apps/api/src/routes/credential-vault.ts
+++ b/apps/api/src/routes/credential-vault.ts
@@ -282,7 +282,15 @@ export function createCredentialVaultRouter(): Router {
       const initialized = meta !== null;
       const unlocked = sharedKeyCache.has(userId);
 
-      res.status(200).json({ initialized, unlocked });
+      // Expose keyVersion + lastRotated so the UI can render passphrase-age
+      // badges. The vault settings page reads these; previously it bound to
+      // undefined and rendered nothing.
+      res.status(200).json({
+        initialized,
+        unlocked,
+        keyVersion: meta?.current_key_version ?? null,
+        lastRotated: meta?.rotated_at ?? null,
+      });
     } catch (err) {
       next(err);
     }
@@ -378,29 +386,34 @@ export function createCredentialVaultRouter(): Router {
           // silently overwritten.
           const rows = await oauthRepository.listEncryptedForUser(userId, client);
 
-          // Re-encrypt each row
+          // Re-encrypt each row. Access-only rows (no refresh token) are
+          // re-encrypted too — previously they were silently skipped via
+          // `continue`, leaving them encrypted under the old key after the
+          // meta row's key_version bumped, i.e. undecryptable.
           for (const row of rows) {
-            if (!row.encrypted_access_token || !row.encrypted_refresh_token) continue;
+            if (!row.encrypted_access_token) continue;
 
             const {
               iv: atIv,
               tag: atTag,
               ciphertext: atCipher,
             } = unpackEncrypted(row.encrypted_access_token);
-            const {
-              iv: rtIv,
-              tag: rtTag,
-              ciphertext: rtCipher,
-            } = unpackEncrypted(row.encrypted_refresh_token);
-
             const accessToken = decrypt({ ciphertext: atCipher, iv: atIv, tag: atTag }, oldKey);
-            const refreshToken = decrypt(
-              { ciphertext: rtCipher, iv: rtIv, tag: rtTag },
-              oldKey,
-            );
-
             const newAtPacked = packEncrypted(encrypt(accessToken, newKey));
-            const newRtPacked = packEncrypted(encrypt(refreshToken, newKey));
+
+            let newRtPacked: Buffer | null = null;
+            if (row.encrypted_refresh_token) {
+              const {
+                iv: rtIv,
+                tag: rtTag,
+                ciphertext: rtCipher,
+              } = unpackEncrypted(row.encrypted_refresh_token);
+              const refreshToken = decrypt(
+                { ciphertext: rtCipher, iv: rtIv, tag: rtTag },
+                oldKey,
+              );
+              newRtPacked = packEncrypted(encrypt(refreshToken, newKey));
+            }
 
             await oauthRepository.rotateEncrypted(
               row.id,
@@ -433,6 +446,10 @@ export function createCredentialVaultRouter(): Router {
         log.error('Credential vault rotation transaction failed; rolled back', {
           userId,
           tokensAttempted: tokensReencrypted,
+          // Surface the actual error — without this, prod debugging is blind
+          // to whatever failed inside the tx (decrypt error, FK violation, …).
+          error: txErr instanceof Error ? txErr.message : String(txErr),
+          stack: txErr instanceof Error ? txErr.stack : undefined,
         });
         next(txErr);
         return;

--- a/packages/connectors/src/oauth/db-token-store.ts
+++ b/packages/connectors/src/oauth/db-token-store.ts
@@ -32,7 +32,24 @@ function packEncrypted(result: { ciphertext: Buffer; iv: Buffer; tag: Buffer }):
   return Buffer.concat([result.iv, result.tag, result.ciphertext]);
 }
 
+/**
+ * Reverse of packEncrypted. Validates length up-front so corruption surfaces
+ * as a clear "packed buffer too short" error rather than the cryptic
+ * "Unsupported state or unable to authenticate data" thrown by AES-GCM
+ * when it's handed a too-short ciphertext.
+ *
+ * Minimum is IV_LENGTH (12) + TAG_LENGTH (16) = 28 bytes; that's an empty
+ * plaintext. Anything shorter is corruption or a wrong-format buffer.
+ */
+const MIN_PACKED_LENGTH = IV_LENGTH + TAG_LENGTH;
+
 function unpackEncrypted(packed: Buffer): { iv: Buffer; tag: Buffer; ciphertext: Buffer } {
+  if (!Buffer.isBuffer(packed) || packed.length < MIN_PACKED_LENGTH) {
+    throw new Error(
+      `unpackEncrypted: packed buffer too short (got ${packed?.length ?? 0} bytes, ` +
+        `need at least ${MIN_PACKED_LENGTH} for IV + tag)`,
+    );
+  }
   const iv = packed.subarray(0, IV_LENGTH);
   const tag = packed.subarray(IV_LENGTH, IV_LENGTH + TAG_LENGTH);
   const ciphertext = packed.subarray(IV_LENGTH + TAG_LENGTH);
@@ -84,6 +101,16 @@ interface OAuthRepositoryLike {
       tag: Buffer;
       keyVersion: number;
     },
+  ) => Promise<void>;
+  /**
+   * Update only the encrypted access token (for refresh-rotation when the
+   * row is stored encrypted). Leaves refresh token alone, NULLs the
+   * plaintext column so subsequent reads cannot fall back to the old value.
+   */
+  updateEncryptedAccessToken?: (
+    id: string,
+    encryptedAccessToken: Buffer,
+    expiresAt: Date,
   ) => Promise<void>;
 }
 
@@ -272,13 +299,29 @@ export class DbTokenStore implements OAuthTokenStore {
     // Token is expired or about to expire — refresh it
     const refreshed = await refreshAccessToken(this.oauthConfig, existing.refreshToken);
 
-    // Persist the new access token
-    await this.repo.updateAccessToken(
-      userId,
-      provider,
-      refreshed.accessToken,
-      refreshed.expiresAt,
-    );
+    // Persist the new access token. If the row is currently stored
+    // encrypted (key cache populated AND row has encrypted_access_token),
+    // write the new token to the ENCRYPTED column — otherwise getToken
+    // would keep returning the old, still-encrypted access token while
+    // the new plaintext sat unread.
+    const row = await this.repo.getToken(userId, provider);
+    const key = this.keyCache?.get(userId) ?? null;
+    if (
+      row?.id
+      && row.encrypted_access_token
+      && key !== null
+      && this.repo.updateEncryptedAccessToken
+    ) {
+      const packed = packEncrypted(encrypt(refreshed.accessToken, key));
+      await this.repo.updateEncryptedAccessToken(row.id, packed, refreshed.expiresAt);
+    } else {
+      await this.repo.updateAccessToken(
+        userId,
+        provider,
+        refreshed.accessToken,
+        refreshed.expiresAt,
+      );
+    }
 
     return {
       ...refreshed,

--- a/packages/db/src/repositories/oauth-repository.ts
+++ b/packages/db/src/repositories/oauth-repository.ts
@@ -195,6 +195,33 @@ export const oauthRepository = {
     return result.rows[0] ?? null;
   },
 
+  /**
+   * Update the encrypted access-token column for a row whose tokens are
+   * stored encrypted (packed IV+tag+ciphertext format). Leaves the refresh
+   * token alone — Google rotates access tokens on refresh but not refresh
+   * tokens. Critical: also clears `access_token` plaintext so a subsequent
+   * read can't fall back to the old/stale plaintext.
+   *
+   * Without this method, refreshIfExpired wrote the new token to
+   * `access_token` (plaintext) while `encrypted_access_token` continued to
+   * hold the previous value — and getToken would then decrypt the old one.
+   */
+  async updateEncryptedAccessToken(
+    id: string,
+    encryptedAccessToken: Buffer,
+    expiresAt: Date,
+  ): Promise<void> {
+    await query(
+      `UPDATE oauth_tokens
+       SET encrypted_access_token = $1,
+           access_token           = NULL,
+           expires_at             = $2,
+           updated_at             = now()
+       WHERE id = $3`,
+      [encryptedAccessToken, expiresAt, id],
+    );
+  },
+
   async getUsersWithActiveTokens(): Promise<OAuthTokenRow[]> {
     return this.listAllConnections();
   },
@@ -294,23 +321,38 @@ export const oauthRepository = {
     id: string,
     input: {
       encryptedAccessToken: Buffer;
-      encryptedRefreshToken: Buffer;
+      // null means "this row had no refresh token to begin with — leave the
+      // column alone". Required for access-only rows; previously the type
+      // forced both Buffers and rotation skipped them, leaving them
+      // encrypted under the OLD key after rotation (undecryptable).
+      encryptedRefreshToken: Buffer | null;
       keyVersion: number;
     },
     client?: PoolClient,
   ): Promise<void> {
-    const sql = `UPDATE oauth_tokens
-       SET encrypted_access_token  = $1,
-           encrypted_refresh_token = $2,
-           encryption_key_version  = $3,
-           updated_at              = now()
-       WHERE id = $4`;
-    const params = [
-      input.encryptedAccessToken,
-      input.encryptedRefreshToken,
-      input.keyVersion,
-      id,
-    ];
+    // When refresh token is null we omit it from the UPDATE so the column
+    // keeps its existing value (NULL stays NULL). Two SQL shapes is fewer
+    // foot-guns than COALESCE on a Buffer column.
+    const sql = input.encryptedRefreshToken === null
+      ? `UPDATE oauth_tokens
+         SET encrypted_access_token = $1,
+             encryption_key_version = $2,
+             updated_at             = now()
+         WHERE id = $3`
+      : `UPDATE oauth_tokens
+         SET encrypted_access_token  = $1,
+             encrypted_refresh_token = $2,
+             encryption_key_version  = $3,
+             updated_at              = now()
+         WHERE id = $4`;
+    const params = input.encryptedRefreshToken === null
+      ? [input.encryptedAccessToken, input.keyVersion, id]
+      : [
+          input.encryptedAccessToken,
+          input.encryptedRefreshToken,
+          input.keyVersion,
+          id,
+        ];
 
     if (client) {
       await client.query(sql, params);


### PR DESCRIPTION
**Stacked on #227 → #226.** Land the chain bottom-up.

Five vault polish fixes that didn't make batch 1.

## Changes
- \`unpackEncrypted\` validates min length (IV+tag=28) before slicing.
  Cryptic GCM auth-tag error → clear "buffer too short" error.
- \`updateAccessToken\` left the encrypted column stale on refresh.
  Added \`updateEncryptedAccessToken\` + DbTokenStore picks the right
  path based on whether the row is currently encrypted.
- \`rotateEncrypted\` accepts \`encryptedRefreshToken: Buffer | null\`,
  so access-only rows aren't silently skipped (which would leave them
  encrypted under the OLD key after rotation, undecryptable).
- \`/api/credential-vault/status\` returns \`keyVersion\` + \`lastRotated\`
  (UI already binds them).
- Rotation tx error log includes the error message + stack.

## Test plan
- [x] All 401 api tests pass (added 1 access-only-rotation test)
- [x] Build clean (full \`pnpm build --concurrency=1\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)