### PR TITLE
fix(copilot-sweep batch 5): frontend nits (#206/#211/#213 follow-up)

### DIFF
--- a/apps/web/public/js/components/tier-promotion-modal.js
+++ b/apps/web/public/js/components/tier-promotion-modal.js
@@ -176,7 +176,11 @@ export function renderTierPromotionModal({
             ? 'suggest actions for your approval — nothing runs without your say-so.'
             : proposedTier === 'low_autonomy'
               ? 'handle small, low-risk actions without checking in each time.'
-              : 'handle most tasks on your behalf — you can still review and undo.'
+              : proposedTier === 'moderate_autonomy'
+                ? 'handle most routine tasks on your behalf — you can still review and undo.'
+                : proposedTier === 'high_autonomy'
+                  ? 'act broadly on your behalf, including higher-stakes work — you can still review, undo, or pull back to a lower tier at any time.'
+                  : 'take more autonomous action on your behalf — you can still review and undo.'
           }
         </p>
         <p class="muted" style="font-size: 0.82rem;">You can always adjust or reverse this from Capabilities settings.</p>

--- a/apps/web/public/js/pages/assistant.js
+++ b/apps/web/public/js/pages/assistant.js
@@ -499,14 +499,24 @@ async function handleReverseCapabilityInstall(registryId, displayName) {
 // This runs once when the assistant page first loads.
 // We subscribe on the global EventSource that app.js maintains.
 let _promotionSseWired = false;
+const PROMOTION_SSE_RETRY_MS = 500;
+const PROMOTION_SSE_MAX_ATTEMPTS = 20; // ~10s total
 function wirePromotionSseListener() {
   if (_promotionSseWired || typeof window === 'undefined') return;
-  _promotionSseWired = true;
-  // app.js exposes a window.__sseSource EventSource; subscribe to the event.
-  // If it's not available yet (race), we schedule a retry on the next renderAssistant.
+  // Set the flag ONLY after a successful wire — previously we set it
+  // up-front, so a single missed-then-retried attempt would mark the
+  // listener as wired and the second renderAssistant() call would no-op
+  // even if app.js created the EventSource later.
+  let attempts = 0;
   const wireIt = () => {
+    attempts += 1;
     const src = window['__sseSource'];
-    if (!src) return false;
+    if (!src) {
+      if (attempts < PROMOTION_SSE_MAX_ATTEMPTS) {
+        setTimeout(wireIt, PROMOTION_SSE_RETRY_MS);
+      }
+      return;
+    }
     src.addEventListener('capability:promotion-offered', (ev) => {
       try {
         const data = JSON.parse(ev.data);
@@ -520,12 +530,9 @@ function wirePromotionSseListener() {
         });
       } catch { /* ignore malformed events */ }
     });
-    return true;
+    _promotionSseWired = true;
   };
-  if (!wireIt()) {
-    // Retry after a tick in case app.js hasn't set window.__sseSource yet
-    setTimeout(wireIt, 500);
-  }
+  wireIt();
 }
 
 function formatThreadStamp(iso) {

--- a/apps/web/public/js/pages/capabilities.js
+++ b/apps/web/public/js/pages/capabilities.js
@@ -667,6 +667,25 @@ function renderOptInCard(optIn) {
   `;
 }
 
+/**
+ * Replace every action button in `el` with a single status badge.
+ *
+ * Per-button replaceWith on the previous implementation produced one badge
+ * per button — Accept + Reject buttons left two stacked "Accepted" badges.
+ * Now: remove all action buttons, then append one badge.
+ */
+function replaceActionsWithBadge(el, { className, text }) {
+  const actionBtns = el.querySelectorAll('[data-action]');
+  if (actionBtns.length === 0) return;
+  const parent = actionBtns[0].parentNode;
+  actionBtns.forEach((b) => b.remove());
+  if (!parent) return;
+  const badge = document.createElement('span');
+  badge.className = className;
+  badge.textContent = text;
+  parent.appendChild(badge);
+}
+
 async function handleAcceptOptIn(optInId, userId, btn) {
   if (btn) { btn.disabled = true; btn.textContent = 'Accepting…'; }
   try {
@@ -675,13 +694,7 @@ async function handleAcceptOptIn(optInId, userId, btn) {
     if (el) {
       el.style.opacity = '0.4';
       el.style.pointerEvents = 'none';
-      const actionBtns = el.querySelectorAll('[data-action]');
-      actionBtns.forEach((b) => b.replaceWith(
-        Object.assign(document.createElement('span'), {
-          className: 'badge badge-success',
-          textContent: 'Accepted',
-        }),
-      ));
+      replaceActionsWithBadge(el, { className: 'badge badge-success', text: 'Accepted' });
     }
     showToast('Skill opt-in accepted.', { kind: 'success' });
   } catch (err) {
@@ -698,13 +711,7 @@ async function handleRejectOptIn(optInId, userId, btn) {
     if (el) {
       el.style.opacity = '0.4';
       el.style.pointerEvents = 'none';
-      const actionBtns = el.querySelectorAll('[data-action]');
-      actionBtns.forEach((b) => b.replaceWith(
-        Object.assign(document.createElement('span'), {
-          className: 'badge badge-muted',
-          textContent: 'Rejected',
-        }),
-      ));
+      replaceActionsWithBadge(el, { className: 'badge badge-muted', text: 'Rejected' });
     }
     showToast('Skill opt-in rejected.', { kind: 'info' });
   } catch (err) {

--- a/apps/web/public/js/pages/provenance-graph.js
+++ b/apps/web/public/js/pages/provenance-graph.js
@@ -62,8 +62,10 @@ function handleProvenanceGraphAction(e) {
       break;
     }
     case 'pg-view-full-graph': {
+      // Reload with a higher cap. The server hard-limits the graph endpoint
+      // to 1000 nodes; passing the same default 200 here would be a no-op.
       const userId = getCurrentUserId();
-      renderProvenanceGraph(document.getElementById('page-content'), userId);
+      renderProvenanceGraph(document.getElementById('page-content'), userId, { limit: 1000 });
       break;
     }
     default:
@@ -98,19 +100,19 @@ async function fetchProvenanceGraph(userId, { nodeType = '', since = '', limit =
 // Main render entry point
 // ─────────────────────────────────────────────────────────────────────────────
 
-export async function renderProvenanceGraph(container, userId) {
+export async function renderProvenanceGraph(container, userId, opts = {}) {
   ensureProvenanceGraphListener();
   container.innerHTML = '<div class="loading">Loading provenance graph…</div>';
 
   let data;
   try {
-    data = await fetchProvenanceGraph(userId);
+    data = await fetchProvenanceGraph(userId, opts);
   } catch (err) {
     container.innerHTML = renderApiError(err, {
       context: "Couldn't load provenance graph.",
-      retry: () => renderProvenanceGraph(container, userId),
+      retry: () => renderProvenanceGraph(container, userId, opts),
     });
-    wireApiRetry(container, () => renderProvenanceGraph(container, userId));
+    wireApiRetry(container, () => renderProvenanceGraph(container, userId, opts));
     return;
   }
 
@@ -155,8 +157,8 @@ export async function renderProvenanceGraph(container, userId) {
         </div>
         ${isTruncated ? `
           <div style="margin-top: 0.5rem; font-size: 0.8rem; color: var(--text-muted);">
-            Showing densest 200 nodes.
-            <button class="btn btn-outline btn-sm" style="font-size: 0.75rem; padding: 0.2rem 0.5rem;" data-action="pg-view-full-graph">Reload without limit</button>
+            Showing the 200 most recent nodes.
+            <button class="btn btn-outline btn-sm" style="font-size: 0.75rem; padding: 0.2rem 0.5rem;" data-action="pg-view-full-graph">Reload with higher limit</button>
           </div>
         ` : ''}
       </div>
@@ -421,7 +423,9 @@ function openFlyout(nodeId, sim) {
   if (!flyout || !title || !body || !node) return;
 
   flyout.style.display = 'block';
-  title.textContent = escapeHtml(node.label) || escapeHtml(node.type);
+  // textContent escapes automatically — running escapeHtml here would
+  // double-escape, e.g. an `&` would render as `&amp;` literally.
+  title.textContent = node.label || node.type;
 
   const occurredAt = node.occurredAt ? new Date(node.occurredAt).toLocaleString() : '';
 


### PR DESCRIPTION
**Stacked on #229 → #228 → #227 → #226.**

Five small frontend fixes from Copilot review.

## Changes
- \`provenance-graph.js\`: drop \`escapeHtml\` on a \`textContent\` assignment
  (would double-escape). Fix "Showing densest 200" → "Showing the 200 most
  recent". "Reload without limit" actually passes \`limit=1000\` now.
- \`capabilities.js\`: factor \`replaceActionsWithBadge\` so accept/reject
  produces a single badge instead of one per replaced button.
- \`tier-promotion-modal.js\`: \`high_autonomy\` and \`moderate_autonomy\`
  now have distinct copy branches.
- \`assistant.js\`: \`_promotionSseWired\` flag flips ONLY after listener
  is attached; bounded retry loop replaces single setTimeout.

## Test plan
- [x] Build clean
- [x] Lint clean
- (no web test suite yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)