### PR TITLE
fix(copilot-sweep batch 7): adaptive prompt input/output sweep (#207 follow-up)

### DIFF
--- a/apps/api/src/routes/about-me.ts
+++ b/apps/api/src/routes/about-me.ts
@@ -131,9 +131,11 @@ export function createAboutMeRouter(): Router {
             userFacts.recentActions.length > 0;
 
           if (hasFacts) {
+            // Template expects {{memory_facts}} (single key); previously
+            // passed `user_facts` so the placeholder rendered literally.
             const result = await runPrompt<SelfPortraitOutput>({
               promptName: 'self-portrait',
-              inputs: { user_facts: userFacts },
+              inputs: { memory_facts: userFacts },
               user: { userId },
               llmClient,
             });

--- a/apps/api/src/routes/capabilities.ts
+++ b/apps/api/src/routes/capabilities.ts
@@ -830,15 +830,42 @@ export function createCapabilitiesRouter(): Router {
             category: e.category,
           }));
 
-          const result = await runPrompt<CapabilityRecipe[]>({
+          // Template expects {{registry}}, {{detected_services}}, {{risk_profile}}.
+          // Output type is a list of {registryId, name, reason,
+          // estimatedValueScore, riskLevel} — NOT CapabilityRecipe; we
+          // transform below before returning.
+          interface RecipeRecOutput {
+            registryId: string;
+            name: string;
+            reason: string;
+            estimatedValueScore: number;
+            riskLevel: 'low' | 'medium' | 'high';
+          }
+          const result = await runPrompt<RecipeRecOutput[]>({
             promptName: 'recipe-recommendation',
-            inputs: { registrySummary },
+            inputs: {
+              registry: registrySummary,
+              detected_services: [],
+              risk_profile: '',
+            },
             user: { userId },
             llmClient,
           });
 
           if (!result.fellBackToDeterministic && Array.isArray(result.output) && result.output.length > 0) {
-            return res.json({ recipes: result.output });
+            // Synthesize a single recipe from the LLM's ordered registry list.
+            // CapabilityRecipe (local-defined above) is the API response shape;
+            // it doesn't have a slot for per-item rationale, so we fold the
+            // reasons into the description and order the registryIds by the
+            // LLM's priority.
+            const recipe: CapabilityRecipe = {
+              slug: 'llm-recommended',
+              displayName: 'Recommended for you',
+              description: result.output.map((r) => `${r.name}: ${r.reason}`).join('\n'),
+              registryIds: result.output.map((r) => r.registryId),
+              category: 'productivity',
+            };
+            return res.json({ recipes: [recipe] });
           }
         } catch (err) {
           log.warn('recipe-recommendation prompt failed, using hardcoded fallback', {
@@ -888,13 +915,19 @@ export function createCapabilitiesRouter(): Router {
       const llmClient = getLlmClientFromConfig();
       if (llmClient) {
         try {
+          // Template expects {{user_message}}, {{installed_capabilities}},
+          // {{risk_profile}}.
           const result = await runPrompt<{
             action: string;
             candidate_capabilities: string[];
             confidence: number;
           }>({
             promptName: 'reverse-capability-intent',
-            inputs: { userMessage: body.userMessage, installedRegistryIds },
+            inputs: {
+              user_message: body.userMessage,
+              installed_capabilities: installedRegistryIds,
+              risk_profile: '',
+            },
             user: { userId },
             llmClient,
           });

--- a/apps/api/src/routes/onboarding.ts
+++ b/apps/api/src/routes/onboarding.ts
@@ -195,7 +195,9 @@ export function createOnboardingRouter(): Router {
 
       const body = req.body as DialogueBody | undefined;
       const history: DialogueTurn[] = Array.isArray(body?.history) ? body.history : [];
-      const context = body?.context;
+      // body?.context is no longer threaded into the prompt — the
+      // onboarding-dialogue template doesn't read it. Kept on the request
+      // shape for future extension but intentionally unused.
 
       const llmClient = getLlmClientFromConfig();
 
@@ -206,15 +208,16 @@ export function createOnboardingRouter(): Router {
             .map((t) => `${t.role === 'user' ? 'User' : 'Assistant'}: ${t.content}`)
             .join('\n');
 
+          // Template inputs: {{previous_turns}}, {{goal}}, {{language}},
+          // {{risk_profile}}. Drop the redundant `history` alias and the
+          // `current_capabilities` key the template doesn't use.
           const result = await runPrompt<{ type: string; text?: string; recipeSlug?: string; recommendedRegistryIds?: string[]; summary?: string }>({
             promptName: 'onboarding-dialogue',
             inputs: {
-              history: previousTurns,
               previous_turns: previousTurns,
               goal: history.length < 3 ? 'gather_context' : 'finalize',
               language: 'en',
               risk_profile: '',
-              current_capabilities: JSON.stringify(context?.current_capabilities ?? []),
             },
             user: { userId },
             llmClient,

--- a/apps/api/src/routes/risk-profile.ts
+++ b/apps/api/src/routes/risk-profile.ts
@@ -46,9 +46,10 @@ async function interpretProfileText(
   if (!llmClient || !profileText.trim()) return {};
 
   try {
+    // Template expects {{risk_profile_text}}, not {{profileText}}.
     const result = await runPrompt<RiskProfileInterpretationOutput>({
       promptName: 'risk-profile-interpretation',
-      inputs: { profileText },
+      inputs: { risk_profile_text: profileText },
       user: { userId },
       llmClient,
     });

--- a/apps/worker/src/jobs/briefing-generator.ts
+++ b/apps/worker/src/jobs/briefing-generator.ts
@@ -213,8 +213,13 @@ async function generateBriefingProse(
   // ── Adaptive path (H: briefing-prose) ─────────────────────────────────
   if (llmClient) {
     try {
-      const briefingData = {
-        cadence,
+      // Map our internal cadence/structured data to the snake_case keys the
+      // template expects ({{date}}, {{events}}, {{language}}, {{pending_tasks}},
+      // {{risk_profile}}). Previously this passed an object whose keys
+      // shared no name with the template — every placeholder rendered
+      // literally, the LLM returned garbage, schema validation failed,
+      // and the deterministic fallback ran every time.
+      const events = {
         activeCapabilities: data.active.slice(0, 20).map((s) => ({
           name: s.display_name,
           trustTier: s.trust_tier,
@@ -235,23 +240,31 @@ async function generateBriefingProse(
           name: s.display_name,
           status: s.status,
         })),
-        suggestions: data.suggestions.slice(0, 5).map((s) => ({
-          name: s.display_name,
-          reason: s.reason_summary ?? '',
-        })),
+        cadence,
         sourceEventCount,
       };
+      const pendingTasks = data.suggestions.slice(0, 5).map((s) => ({
+        name: s.display_name,
+        reason: s.reason_summary ?? '',
+      }));
 
-      const result = await runPrompt<{ prose: string }>({
+      // Output type matches the prompt's documented schema: { briefing: string }.
+      const result = await runPrompt<{ briefing: string; highlight_count?: number }>({
         promptName: 'briefing-prose',
-        inputs: briefingData,
+        inputs: {
+          date: new Date().toISOString().slice(0, 10),
+          events,
+          language: 'en',
+          pending_tasks: pendingTasks,
+          risk_profile: '',
+        },
         user: { userId },
         llmClient,
       });
 
-      if (!result.fellBackToDeterministic && typeof result.output?.prose === 'string' && result.output.prose.trim()) {
+      if (!result.fellBackToDeterministic && typeof result.output?.briefing === 'string' && result.output.briefing.trim()) {
         return {
-          prose: result.output.prose,
+          prose: result.output.briefing,
           sourceEventCount,
           llmProvider: result.modelUsed,
         };

--- a/apps/worker/src/jobs/dormancy-check.ts
+++ b/apps/worker/src/jobs/dormancy-check.ts
@@ -187,13 +187,17 @@ export async function runDormancyCheckJob(deps: DormancyCheckJobDeps = {}): Prom
             getRiskProfileText(server.user_id),
           ]);
 
+          // Map to snake_case keys per the dormancy-judgment template:
+          // {{server_name}}, {{server_id}}, {{activity_history}},
+          // {{user_activity}}, {{risk_profile}}.
           const judgment = await runPrompt<DormancyJudgmentOutput>({
             promptName: 'dormancy-judgment',
             inputs: {
-              serverName: server.display_name,
-              lastActiveDaysAgo: lastActiveDays,
-              activityHistory,
-              riskProfile,
+              server_name: server.display_name,
+              server_id: server.id,
+              activity_history: activityHistory,
+              user_activity: '',
+              risk_profile: riskProfile,
             },
             user: { userId: server.user_id },
             llmClient,

--- a/packages/capability-engine/src/inference-engine.ts
+++ b/packages/capability-engine/src/inference-engine.ts
@@ -110,9 +110,31 @@ export class CapabilityInferenceEngine {
   }
 
   async run(userId: string, signals: SignalLike[]): Promise<AppSuggestionInput[]> {
+    // Cache the registry entries for the duration of this call. Both the
+    // adaptive path (verifyAgainstRegistry → aggregateAndScore) and the
+    // deterministic path (runDeterministic) used to fetch entries
+    // separately, doubling the registry I/O on every run.
+    this._cachedRegistryEntries = await this.getRegistryEntriesCached();
+    try {
+      return await this._runInner(userId, signals);
+    } finally {
+      this._cachedRegistryEntries = null;
+    }
+  }
+
+  private _cachedRegistryEntries: RegistryEntry[] | null = null;
+  private async getRegistryEntriesCached(): Promise<RegistryEntry[]> {
+    return this._cachedRegistryEntries ?? this.options.registry.getAll();
+  }
+
+  private async _runInner(userId: string, signals: SignalLike[]): Promise<AppSuggestionInput[]> {
     // ── Adaptive path (B: service-detection) ──────────────────────────────
     if (this.llmClient) {
       try {
+        // service-detection template expects {{signals}} and {{risk_profile}}.
+        // Pass risk_profile as empty string when no profile is available;
+        // omitting it leaves the template literal `{{risk_profile}}` in the
+        // rendered prompt (the runner only substitutes keys it finds).
         const detected = await runPrompt<ServiceDetectionOutput[]>({
           promptName: 'service-detection',
           inputs: {
@@ -121,6 +143,7 @@ export class CapabilityInferenceEngine {
               excerpt: s.excerpt,
               occurredAt: s.occurredAt,
             })),
+            risk_profile: '',
           },
           user: { userId },
           llmClient: this.llmClient,
@@ -144,7 +167,7 @@ export class CapabilityInferenceEngine {
    * Run the deterministic v1 keyword-match pipeline.
    */
   async runDeterministic(userId: string, signals: SignalLike[]): Promise<AppSuggestionInput[]> {
-    const entries = await this.options.registry.getAll();
+    const entries = await this.getRegistryEntriesCached();
 
     const allMentions: SignalMention[] = [];
     for (const signal of signals) {
@@ -179,7 +202,7 @@ export class CapabilityInferenceEngine {
   private async verifyAgainstRegistry(
     detected: ServiceDetectionOutput[],
   ): Promise<SignalMention[]> {
-    const entries = await this.options.registry.getAll();
+    const entries = await this.getRegistryEntriesCached();
     const byId = new Map(entries.map((e) => [e.id.toLowerCase(), e]));
     const byName = new Map(entries.map((e) => [e.displayName.toLowerCase(), e]));
 
@@ -225,7 +248,7 @@ export class CapabilityInferenceEngine {
     mentions: SignalMention[],
     _signals: SignalLike[],
   ): Promise<AppSuggestionInput[]> {
-    const entries = await this.options.registry.getAll();
+    const entries = await this.getRegistryEntriesCached();
     const displayNames = new Map(entries.map((e) => [e.id, e.displayName]));
     const aggregated = aggregateMentions(userId, mentions, displayNames);
     const suggestions = [...aggregated.values()];
@@ -242,9 +265,18 @@ export class CapabilityInferenceEngine {
 
     if (this.llmClient) {
       try {
+        // capability-ranking template expects {{capabilities}},
+        // {{user_profile_summary}}, {{language}}, {{risk_profile}}.
+        // Previously this passed { suggestions } so every placeholder
+        // rendered literally and the LLM had nothing to score.
         const ranked = await runPrompt<CapabilityRankingOutput[]>({
           promptName: 'capability-ranking',
-          inputs: { suggestions },
+          inputs: {
+            capabilities: suggestions,
+            user_profile_summary: '',
+            language: 'en',
+            risk_profile: '',
+          },
           user: { userId },
           llmClient: this.llmClient,
         });

--- a/packages/policy-engine/src/trust-tier-engine.ts
+++ b/packages/policy-engine/src/trust-tier-engine.ts
@@ -146,13 +146,31 @@ async function judgePromotion(opts: {
     return deterministicPromotion(opts.currentTier, opts.approvalStats);
   }
 
+  // Map our internal camelCase fields to the snake_case keys the prompt
+  // template expects ({{current_tier}}, {{target_tier}}, {{risk_profile}},
+  // {{feedback_history}}, {{decision_summary}}). Without this mapping the
+  // template renders literal `{{current_tier}}` placeholders, the LLM
+  // returns garbage, schema validation fails, and we silently fall back
+  // to deterministic — meaning the adaptive judgment never actually ran.
+  const next = nextTier(opts.currentTier);
+  const stats = opts.approvalStats;
+  const totalDecisions = stats.totalApprovals + stats.totalRejections;
+  const decisionSummary =
+    `${totalDecisions} total decisions, ${stats.approvalRatio.toFixed(2)} approval ratio, ` +
+    `${stats.consecutiveApprovals} consecutive approvals`;
+  const feedbackHistory =
+    `recent rejections: ${stats.recentRejections}; ` +
+    `total undos: ${stats.totalUndos}; ` +
+    `critical undo present: ${stats.hasCriticalUndo}`;
   try {
     const result = await runPrompt<TierPromotionLlmOutput>({
       promptName: 'tier-promotion-judgment',
       inputs: {
-        currentTier: opts.currentTier,
-        approvalStats: opts.approvalStats,
-        riskProfile: opts.riskProfileText ?? '',
+        current_tier: opts.currentTier,
+        target_tier: next ?? opts.currentTier,
+        risk_profile: opts.riskProfileText ?? '',
+        feedback_history: feedbackHistory,
+        decision_summary: decisionSummary,
       },
       user: { userId: opts.userId },
       llmClient: opts.llmClient,
@@ -163,7 +181,6 @@ async function judgePromotion(opts: {
     }
 
     const output = result.output;
-    const next = nextTier(opts.currentTier);
 
     return {
       shouldPromote: output.recommend_promote,

--- a/packages/registry-client/src/oauth-recovery.ts
+++ b/packages/registry-client/src/oauth-recovery.ts
@@ -52,12 +52,13 @@ export async function recoverOAuthFlow(opts: {
   if (!opts.llmClient) return null;
 
   try {
+    // Map to the snake_case keys the prompt template expects.
+    // Template: {{failure_trace}} {{server_auth_metadata}}
     const result = await runPrompt<OAuthRecoveryLlmOutput>({
       promptName: 'oauth-recovery',
       inputs: {
-        registryId: opts.registryId,
-        failureTrace: opts.failureTrace,
-        authMetadata: opts.authMetadata ?? null,
+        failure_trace: opts.failureTrace,
+        server_auth_metadata: opts.authMetadata ?? null,
       },
       user: { userId: 'system' },
       llmClient: opts.llmClient,


### PR DESCRIPTION
**Top of the stack: #231 → #230 → #229 → #228 → #227 → #226.**

The big one. The "adaptive judgment layer" introduced in #207 was
silently always falling back to deterministic logic because every
\`runPrompt\` caller passed camelCase input keys but the prompt templates
use snake_case placeholders. Unmatched placeholders rendered literally,
the LLM output failed schema validation, and the deterministic fallback
ran every time.

## Files fixed (caller → template input rename)
- \`packages/policy-engine/src/trust-tier-engine.ts\` → tier-promotion-judgment
- \`packages/registry-client/src/oauth-recovery.ts\` → oauth-recovery
- \`packages/capability-engine/src/inference-engine.ts\` → service-detection
  + capability-ranking
- \`apps/api/src/routes/risk-profile.ts\` → risk-profile-interpretation
- \`apps/api/src/routes/about-me.ts\` → self-portrait
- \`apps/api/src/routes/onboarding.ts\` → onboarding-dialogue
- \`apps/api/src/routes/capabilities.ts\` → recipe-recommendation +
  reverse-capability-intent (output type for recipe-recommendation
  also corrected to match the prompt's documented schema)
- \`apps/worker/src/jobs/briefing-generator.ts\` → briefing-prose
  (output type was \`{prose}\`; prompt returns \`{briefing}\`)
- \`apps/worker/src/jobs/dormancy-check.ts\` → dormancy-judgment

## Performance
- \`CapabilityInferenceEngine\` now caches \`registry.getAll()\` across one
  \`run()\` lifecycle (was called 2-3× per run from independent paths).

## Test plan
- [x] Full suite passes (1453 tests across 14 packages)
- [ ] Runtime verification that adaptive paths now actually engage
  cannot be done from this workspace; will need a manual smoke-test
  with a real LLM provider configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)