### PR TITLE
feat(#191 + #180): auto-launch toggle UI + DXT drag-drop entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Auto-launch toggle UI + DXT drag-drop entry point (#191 + #180)
+
+Closes the auto-launch UX for #191 and the DXT drag-drop entry point for
+#180. The IPC handlers `get-launch-at-login` / `set-launch-at-login`
+landed in #218 with no UI; this PR puts a real toggle in Settings → Desktop
+and wires the `app.setLoginItemSettings` round-trip end-to-end.
+
+For #180, the existing DXT import flow (#219 export, #224 install confirm)
+had no entry point — users could only POST a `.dxt` file via curl. This
+PR adds two real entry points: body-wide drag-drop in the renderer and an
+OS file-association handler in the main process.
+
+### Ships
+
+- `apps/web/public/js/pages/settings.js` — new "Desktop" card visible
+  only when `window.skytwinDesktop?.isDesktop`. Toggle switch wired to
+  `setLaunchAtLogin(boolean)`; hydrates from `getLaunchAtLogin()` on
+  render. Toast on save success / failure; on failure the toggle reverts
+  to its previous state.
+- `apps/desktop/src/main.ts` — `read-dxt-file` IPC handler (`.dxt` or
+  `.json` path → `{ name, base64 }`); `app.on('open-file', ...)` handler
+  that buffers the path and forwards it to the renderer once the
+  webContents finish loading. Pending-path drain on `did-finish-load`
+  covers the case where the user double-clicks a `.dxt` before the window
+  is ready.
+- `apps/desktop/src/preload.ts` — exposes `readDxtFile(filePath)` and
+  `onDxtFileOpened(listener)` (returns unsubscribe fn).
+- `apps/web/public/js/app.js` — `wireDxtDropAndOpen()` runs once on
+  `DOMContentLoaded`. Document-level `dragover`/`drop` handlers filter
+  for `.dxt`/`.json` files (via `DataTransfer.types.includes('Files')`
+  + filename check), read via `FileReader.readAsDataURL`, POST to
+  `/api/dxt/import` with the base64 blob, and navigate to `#/dxt/imports`
+  on success. Subscribes to `skytwinDesktop.onDxtFileOpened` for the
+  Finder/Explorer double-click path — same import flow, file is read via
+  the IPC handler instead of FileReader. Toast feedback on every code
+  path. Multi-file drops produce a "drop one at a time" toast rather than
+  silently picking the first.
+
+### Why drag-drop runs in the renderer, not the main process
+
+Browser file drops carry the `File` object directly — we already have the
+bytes without touching disk. The OS-passed path from `app.on('open-file')`
+is the only case where the renderer doesn't have bytes; that's why the
+`readDxtFile` IPC exists as a narrow allowlist (`.dxt`/`.json` only,
+explicit filePath argument). Keeping the body-wide drag-drop in the
+renderer also means it works in the pure-web build of the dashboard where
+no `skytwinDesktop` exists.
+
+### Out of scope
+
+- File-association registration in `electron-builder` config (the OS won't
+  fire `open-file` for `.dxt` until macOS Info.plist `CFBundleDocumentTypes`
+  / Windows registry associations are declared at install time — that's a
+  packaging concern, not a runtime one).
+
 ## [unreleased] — Desktop idle bridge via Electron powerMonitor (#180 partial)
 
 Closes one of the four "desktop integration" sub-asks of #180: a real

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, ipcMain, powerMonitor, shell, type Tray } from 'electron';
+import { promises as fs } from 'fs';
 import { join } from 'path';
 import { ServiceManager } from './service-manager.js';
 import { createTray } from './tray.js';
@@ -121,6 +122,10 @@ async function startApp(): Promise<void> {
   splashWindow?.close();
   splashWindow = null;
 
+  // If a .dxt file was double-clicked before the window finished loading,
+  // the open-file event fired into pendingDxtPath. Drain it now.
+  mainWindow.webContents.once('did-finish-load', forwardPendingDxtPathIfReady);
+
   // Wire auto-update only for packaged (production) builds.
   // Skipped in dev mode to avoid noisy update checks against GitHub Releases
   // during local development where the version may lag the published channel.
@@ -183,6 +188,32 @@ ipcMain.handle('resume-twin', async () => {
   await serviceManager.resume();
   return serviceManager.getStatus();
 });
+
+ipcMain.handle('read-dxt-file', async (_event, filePath: string) => {
+  if (typeof filePath !== 'string' || filePath === '') {
+    throw new Error('filePath required');
+  }
+  const lower = filePath.toLowerCase();
+  if (!lower.endsWith('.dxt') && !lower.endsWith('.json')) {
+    throw new Error('only .dxt or .json files are accepted');
+  }
+  const data = await fs.readFile(filePath);
+  return { name: filePath.split(/[\\/]/).pop() ?? 'artifact.dxt', base64: data.toString('base64') };
+});
+
+app.on('open-file', (event, filePath) => {
+  event.preventDefault();
+  pendingDxtPath = filePath;
+  forwardPendingDxtPathIfReady();
+});
+
+let pendingDxtPath: string | null = null;
+function forwardPendingDxtPathIfReady(): void {
+  if (pendingDxtPath === null) return;
+  if (mainWindow === null || mainWindow.isDestroyed() || mainWindow.webContents.isLoading()) return;
+  mainWindow.webContents.send('dxt-file-opened', { path: pendingDxtPath });
+  pendingDxtPath = null;
+}
 
 // App lifecycle
 app.whenReady().then(startApp);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -47,4 +47,30 @@ contextBridge.exposeInMainWorld('skytwinDesktop', {
     ipcRenderer.on('idle-state-changed', wrapped);
     return () => ipcRenderer.off('idle-state-changed', wrapped);
   },
+
+  /**
+   * Read a DXT file from disk by path. Used by the renderer when the OS
+   * passed us a path via the `open-file` event (double-click on a .dxt file)
+   * or via drag-drop where the renderer extracted only the path. Returns
+   * `{ name, base64 }`.
+   */
+  readDxtFile: (filePath: string) =>
+    ipcRenderer.invoke('read-dxt-file', filePath) as Promise<{ name: string; base64: string }>,
+
+  /**
+   * Subscribe to OS-level "open this DXT file" events. Returns an
+   * unsubscribe function. Fires when the user double-clicks a .dxt file
+   * in Finder/Explorer (file association required) or otherwise hands one
+   * to the OS to open with SkyTwin.
+   */
+  onDxtFileOpened: (
+    listener: (payload: { path: string }) => void,
+  ): (() => void) => {
+    const wrapped = (
+      _e: Electron.IpcRendererEvent,
+      payload: { path: string },
+    ) => listener(payload);
+    ipcRenderer.on('dxt-file-opened', wrapped);
+    return () => ipcRenderer.off('dxt-file-opened', wrapped);
+  },
 });

--- a/apps/web/public/js/app.js
+++ b/apps/web/public/js/app.js
@@ -411,10 +411,115 @@ document.querySelectorAll('.nav-link').forEach(link => {
 });
 
 window.addEventListener('hashchange', navigate);
+
+/**
+ * Body-wide drag-drop entry point for .dxt artifacts.
+ *
+ * Drops anywhere on the page route through the existing /api/dxt/import
+ * preview flow, then navigate to the imports page so the user lands on
+ * the confirm/reject UI shipped in #224. Skips any drop that doesn't
+ * carry exactly one .dxt or .json file so we never interfere with text /
+ * image / link drags.
+ *
+ * Also subscribes to the desktop `onDxtFileOpened` event so double-clicking
+ * a .dxt file in Finder/Explorer (with file association registered) lands
+ * in the same flow.
+ */
+function wireDxtDropAndOpen() {
+  if (window._dxtDropWired) return;
+  window._dxtDropWired = true;
+
+  const isDxtFile = (f) => {
+    const name = (f?.name ?? '').toLowerCase();
+    return name.endsWith('.dxt') || name.endsWith('.json');
+  };
+
+  const importBlob = async (base64) => {
+    const userId = localStorage.getItem(KEY_USER_ID) ?? '';
+    if (!userId) {
+      showToast('Sign in first, then drop the file again', 'error');
+      return;
+    }
+    try {
+      const res = await fetch(`/api/dxt/import?userId=${encodeURIComponent(userId)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ blob: base64 }),
+      });
+      if (!res.ok) {
+        const txt = await res.text().catch(() => '');
+        throw new Error(`HTTP ${res.status}: ${txt.slice(0, 200)}`);
+      }
+      const data = await res.json();
+      showToast(`Capability ready to review: ${data.preview?.capability?.name ?? 'unknown'}`);
+      window.location.hash = '#/dxt/imports';
+    } catch (err) {
+      showToast(`DXT import failed: ${err?.message ?? 'unknown error'}`, 'error');
+    }
+  };
+
+  const fileToBase64 = (file) => new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== 'string') {
+        reject(new Error('FileReader returned non-string'));
+        return;
+      }
+      const comma = result.indexOf(',');
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('read failed'));
+    reader.readAsDataURL(file);
+  });
+
+  document.addEventListener('dragover', (e) => {
+    if (!e.dataTransfer) return;
+    const types = Array.from(e.dataTransfer.types ?? []);
+    if (!types.includes('Files')) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  });
+
+  document.addEventListener('drop', async (e) => {
+    if (!e.dataTransfer) return;
+    const files = Array.from(e.dataTransfer.files ?? []);
+    if (files.length === 0) return;
+    const dxtFiles = files.filter(isDxtFile);
+    if (dxtFiles.length === 0) return;
+    e.preventDefault();
+    if (dxtFiles.length > 1) {
+      showToast('Drop one .dxt file at a time', 'error');
+      return;
+    }
+    try {
+      const base64 = await fileToBase64(dxtFiles[0]);
+      await importBlob(base64);
+    } catch (err) {
+      showToast(`Couldn't read file: ${err?.message ?? 'unknown error'}`, 'error');
+    }
+  });
+
+  // Desktop file-association entry point. The main process forwards
+  // OS open-file events here; we read the file via IPC and route it
+  // through the same import flow.
+  if (window.skytwinDesktop?.onDxtFileOpened && window.skytwinDesktop.readDxtFile) {
+    window.skytwinDesktop.onDxtFileOpened(async ({ path }) => {
+      try {
+        const { base64 } = await window.skytwinDesktop.readDxtFile(path);
+        await importBlob(base64);
+      } catch (err) {
+        showToast(`Couldn't open ${path}: ${err?.message ?? 'unknown error'}`, 'error');
+      }
+    });
+  }
+}
+
 window.addEventListener('DOMContentLoaded', () => {
   // Wire dashboard event handlers + document-level delegators.
   // Idempotent so re-running this in tests is safe.
   initDashboardGlobals();
+  wireDxtDropAndOpen();
 
   // Mount the always-visible Pause-everything safety button (#190).
   // Floats top-right across all routes so the panic affordance is always

--- a/apps/web/public/js/pages/settings.js
+++ b/apps/web/public/js/pages/settings.js
@@ -148,6 +148,27 @@ export async function renderSettings(container, userId) {
       <a href="#/capabilities" class="btn">Open Capabilities →</a>
     </div>
 
+    ${window.skytwinDesktop?.isDesktop ? `
+    <div class="card" id="desktop-settings-card">
+      <div class="card-header">
+        <span class="card-title">Desktop</span>
+      </div>
+      <div class="card-subtitle" style="margin-bottom: 1rem;">
+        Settings that only apply when you're running the SkyTwin desktop app.
+      </div>
+      <div style="display: flex; align-items: center; justify-content: space-between; padding: 0.75rem; background: var(--bg); border-radius: var(--radius-sm);">
+        <div>
+          <div style="font-weight: 500;">Start at login</div>
+          <div style="font-size: 0.85rem; color: var(--text-muted);">Launch SkyTwin automatically when you sign in to your computer.</div>
+        </div>
+        <label class="toggle-switch">
+          <input type="checkbox" id="launch-at-login-toggle" data-action="toggle-launch-at-login">
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+    </div>
+    ` : ''}
+
     <details class="card collapsible-card" id="ai-brain-card">
       <summary class="card-header collapsible-header">
         <span class="card-title">${aiProviders.length > 0 ? 'AI brain — connected providers' : 'AI brain — needed for Chat (optional otherwise)'}</span>
@@ -385,6 +406,16 @@ export async function renderSettings(container, userId) {
   // selection (no stale state across save-induced re-renders).
   const themeTarget = document.getElementById('theme-switcher-target');
   if (themeTarget) mountThemeSwitcher(themeTarget);
+
+  // Hydrate the launch-at-login toggle from the desktop API. Skipped in
+  // pure-web mode (no skytwinDesktop). The fetch is best-effort — if it
+  // fails the toggle stays unchecked rather than blocking page render.
+  const launchToggle = document.getElementById('launch-at-login-toggle');
+  if (launchToggle instanceof HTMLInputElement && window.skytwinDesktop?.getLaunchAtLogin) {
+    window.skytwinDesktop.getLaunchAtLogin()
+      .then((enabled) => { launchToggle.checked = !!enabled; })
+      .catch(() => { /* leave unchecked */ });
+  }
 }
 
 // Singleton click delegator. Settings re-renders after every successful
@@ -574,6 +605,18 @@ function ensureSettingsListener() {
       case 'sign-out':
         window.signOut();
         return;
+      case 'toggle-launch-at-login': {
+        const checkbox = el;
+        if (!(checkbox instanceof HTMLInputElement)) return;
+        const enabled = checkbox.checked;
+        window.skytwinDesktop?.setLaunchAtLogin?.(enabled)
+          .then(() => showSavedToast(enabled ? 'Will start at login' : 'Won\'t start at login'))
+          .catch((err) => {
+            checkbox.checked = !enabled;
+            showErrorToast(`Couldn\'t save: ${err?.message || 'unknown error'}`);
+          });
+        return;
+      }
       case 'ai-test-provider': {
         const idx = parseInt(el.getAttribute('data-idx') || '', 10);
         if (Number.isFinite(idx)) window.aiTestProvider(idx, uid);


### PR DESCRIPTION
## Summary

Closes two distinct user-facing entry points that were previously missing.

**#191 (auto-launch toggle UI)** — Settings → Desktop card with a real toggle wired to `skytwinDesktop.setLaunchAtLogin` / `getLaunchAtLogin`. The IPC handlers landed in #218; this puts the user-facing piece on the page. Toast on save; toggle reverts on error.

**#180 (DXT drag-drop entry point)** — body-wide `dragover`/`drop` in the renderer + `app.on('open-file')` in the main process. Both feed the existing #224 import-confirm flow. Renderer handles browser-native drops via `FileReader.readAsDataURL`; main process handles OS file-association (Finder/Explorer double-click) via a narrow `readDxtFile` IPC allowlisted to `.dxt`/`.json`.

## Test plan

- [x] `pnpm --filter @skytwin/desktop test` — 176 passing, 4 skipped
- [x] `pnpm --filter @skytwin/desktop exec tsc --noEmit` clean
- [ ] Manual: settings toggle round-trips to `app.setLoginItemSettings`
- [ ] Manual: drop a .dxt onto the dashboard → lands on `/dxt/imports` with the preview
- [ ] CI green

## Out of scope

- File-association registration in electron-builder config (`open-file` won't fire for .dxt until Info.plist / Windows registry entries are added at packaging time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)