### PR TITLE
fix(copilot-sweep batch 4 RECOVERY): always-on daemon scripts (#229 was content-lost in cascade rebase)

### DIFF
--- a/apps/desktop/scripts/install-launchd.plist
+++ b/apps/desktop/scripts/install-launchd.plist
@@ -19,9 +19,14 @@
     a path here without consulting #188.
 
   Log paths:
-    ~/.skytwin/logs/ must exist before launchd starts the daemon.
-    The SkyTwin installer (#188) creates this directory. If you are
-    running this plist manually, create the directory first:
+    /Users/Shared/.skytwin/logs/ (see StandardOutPath / StandardErrorPath
+    below) must exist before launchd starts the daemon. launchd plists
+    cannot expand `~` — the SkyTwin installer (#188) substitutes the
+    real per-user home directory at install time. If you are running
+    this plist manually, EITHER create the shared directory:
+      sudo mkdir -p /Users/Shared/.skytwin/logs && sudo chmod 1777 /Users/Shared/.skytwin/logs
+    OR edit the plist to point at your home dir:
+      sed -i '' "s|/Users/Shared/|$HOME/|g" install-launchd.plist
       mkdir -p ~/.skytwin/logs
 -->
 <plist version="1.0">

--- a/apps/desktop/scripts/install-systemd.service
+++ b/apps/desktop/scripts/install-systemd.service
@@ -33,6 +33,11 @@ Documentation=https://github.com/jayzalowitz/skytwin
 # and worker can reach their upstream dependencies (DB, OAuth endpoints).
 After=network-online.target
 Wants=network-online.target
+# Keep the service running for at most 10 restarts in 30 seconds before
+# systemd marks it as failed. Must live under [Unit] — when placed under
+# [Service], systemd silently ignores them.
+StartLimitIntervalSec=30
+StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -51,15 +56,13 @@ StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=skytwin-headless
 
-# Restart policy: always restart on non-zero exit.
-Restart=always
+# Restart policy: restart on non-zero exit, signal, watchdog timeout, etc.
+# `on-failure` matches the comment's intent ("on non-zero exit"); `always`
+# would also restart on a clean exit(0) which the daemon should treat as
+# "operator stopped me on purpose".
+Restart=on-failure
 # Wait 5 seconds between restart attempts to avoid a tight crash loop.
 RestartSec=5s
-
-# Keep the service running for at most 10 restarts in 30 seconds
-# before systemd gives up and marks it as failed.
-StartLimitIntervalSec=30
-StartLimitBurst=10
 
 # Security hardening — run as the installing user, not root.
 # systemd user services already run as the installing user, but these
@@ -69,3 +72,7 @@ PrivateTmp=true
 
 [Install]
 WantedBy=default.target
+
+# StartLimitIntervalSec / StartLimitBurst belong in [Unit], not [Service].
+# Putting them under [Service] is a common gotcha — systemd silently
+# ignores them there. Re-declared in [Unit] below.

--- a/apps/desktop/src/headless.ts
+++ b/apps/desktop/src/headless.ts
@@ -6,8 +6,9 @@
  *   pnpm --filter @skytwin/desktop headless   (via package.json script)
  *
  * This file intentionally has NO Electron imports. It starts the API and
- * worker sub-processes through the same ServiceManager used by the Electron
- * main process, exposes /health on the configured port, and handles SIGTERM
+ * worker as forked Node child processes (see spawnChild → child_process.fork
+ * — there is no separate ServiceManager class here despite the name appearing
+ * elsewhere), exposes /health on the configured port, and handles SIGTERM
  * for graceful shutdown.
  *
  * The actual Electron window / tray paths in main.ts are NOT touched.
@@ -24,8 +25,24 @@ import { join } from 'path';
 // can set process.env values before calling startHeadless)
 // ---------------------------------------------------------------------------
 
+/** Default port for the headless health endpoint. Exported so callers can
+ *  fall back to the same value when SKYTWIN_API_PORT is unset or garbage. */
+export const DEFAULT_HEADLESS_PORT = 4000;
+
 function resolvePort(): number {
-  return parseInt(process.env['SKYTWIN_API_PORT'] ?? '4000', 10);
+  // parseInt('garbage', 10) === NaN, and server.listen(NaN) throws at runtime.
+  // Validate the result; fall back to the default for any non-finite or
+  // out-of-range value. 0 is allowed (OS-assigned ephemeral port).
+  const raw = process.env['SKYTWIN_API_PORT'];
+  if (raw === undefined || raw === '') return DEFAULT_HEADLESS_PORT;
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 65535) {
+    process.stderr.write(
+      `[headless] SKYTWIN_API_PORT="${raw}" is not a valid port; falling back to ${DEFAULT_HEADLESS_PORT}\n`,
+    );
+    return DEFAULT_HEADLESS_PORT;
+  }
+  return parsed;
 }
 
 function resolveWorkerEntry(): string {
@@ -43,8 +60,12 @@ function resolveApiEntry(): string {
 export interface HeadlessServer {
   /** The raw http.Server so tests can inject and inspect it. */
   server: http.Server;
-  /** The port the health server is listening on (useful when port 0 was given). */
-  port: number;
+  /**
+   * The port the health server is bound to. Read via getter so callers see
+   * the OS-assigned port after a port:0 listen, not the requested 0.
+   * Returns the requested port value before the server has bound.
+   */
+  readonly port: number;
   /** Perform a graceful shutdown: stop child processes then close the HTTP server. */
   shutdown: () => Promise<void>;
 }
@@ -78,6 +99,8 @@ function spawnChild(entryPath: string, label: string): ChildProcess {
 
 function stopChild(child: ChildProcess | null, label: string): Promise<void> {
   if (!child) return Promise.resolve();
+  // Already exited — don't wait 5s for an event that won't fire.
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
   return new Promise<void>((resolve) => {
     const timer = setTimeout(() => {
       try { child.kill('SIGKILL'); } catch { /* already dead */ }
@@ -89,6 +112,7 @@ function stopChild(child: ChildProcess | null, label: string): Promise<void> {
     });
     try { child.kill('SIGTERM'); } catch {
       process.stderr.write(`[headless] could not send SIGTERM to ${label}\n`);
+      clearTimeout(timer);
       resolve();
     }
   });
@@ -116,8 +140,14 @@ function createHealthServer(port: number): http.Server {
   });
 
   server.listen(port, () => {
-    process.stdout.write(`[headless] SkyTwin headless daemon listening on port ${port}\n`);
-    process.stdout.write(`[headless] Health: http://localhost:${port}/health\n`);
+    // Read the bound port from address() — the requested `port` is wrong
+    // when port:0 (OS-assigned ephemeral). The previous log claimed
+    // "listening on port 0" while the real port was something else, which
+    // also broke any caller that grepped the log to discover the URL.
+    const addr = server.address();
+    const actualPort = typeof addr === 'object' && addr !== null ? addr.port : port;
+    process.stdout.write(`[headless] SkyTwin headless daemon listening on port ${actualPort}\n`);
+    process.stdout.write(`[headless] Health: http://localhost:${actualPort}/health\n`);
   });
 
   return server;
@@ -178,7 +208,15 @@ export function startHeadless(options?: { noSpawn?: boolean; port?: number }): H
     process.stdout.write('[headless] Shutdown complete\n');
   }
 
-  return { server, port, shutdown };
+  return {
+    server,
+    get port() {
+      // Defer to the bound address — supports port:0 / OS-assigned ports.
+      const addr = server.address();
+      return typeof addr === 'object' && addr !== null ? addr.port : port;
+    },
+    shutdown,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   test: {
@@ -7,8 +8,11 @@ export default defineConfig({
     // crash on nativeImage.createFromDataURL (which only exists inside a
     // real Electron process). headless.ts has no Electron imports and does
     // not need this alias.
+    //
+    // Use fileURLToPath rather than `new URL(...).pathname` — the latter
+    // produces paths like `/C:/Users/...` on Windows, which fail to resolve.
     alias: {
-      electron: new URL('./src/__mocks__/electron.ts', import.meta.url).pathname,
+      electron: fileURLToPath(new URL('./src/__mocks__/electron.ts', import.meta.url)),
     },
   },
 });


### PR DESCRIPTION
**This re-applies PR #229's content, which was lost during a stacked-PR cascade rebase.**

PR #229 was force-pushed to a base-equivalent commit during the cascade-merge sequence (`git rebase --onto origin/main <old-tip>` produced an empty diff because the old-tip equalled the new branch tip after the previous PR's rebase). GitHub squash-merged the empty diff and reported the PR as merged, but the actual daemon-scripts content never reached \`main\`.

This PR cherry-picks the original commit (\`f598fb2\`) onto current main.

## Original changes (verbatim from #229)

- \`resolvePort\`: validate parseInt; falls back to default 4000 with stderr warning on garbage / out-of-range. Previously \`server.listen(NaN)\` would throw.
- \`HeadlessServer.port\` getter reads bound address — fixes port:0 reporting.
- \`stopChild\` short-circuits when child already exited; clears timer on SIGTERM-throw branch.
- vitest.config.ts uses \`fileURLToPath\` (Windows-safe) instead of \`new URL(...).pathname\`.
- systemd .service: \`StartLimit*\` moved to \`[Unit]\`; \`Restart=always\` → \`on-failure\` to match comment.
- launchd .plist: comment aligned with actual log path; document the \`~\` non-expansion gotcha.
- Header comment updated — no ServiceManager class, headless.ts forks directly via child_process.fork.

## Test plan
- [x] 150 desktop tests pass
- [x] Build clean

## Postmortem note for the merge gate

The cascade-rebase tooling I used (`git rebase --onto origin/main <prev-old-tip> <branch>`) silently produces an empty diff when `<prev-old-tip>` equals the current branch tip — which happens when the previous cascade run already moved the branch. Future cascade scripts should diff before pushing to detect zero-content force-pushes, or just cherry-pick the original commit onto current main rather than rebasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)