### PR TITLE
feat(#187 AC#7): embedded LLM as first-class llm-client provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Embedded LLM as a first-class llm-client provider (#187 AC#7)
+
+Closes AC#7 of #187: "Same `@skytwin/policy-prompts` prompts work
+against embedded model AND hosted models." Adds `'embedded'` as a
+fifth `AIProviderName` alongside the existing four (anthropic, openai,
+google, ollama). Callers of `LlmClient.generate()` now get embedded
+inference transparently when `embedded` is in their provider chain —
+no separate code path, no separate prompt format. Same circuit
+breaker, same fallback chain, same streaming wrapper. Local
+inference becomes one entry in the user's chain instead of a parallel
+universe the rest of the codebase has to know about.
+
+### Ships
+
+- `packages/shared-types/src/ai-provider.ts` — `AIProviderName` extended
+  with `'embedded'`. `PROVIDER_MODELS.embedded` lists `'auto'` (the
+  factory's default model resolution). `PROVIDER_INFO.embedded` carries
+  user-facing label/description plus `requiresApiKey: false`,
+  `requiresBaseUrl: false`.
+- `packages/llm-client/src/providers/embedded.ts` — provider function
+  that wraps `createEmbeddedTextPort()`. Renders `ChatMessage[]` to the
+  `role: content` block format `llama-cli -p` consumes (`system: ...`
+  → `user: ...` → `assistant:` trailing prompt). Inline `system`
+  messages take precedence over `options.systemPrompt`, matching the
+  OpenAI / Ollama providers. Caches the port instance per
+  resolved-model-key so detection runs once per model. Exports
+  `_clearEmbeddedPortCache()` for test isolation.
+- `packages/llm-client/src/llm-client.ts` — `embedded` registered in
+  `PROVIDER_FNS` and `PROVIDER_STREAM_FNS` (via `makeFallbackStream`,
+  the same path Ollama uses today). No structural changes to the
+  client; the new provider just slots into the existing chain.
+- `packages/llm-client/package.json` — declares
+  `@skytwin/embedded-llm: workspace:*`.
+- `apps/web/public/js/pages/settings.js` — adds `embedded` to the
+  `Settings → AI brain` provider picker dropdown plus its
+  `PROVIDER_MODELS` and `PROVIDER_LABELS` maps.
+- `packages/llm-client/src/__tests__/embedded-provider.test.ts` —
+  11 unit tests: trims output, passes maxTokens/temperature,
+  renders multi-turn ChatMessage[] with assistant trailer, inline
+  vs options system precedence, explicit modelPath vs auto, port
+  caching across calls, separate cache entries per model, error
+  propagation, ignored apiKey/baseUrl. Mocks `@skytwin/embedded-llm`
+  via `vi.mock` so tests never touch the real subprocess. Total
+  package now: 126 tests passing.
+
+### How callers use it
+
+```ts
+import { LlmClient } from '@skytwin/llm-client';
+
+const client = new LlmClient(userId, [
+  { provider: 'anthropic', apiKey: '...', model: 'claude-...' },
+  { provider: 'embedded', apiKey: '', model: 'auto' },        // local fallback
+]);
+
+// Identical call site whether the chain runs hosted or embedded.
+const { content } = await client.generate(prompt, { maxTokens: 256 });
+```
+
+### Out of scope
+
+- Streaming with token-level granularity from llama-cli — wrapped via
+  `makeFallbackStream` for now (single chunk on completion).
+- Cost dashboard zero-cost rendering for `embedded` provider — small
+  UI tweak in the cost panel; tracked as follow-up under #187 AC#8.
+
 ## [unreleased] — Auto-launch toggle UI + DXT drag-drop entry point (#191 + #180)
 
 Closes the auto-launch UX for #191 and the DXT drag-drop entry point for

--- a/apps/web/public/js/pages/settings.js
+++ b/apps/web/public/js/pages/settings.js
@@ -190,6 +190,7 @@ export async function renderSettings(container, userId) {
             <option value="openai">OpenAI (GPT)</option>
             <option value="google">Google (Gemini)</option>
             <option value="ollama">Local AI on this machine (Ollama)</option>
+            <option value="embedded">Embedded (llama.cpp, no install)</option>
           </select>
         </div>
         <div style="margin-top: 0.75rem; display: flex; gap: 0.5rem; justify-content: space-between; align-items: center;">
@@ -972,6 +973,9 @@ const PROVIDER_MODELS = {
     { id: 'llama3.1', label: 'Llama 3.1' },
     { id: 'mistral', label: 'Mistral' },
   ],
+  embedded: [
+    { id: 'auto', label: 'Auto-detect (first GGUF in model dir)' },
+  ],
 };
 
 const PROVIDER_LABELS = {
@@ -979,6 +983,7 @@ const PROVIDER_LABELS = {
   openai: 'OpenAI (GPT)',
   google: 'Google (Gemini)',
   ollama: 'Ollama (local)',
+  embedded: 'Embedded (llama.cpp)',
 };
 
 // In-memory state for the current chain being edited

--- a/packages/llm-client/package.json
+++ b/packages/llm-client/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@skytwin/core": "workspace:*",
+    "@skytwin/embedded-llm": "workspace:*",
     "@skytwin/shared-types": "workspace:*"
   },
   "devDependencies": {

--- a/packages/llm-client/src/__tests__/embedded-provider.test.ts
+++ b/packages/llm-client/src/__tests__/embedded-provider.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@skytwin/embedded-llm', () => ({
+  createEmbeddedTextPort: vi.fn(),
+}));
+
+import { createEmbeddedTextPort } from '@skytwin/embedded-llm';
+import {
+  _clearEmbeddedPortCache,
+  generate as embeddedGenerate,
+} from '../providers/embedded.js';
+
+const createPortMock = vi.mocked(createEmbeddedTextPort);
+const generateMock = vi.fn();
+
+beforeEach(() => {
+  generateMock.mockReset();
+  createPortMock.mockReset();
+  createPortMock.mockResolvedValue({
+    capabilities: { available: true, modelName: 'fake.gguf', contextWindow: 4096 },
+    generate: generateMock,
+  });
+  _clearEmbeddedPortCache();
+});
+
+afterEach(() => {
+  _clearEmbeddedPortCache();
+});
+
+describe('embedded provider', () => {
+  it('returns the trimmed output of EmbeddedTextPort.generate', async () => {
+    generateMock.mockResolvedValue('  Hello there.\n');
+    const result = await embeddedGenerate('', 'auto', 'Say hi');
+    expect(result).toBe('Hello there.');
+    expect(generateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes maxTokens and temperature through', async () => {
+    generateMock.mockResolvedValue('ok');
+    await embeddedGenerate('', 'auto', 'hi', { maxTokens: 64, temperature: 0.1 });
+    expect(generateMock).toHaveBeenCalledWith(expect.any(String), {
+      maxTokens: 64,
+      temperature: 0.1,
+    });
+  });
+
+  it('renders ChatMessage[] as `role: content` blocks ending in `assistant:`', async () => {
+    generateMock.mockResolvedValue('done');
+    await embeddedGenerate('', 'auto', [
+      { role: 'system', content: 'be brief' },
+      { role: 'user', content: 'count to 3' },
+    ]);
+    const promptArg = generateMock.mock.calls[0]![0] as string;
+    expect(promptArg).toContain('system: be brief');
+    expect(promptArg).toContain('user: count to 3');
+    expect(promptArg.trimEnd().endsWith('assistant:')).toBe(true);
+  });
+
+  it('respects inline system messages over options.systemPrompt', async () => {
+    generateMock.mockResolvedValue('done');
+    await embeddedGenerate(
+      '',
+      'auto',
+      [
+        { role: 'system', content: 'inline-sys' },
+        { role: 'user', content: 'hi' },
+      ],
+      { systemPrompt: 'options-sys' },
+    );
+    const promptArg = generateMock.mock.calls[0]![0] as string;
+    expect(promptArg).toContain('inline-sys');
+    expect(promptArg).not.toContain('options-sys');
+  });
+
+  it('uses options.systemPrompt when no inline system message exists', async () => {
+    generateMock.mockResolvedValue('done');
+    await embeddedGenerate('', 'auto', 'hi', { systemPrompt: 'be terse' });
+    const promptArg = generateMock.mock.calls[0]![0] as string;
+    expect(promptArg).toContain('system: be terse');
+  });
+
+  it('passes explicit modelPath when model is an absolute-looking string', async () => {
+    generateMock.mockResolvedValue('ok');
+    await embeddedGenerate('', '/custom/phi.gguf', 'hi');
+    expect(createPortMock).toHaveBeenCalledWith({ modelPath: '/custom/phi.gguf' });
+  });
+
+  it('omits modelPath override when model is "auto"', async () => {
+    generateMock.mockResolvedValue('ok');
+    await embeddedGenerate('', 'auto', 'hi');
+    expect(createPortMock).toHaveBeenCalledWith({});
+  });
+
+  it('caches the port across calls with the same model key', async () => {
+    generateMock.mockResolvedValue('ok');
+    await embeddedGenerate('', 'auto', 'hi');
+    await embeddedGenerate('', 'auto', 'hello');
+    expect(createPortMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses separate cache entries for different model paths', async () => {
+    generateMock.mockResolvedValue('ok');
+    await embeddedGenerate('', '/a.gguf', 'hi');
+    await embeddedGenerate('', '/b.gguf', 'hello');
+    expect(createPortMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates errors from the underlying port', async () => {
+    generateMock.mockRejectedValue(new Error('llama-cli exited with code 1'));
+    await expect(embeddedGenerate('', 'auto', 'hi')).rejects.toThrow(/exited with code 1/);
+  });
+
+  it('ignores apiKey and baseUrl arguments', async () => {
+    generateMock.mockResolvedValue('ok');
+    await embeddedGenerate(
+      'sk-fake',
+      'auto',
+      'hi',
+      { baseUrl: 'http://example.com' },
+    );
+    // No assertion on generateMock args other than that it ran — apiKey
+    // and baseUrl are intentionally ignored by the provider.
+    expect(generateMock).toHaveBeenCalled();
+  });
+});

--- a/packages/llm-client/src/llm-client.ts
+++ b/packages/llm-client/src/llm-client.ts
@@ -16,12 +16,14 @@ import {
 import { generate as openaiGenerate } from './providers/openai.js';
 import { generate as googleGenerate } from './providers/google.js';
 import { generate as ollamaGenerate } from './providers/ollama.js';
+import { generate as embeddedGenerate } from './providers/embedded.js';
 
 const PROVIDER_FNS: Record<AIProviderName, ProviderGenerateFn> = {
   anthropic: anthropicGenerate,
   openai: openaiGenerate,
   google: googleGenerate,
   ollama: ollamaGenerate,
+  embedded: embeddedGenerate,
 };
 
 /**
@@ -41,6 +43,7 @@ const PROVIDER_STREAM_FNS: Record<AIProviderName, ProviderStreamFn> = {
   openai: makeFallbackStream(openaiGenerate),
   google: makeFallbackStream(googleGenerate),
   ollama: makeFallbackStream(ollamaGenerate),
+  embedded: makeFallbackStream(embeddedGenerate),
 };
 
 /**

--- a/packages/llm-client/src/providers/embedded.ts
+++ b/packages/llm-client/src/providers/embedded.ts
@@ -1,0 +1,92 @@
+import {
+  createEmbeddedTextPort,
+  type EmbeddedTextPort,
+} from '@skytwin/embedded-llm';
+import type { ChatMessage, GenerateOptions } from '../types.js';
+import { toMessages } from '../messages.js';
+
+/**
+ * Cached `EmbeddedTextPort` instance keyed by model path. Subprocess-based
+ * backends are stateless once constructed (each `.generate()` spawns a
+ * fresh process), but the runtime detection that `createEmbeddedTextPort`
+ * runs hits `existsSync` and `which` — caching avoids redoing that on
+ * every request.
+ */
+const PORT_CACHE = new Map<string, Promise<EmbeddedTextPort>>();
+
+function getPort(modelPath: string | undefined): Promise<EmbeddedTextPort> {
+  const key = modelPath ?? '__auto__';
+  let cached = PORT_CACHE.get(key);
+  if (cached === undefined) {
+    cached = createEmbeddedTextPort(modelPath !== undefined ? { modelPath } : {});
+    PORT_CACHE.set(key, cached);
+  }
+  return cached;
+}
+
+/**
+ * Render a `ChatMessage[]` to the single-string prompt format that
+ * llama.cpp expects when invoked via `llama-cli -p ...`. Mirrors the
+ * loose structure most chat models recognize: `system:` / `user:` /
+ * `assistant:` line prefixes.
+ *
+ * Inline `system` messages take precedence over `options.systemPrompt`,
+ * matching the OpenAI / Ollama providers in this directory.
+ */
+function buildPrompt(prompt: string | ChatMessage[], options: GenerateOptions): string {
+  const inputMessages = toMessages(prompt);
+  const hasInlineSystem = inputMessages.some((m) => m.role === 'system');
+  const messages: ChatMessage[] = [];
+  if (
+    options.systemPrompt !== undefined &&
+    options.systemPrompt !== '' &&
+    !hasInlineSystem
+  ) {
+    messages.push({ role: 'system', content: options.systemPrompt });
+  }
+  messages.push(...inputMessages);
+
+  return messages
+    .map((m) => `${m.role}: ${m.content}`)
+    .join('\n\n')
+    .concat('\n\nassistant:');
+}
+
+/**
+ * Embedded provider — wraps `@skytwin/embedded-llm.LlamaCppTextBackend`.
+ *
+ * - `apiKey` is ignored (subprocess auth is "you have the binary").
+ * - `model` selects a specific GGUF when set to an absolute path; the
+ *   sentinel value `'auto'` falls back to env-var resolution + first
+ *   matching file in the detected `modelDir`.
+ * - `baseUrl` is ignored.
+ *
+ * If the binary is missing or no GGUF is resolvable, the underlying
+ * port is `NullEmbeddedTextPort` whose `.generate()` throws
+ * `NotAvailableError` — which the LlmClient chain treats like any
+ * other provider failure (tries the next provider).
+ */
+export async function generate(
+  _apiKey: string,
+  model: string,
+  prompt: string | ChatMessage[],
+  options: GenerateOptions & { baseUrl?: string } = {},
+): Promise<string> {
+  const modelPath =
+    model && model !== '' && model !== 'auto' && model !== 'default' ? model : undefined;
+  const port = await getPort(modelPath);
+  const text = await port.generate(buildPrompt(prompt, options), {
+    maxTokens: options.maxTokens,
+    temperature: options.temperature,
+  });
+  return text.trim();
+}
+
+/**
+ * Test helper — clears the port cache. Production callers never need
+ * this; tests use it to reset state between cases that mock
+ * `@skytwin/embedded-llm`.
+ */
+export function _clearEmbeddedPortCache(): void {
+  PORT_CACHE.clear();
+}

--- a/packages/shared-types/src/ai-provider.ts
+++ b/packages/shared-types/src/ai-provider.ts
@@ -1,7 +1,10 @@
 /**
  * Supported AI provider identifiers.
+ *
+ * `embedded` runs llama.cpp via subprocess (no HTTP, no API key) using
+ * `@skytwin/embedded-llm` — see `packages/llm-client/src/providers/embedded.ts`.
  */
-export type AIProviderName = 'anthropic' | 'openai' | 'google' | 'ollama';
+export type AIProviderName = 'anthropic' | 'openai' | 'google' | 'ollama' | 'embedded';
 
 /**
  * A single provider configuration in the user's AI chain.
@@ -42,6 +45,9 @@ export const PROVIDER_MODELS: Record<AIProviderName, { id: string; label: string
     { id: 'llama3.1', label: 'Llama 3.1' },
     { id: 'mistral', label: 'Mistral' },
   ],
+  embedded: [
+    { id: 'auto', label: 'Auto-detect (first GGUF in model dir)' },
+  ],
 };
 
 /**
@@ -71,5 +77,12 @@ export const PROVIDER_INFO: Record<AIProviderName, { label: string; description:
     description: 'Free, runs on your machine. Requires Ollama running locally.',
     requiresApiKey: false,
     requiresBaseUrl: true,
+  },
+  embedded: {
+    label: 'Embedded (llama.cpp)',
+    description:
+      'Free, runs in-process via llama.cpp. Requires `llama-cli` on PATH and a GGUF model (auto-detected from SKYTWIN_LLAMA_MODELS or pinned via SKYTWIN_LLAMA_MODEL).',
+    requiresApiKey: false,
+    requiresBaseUrl: false,
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,6 +611,9 @@ importers:
       '@skytwin/core':
         specifier: workspace:*
         version: link:../core
+      '@skytwin/embedded-llm':
+        specifier: workspace:*
+        version: link:../embedded-llm
       '@skytwin/shared-types':
         specifier: workspace:*
         version: link:../shared-types


### PR DESCRIPTION
## Summary

Closes AC#7 of #187: same prompts work against embedded model AND hosted models — verified by routing through the same `LlmClient` chain.

Adds `'embedded'` as a fifth `AIProviderName`. Wraps `createEmbeddedTextPort()` from `@skytwin/embedded-llm` (PR #238) in a provider function that registers in `PROVIDER_FNS` / `PROVIDER_STREAM_FNS` alongside anthropic/openai/google/ollama. Callers using `LlmClient.generate()` now get local llama.cpp inference transparently when `'embedded'` is in their chain — same circuit breaker, same fallback, same streaming wrapper, same prompt API.

## Why this matters

Without this PR, embedded LLM was a parallel universe — anyone wanting local inference had to import `@skytwin/embedded-llm` directly and bypass the existing chain/circuit-breaker/streaming infrastructure. With it, local inference is just another entry in the user's provider chain. This is the architectural commitment from #187: "the same prompts run against any model."

## Test plan

- [x] `pnpm --filter @skytwin/llm-client test` — 126 passing (11 new for embedded provider)
- [x] `pnpm build` — all 34 workspace packages clean
- [x] `vi.mock` ensures tests never spawn real `llama-cli`
- [ ] CI green

## How callers use it

```ts
const client = new LlmClient(userId, [
  { provider: 'anthropic', apiKey: '...', model: 'claude-...' },
  { provider: 'embedded', apiKey: '', model: 'auto' },        // local fallback
]);
const { content } = await client.generate(prompt, { maxTokens: 256 });
```

## Out of scope

- Token-level streaming from `llama-cli` (currently uses `makeFallbackStream`, same as Ollama/OpenAI/Google)
- Cost dashboard recognizing `embedded` provider as zero-cost (small UI tweak, follow-up under #187 AC#8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)