### PR TITLE
feat(#187 AC#2): embedded LLM model downloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,94 @@
 All notable changes to SkyTwin will be documented in this file.
 
-## [unreleased] — Accessibility: high-contrast + text-scale + voice STT route (#194 Child 4)
+## [unreleased] — Embedded LLM model downloader (#187 AC#2)
+
+Closes AC#2 of #187. The single piece between "developer tool" and
+"consumer app": a fresh install can now fetch its own model with no
+config, no API keys, no per-message cost. The registry shipped in #246
+told us *which* model to download; this PR makes it actually happen,
+with pause / resume / cancel and persistence across API restarts.
+
+### Why this is the launch-gating piece
+
+A non-technical user opening SkyTwin previously hit a wall: the twin
+needed an LLM, but configuring one meant either installing llama.cpp
+manually + downloading a GGUF + setting `SKYTWIN_LLAMA_MODELS`, or
+buying API keys from Anthropic/OpenAI. Now: open Settings → "Local AI
+brain" card detects the user's RAM bracket via `navigator.deviceMemory`,
+recommends the highest-quality model that fits, click Download → 3-15
+minutes later the twin works fully offline.
+
+### Ships
+
+- `039-model-downloads.sql`: `model_downloads` table tracking each
+  download — model_id, target_path, total_bytes, bytes_downloaded,
+  sha256_expected, status (pending → downloading → verifying →
+  installing → complete; or paused / failed / cancelled), started_at,
+  paused_at, completed_at.
+- `modelDownloadRepository`: create, findById, listForUser, findActive
+  (idempotency on user+model), updateProgress (chunk-tick), setStatus
+  (with paused_at / completed_at side effects), `recoverOrphanedDownloads`
+  (boot-time recovery — orphaned `downloading` rows flip to `paused`).
+- `apps/api/src/embedded-llm/downloader.ts`: the download engine.
+  - Streams `fetch()` body to `<target_path>.partial`, atomic rename
+    on success.
+  - Resume via HTTP `Range` header — server that ignores Range falls
+    back to full re-download (rare; logged).
+  - Progress flushed to DB every ~1MB to keep transactions cheap.
+  - SHA-256 verification post-download (skipped when registry hash is
+    placeholder all-zeros — v1 hashes are stubs pending real artifact
+    measurement).
+  - In-flight `AbortController` map for pause/cancel.
+  - Default model dir: `~/.skytwin/models/llama` if `SKYTWIN_LLAMA_MODELS`
+    unset (matches the runtime detector's read path).
+- `apps/api/src/routes/embedded-llm.ts`: extended with downloader
+  endpoints (start, get, list-for-user, pause, resume, cancel,
+  model-dir). Idempotent on `(userId, modelId)` so spam-clicking
+  Download doesn't spawn duplicate transfers.
+- Boot-time recovery wired into `apps/api/src/index.ts` —
+  `recoverOnBoot()` runs alongside execution-router init.
+- `apps/web/public/js/components/embedded-llm-card.js`: Settings card.
+  Detects RAM bracket, recommends a default, shows a select for
+  override, renders the download in progress with progress bar (reuses
+  existing `.confidence-bar` styles), pause/resume/cancel buttons,
+  error surface. Polls `/downloads/:id` every 1s while a download is
+  active; stops polling on terminal status.
+- 14 unit tests for the route layer in
+  `apps/api/src/__tests__/embedded-llm-downloads-routes.test.ts`:
+  start happy + missing-userId/modelId + 404 unknown-model, get +
+  404, percent capping at 100% for over-fetch, percent=0 for pending,
+  list-for-user, pause ok/false, resume + 404, cancel. Mocks
+  `@skytwin/db` + the downloader module — no real HTTP / filesystem.
+
+API total: 477 passing (24 skipped). All 34 packages build clean.
+
+### Why this fits the theme
+
+This is "boring deterministic" infrastructure — `fetch()` with `Range`,
+SHA-256 verify, atomic rename. No LLM in the cryptography or the
+download path. Every byte is accounted for; every state transition is
+reflected in the row; every user-facing button has a deterministic
+back-end consequence. The adaptive layer (the prompts that consume the
+model once installed) doesn't change at all.
+
+### Out of scope
+
+- **Real SHA-256 hashes in the registry**: the v1 registry ships with
+  all-zero placeholder hashes. The downloader detects this and skips
+  verification. Filling in real hashes is a one-line change per model
+  once an artifact has been measured (download once, `shasum -a 256`,
+  paste). Tracking as a follow-up.
+- **First-run onboarding integration**: the card lives in Settings
+  today. The natural follow-up is to surface it as the first card on
+  the dashboard when no model is installed AND no LLM provider is
+  configured — making "your twin is downloading its brain" the
+  explicit first-run state. Small change to `dashboard.js`.
+- **Resume after API restart with a UI prompt**: orphaned downloads
+  flip to `paused` on boot; the user sees a "Paused" download with a
+  Resume button on next Settings visit, which is the desired UX. A
+  toast / banner alerting them proactively is a small follow-up.
+
+
 
 Closes the a11y commitments of #194 Child 4. Detailed entry in PR #244.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,14 +53,67 @@ minutes later the twin works fully offline.
   existing `.confidence-bar` styles), pause/resume/cancel buttons,
   error surface. Polls `/downloads/:id` every 1s while a download is
   active; stops polling on terminal status.
-- 14 unit tests for the route layer in
+- 25 unit tests for the route layer in
   `apps/api/src/__tests__/embedded-llm-downloads-routes.test.ts`:
   start happy + missing-userId/modelId + 404 unknown-model, get +
   404, percent capping at 100% for over-fetch, percent=0 for pending,
-  list-for-user, pause ok/false, resume + 404, cancel. Mocks
-  `@skytwin/db` + the downloader module — no real HTTP / filesystem.
+  list-for-user, pause ok/false, pause-404, resume + 404, cancel,
+  cancel-404, plus 7 cross-user-403 tests covering every mutating
+  endpoint plus the dev-bypass-allowed case. Mocks `@skytwin/db` +
+  the downloader module — no real HTTP / filesystem.
 
-API total: 477 passing (24 skipped). All 34 packages build clean.
+API total: 486 passing (24 skipped). All 34 packages build clean.
+
+### Fixed (post-/review)
+
+Copilot review on PR #247 surfaced 12 substantive findings; all
+addressed before merge:
+
+- **IDOR on `POST /downloads/start`**: applied `requireOwnership`
+  middleware so the request body's `userId` must match the
+  authenticated user.
+- **IDOR on `GET /downloads/:id` and the pause/resume/cancel routes**:
+  introduced a `loadOwnedDownload(req, res, id)` helper that fetches
+  the row and rejects with 403 if `req.authenticatedUserId` doesn't
+  match `row.user_id`. Dev bypass (no `authenticatedUserId`) keeps
+  current behavior.
+- **OOM on multi-GB SHA-256 verify**: replaced `readFile(path)` with a
+  streaming `createReadStream → hash.update(chunk)` loop in a new
+  `computeSha256(path)` helper. A 4GB GGUF no longer needs 4GB of
+  Node heap to verify.
+- **DB-level idempotency**: schema changed from a non-unique partial
+  index to a `UNIQUE` partial index on `(user_id, model_id)` for
+  non-terminal statuses, so two concurrent `/downloads/start` calls
+  can't both win past `findActive()`. `startDownload()` now also
+  catches the `23505` unique-violation that the loser's `INSERT`
+  raises and re-fetches the surviving row.
+- **In-memory race**: `startDownload()` now bails if the row is
+  already in `inFlight`, preventing two concurrent runners writing
+  the same `.partial`.
+- **Stale progress on Range-ignored**: when the server returns 200 to
+  a Range request, we now `updateProgress(id, 0)` immediately so the
+  poll UI doesn't display stale `bytes_downloaded` until the next
+  1MB flush.
+- **`total_bytes` never persisted**: added
+  `modelDownloadRepository.updateTotalBytes(id, n)` and call it when
+  Content-Length disagrees with the registry by >1MB. The progress
+  bar denominator now matches reality.
+- **DOM update broke action buttons**: the polling tick was finding
+  `labelLine.firstElementChild` and replacing it, which clobbered
+  the size/percent span on first run and the action-button span on
+  subsequent runs. Switched to stable `data-role` selectors
+  (`embedded-llm-progress-text`, `embedded-llm-status`) so updates
+  are scoped.
+- **Singleton listener stale closure**: `ensureListener()` no longer
+  closes over `container` or `userId` from the first mount. The
+  delegator now re-derives both at click time:
+  `document.getElementById('embedded-llm-card-target')` for the
+  container, `localStorage.getItem(KEY_USER_ID)` for the userId.
+  Same pattern as the other singleton delegators in this codebase.
+- **Test auth pattern**: switched from injecting `req.user.id` to
+  `req.authenticatedUserId` to match production. Added 7 new tests
+  covering cross-user 403 on every mutating endpoint plus the
+  dev-bypass-allowed path.
 
 ### Why this fits the theme
 

--- a/apps/api/src/__tests__/embedded-llm-downloads-routes.test.ts
+++ b/apps/api/src/__tests__/embedded-llm-downloads-routes.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for the embedded-llm download API routes (#187 AC#2).
+ *
+ * The downloader's actual byte-streaming logic lives in
+ * `embedded-llm/downloader.ts` and would require a real HTTP server +
+ * filesystem to test end-to-end. These tests cover the route layer:
+ * input validation, repository handoff, and the rowToJson shape (which
+ * the polling UI depends on).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import type { Express } from 'express';
+
+const { mockRepo, mockStartDownload, mockPauseDownload, mockCancelDownload } = vi.hoisted(() => ({
+  mockRepo: {
+    findById: vi.fn(),
+    listForUser: vi.fn(),
+  },
+  mockStartDownload: vi.fn(),
+  mockPauseDownload: vi.fn(),
+  mockCancelDownload: vi.fn(),
+}));
+
+vi.mock('@skytwin/db', () => ({
+  modelDownloadRepository: mockRepo,
+}));
+
+vi.mock('../embedded-llm/downloader.js', () => ({
+  startDownload: mockStartDownload,
+  pauseDownload: mockPauseDownload,
+  cancelDownload: mockCancelDownload,
+  resolveModelDir: () => '/tmp/skytwin-models',
+}));
+
+import { createEmbeddedLlmRouter } from '../routes/embedded-llm.js';
+
+const USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const DOWNLOAD_ID = 'dddddddd-eeee-ffff-aaaa-111111111111';
+
+const SAMPLE_ROW = {
+  id: DOWNLOAD_ID,
+  user_id: USER_ID,
+  model_id: 'qwen-2.5-3b-q4',
+  target_path: '/tmp/skytwin-models/qwen-2.5-3b-q4.gguf',
+  total_bytes: 2_000_000_000,
+  bytes_downloaded: 1_000_000_000,
+  sha256_expected: '0'.repeat(64),
+  status: 'downloading' as const,
+  error: null,
+  started_at: new Date('2026-05-09T01:00:00Z'),
+  paused_at: null,
+  completed_at: null,
+};
+
+function buildApp(userId: string | null = USER_ID): Express {
+  const app = express();
+  app.use(express.json());
+  if (userId !== null) {
+    app.use((req, _res, next) => {
+      (req as unknown as { user: { id: string } }).user = { id: userId };
+      next();
+    });
+  }
+  app.use('/api/embedded-llm', createEmbeddedLlmRouter());
+  app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(500).json({ error: err.message });
+  });
+  return app;
+}
+
+async function req(
+  app: Express,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') { server.close(); reject(new Error('no port')); return; }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      const opts: RequestInit = { method, headers };
+      if (body !== undefined) opts.body = JSON.stringify(body);
+      fetch(url, opts).then(async (res) => {
+        const json = await res.json().catch(() => null);
+        server.close();
+        resolve({ status: res.status, body: json as Record<string, unknown> });
+      }).catch((err) => { server.close(); reject(err); });
+    });
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /api/embedded-llm/model-dir', () => {
+  it('returns the resolved model directory', async () => {
+    const { status, body } = await req(buildApp(), 'GET', '/api/embedded-llm/model-dir');
+    expect(status).toBe(200);
+    expect(body['modelDir']).toBe('/tmp/skytwin-models');
+  });
+});
+
+describe('POST /api/embedded-llm/downloads/start', () => {
+  it('starts a download and returns row + resumed flag', async () => {
+    mockStartDownload.mockResolvedValue({ download: SAMPLE_ROW, resumed: false });
+    const { status, body } = await req(buildApp(), 'POST', '/api/embedded-llm/downloads/start', {
+      userId: USER_ID,
+      modelId: 'qwen-2.5-3b-q4',
+    });
+    expect(status).toBe(200);
+    expect(body['resumed']).toBe(false);
+    const dl = body['download'] as Record<string, unknown>;
+    expect(dl['id']).toBe(DOWNLOAD_ID);
+    expect(dl['percent']).toBe(50);
+    expect(dl['status']).toBe('downloading');
+  });
+
+  it('signals resumed=true when continuing a partial', async () => {
+    mockStartDownload.mockResolvedValue({ download: SAMPLE_ROW, resumed: true });
+    const { body } = await req(buildApp(), 'POST', '/api/embedded-llm/downloads/start', {
+      userId: USER_ID,
+      modelId: 'qwen-2.5-3b-q4',
+    });
+    expect(body['resumed']).toBe(true);
+  });
+
+  it('rejects missing userId', async () => {
+    const { status } = await req(buildApp(), 'POST', '/api/embedded-llm/downloads/start', {
+      modelId: 'qwen-2.5-3b-q4',
+    });
+    expect(status).toBe(400);
+  });
+
+  it('rejects missing modelId', async () => {
+    const { status } = await req(buildApp(), 'POST', '/api/embedded-llm/downloads/start', {
+      userId: USER_ID,
+    });
+    expect(status).toBe(400);
+  });
+
+  it('returns 404 when model id is not in the registry', async () => {
+    mockStartDownload.mockRejectedValue(new Error('unknown model id: not-real'));
+    const { status, body } = await req(buildApp(), 'POST', '/api/embedded-llm/downloads/start', {
+      userId: USER_ID,
+      modelId: 'not-real',
+    });
+    expect(status).toBe(404);
+    expect(body['error']).toMatch(/unknown model id/);
+  });
+});
+
+describe('GET /api/embedded-llm/downloads/:id', () => {
+  it('returns the row in JSON-friendly shape', async () => {
+    mockRepo.findById.mockResolvedValue(SAMPLE_ROW);
+    const { status, body } = await req(
+      buildApp(),
+      'GET',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}`,
+    );
+    expect(status).toBe(200);
+    const dl = body['download'] as Record<string, unknown>;
+    expect(dl['percent']).toBe(50);
+    expect(dl['totalBytes']).toBe(2_000_000_000);
+    expect(dl['bytesDownloaded']).toBe(1_000_000_000);
+    // sha256_expected must NOT appear in JSON output (hashes leak info
+    // about which artifact endpoint is being downloaded).
+    expect(JSON.stringify(dl)).not.toContain('sha256');
+  });
+
+  it('returns 404 when download not found', async () => {
+    mockRepo.findById.mockResolvedValue(null);
+    const { status } = await req(
+      buildApp(),
+      'GET',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}`,
+    );
+    expect(status).toBe(404);
+  });
+
+  it('caps percent at 100 for over-fetched downloads', async () => {
+    // Edge case: bytes_downloaded > total_bytes when Content-Length
+    // was wrong and we kept reading. UI shouldn't show 103%.
+    mockRepo.findById.mockResolvedValue({
+      ...SAMPLE_ROW,
+      bytes_downloaded: 2_100_000_000,
+    });
+    const { body } = await req(
+      buildApp(),
+      'GET',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}`,
+    );
+    const dl = body['download'] as Record<string, unknown>;
+    expect(dl['percent']).toBe(100);
+  });
+
+  it('reports 0% for a pending download with totalBytes>0', async () => {
+    mockRepo.findById.mockResolvedValue({
+      ...SAMPLE_ROW,
+      status: 'pending',
+      bytes_downloaded: 0,
+    });
+    const { body } = await req(
+      buildApp(),
+      'GET',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}`,
+    );
+    const dl = body['download'] as Record<string, unknown>;
+    expect(dl['percent']).toBe(0);
+  });
+});
+
+describe('GET /api/embedded-llm/downloads/user/:userId', () => {
+  it('returns the user list', async () => {
+    mockRepo.listForUser.mockResolvedValue([SAMPLE_ROW]);
+    const { status, body } = await req(
+      buildApp(),
+      'GET',
+      `/api/embedded-llm/downloads/user/${USER_ID}`,
+    );
+    expect(status).toBe(200);
+    const downloads = body['downloads'] as Array<Record<string, unknown>>;
+    expect(downloads).toHaveLength(1);
+    expect(downloads[0]?.['percent']).toBe(50);
+  });
+});
+
+describe('POST /api/embedded-llm/downloads/:id/pause', () => {
+  it('returns ok=true on successful pause', async () => {
+    mockPauseDownload.mockResolvedValue(true);
+    const { status, body } = await req(
+      buildApp(),
+      'POST',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}/pause`,
+    );
+    expect(status).toBe(200);
+    expect(body['ok']).toBe(true);
+    expect(mockPauseDownload).toHaveBeenCalledWith(DOWNLOAD_ID);
+  });
+
+  it('returns ok=false when row is not pausable', async () => {
+    mockPauseDownload.mockResolvedValue(false);
+    const { body } = await req(
+      buildApp(),
+      'POST',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}/pause`,
+    );
+    expect(body['ok']).toBe(false);
+  });
+});
+
+describe('POST /api/embedded-llm/downloads/:id/resume', () => {
+  it('re-enters startDownload for the row\'s (user, model)', async () => {
+    mockRepo.findById.mockResolvedValue({ ...SAMPLE_ROW, status: 'paused' });
+    mockStartDownload.mockResolvedValue({
+      download: { ...SAMPLE_ROW, status: 'downloading' },
+      resumed: true,
+    });
+    const { status, body } = await req(
+      buildApp(),
+      'POST',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}/resume`,
+    );
+    expect(status).toBe(200);
+    expect(body['resumed']).toBe(true);
+    expect(mockStartDownload).toHaveBeenCalledWith(USER_ID, 'qwen-2.5-3b-q4');
+  });
+
+  it('returns 404 when download not found', async () => {
+    mockRepo.findById.mockResolvedValue(null);
+    const { status } = await req(
+      buildApp(),
+      'POST',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}/resume`,
+    );
+    expect(status).toBe(404);
+  });
+});
+
+describe('POST /api/embedded-llm/downloads/:id/cancel', () => {
+  it('returns ok=true on successful cancel', async () => {
+    mockCancelDownload.mockResolvedValue(true);
+    const { status, body } = await req(
+      buildApp(),
+      'POST',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}/cancel`,
+    );
+    expect(status).toBe(200);
+    expect(body['ok']).toBe(true);
+  });
+});

--- a/apps/api/src/__tests__/embedded-llm-downloads-routes.test.ts
+++ b/apps/api/src/__tests__/embedded-llm-downloads-routes.test.ts
@@ -52,12 +52,19 @@ const SAMPLE_ROW = {
   completed_at: null,
 };
 
-function buildApp(userId: string | null = USER_ID): Express {
+/**
+ * Build an Express app for tests. Production auth sets
+ * `req.authenticatedUserId` via `sessionAuth`; the ownership middleware
+ * compares it against userId in params/body/query (or against the row's
+ * user_id for `:id`-keyed routes). Pass `null` to simulate dev bypass —
+ * `requireOwnership` skips the check when `authenticatedUserId` is undefined.
+ */
+function buildApp(authUserId: string | null = USER_ID): Express {
   const app = express();
   app.use(express.json());
-  if (userId !== null) {
+  if (authUserId !== null) {
     app.use((req, _res, next) => {
-      (req as unknown as { user: { id: string } }).user = { id: userId };
+      req.authenticatedUserId = authUserId;
       next();
     });
   }
@@ -229,6 +236,7 @@ describe('GET /api/embedded-llm/downloads/user/:userId', () => {
 
 describe('POST /api/embedded-llm/downloads/:id/pause', () => {
   it('returns ok=true on successful pause', async () => {
+    mockRepo.findById.mockResolvedValue(SAMPLE_ROW);
     mockPauseDownload.mockResolvedValue(true);
     const { status, body } = await req(
       buildApp(),
@@ -241,6 +249,7 @@ describe('POST /api/embedded-llm/downloads/:id/pause', () => {
   });
 
   it('returns ok=false when row is not pausable', async () => {
+    mockRepo.findById.mockResolvedValue(SAMPLE_ROW);
     mockPauseDownload.mockResolvedValue(false);
     const { body } = await req(
       buildApp(),
@@ -248,6 +257,17 @@ describe('POST /api/embedded-llm/downloads/:id/pause', () => {
       `/api/embedded-llm/downloads/${DOWNLOAD_ID}/pause`,
     );
     expect(body['ok']).toBe(false);
+  });
+
+  it('returns 404 when download not found', async () => {
+    mockRepo.findById.mockResolvedValue(null);
+    const { status } = await req(
+      buildApp(),
+      'POST',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}/pause`,
+    );
+    expect(status).toBe(404);
+    expect(mockPauseDownload).not.toHaveBeenCalled();
   });
 });
 
@@ -281,6 +301,7 @@ describe('POST /api/embedded-llm/downloads/:id/resume', () => {
 
 describe('POST /api/embedded-llm/downloads/:id/cancel', () => {
   it('returns ok=true on successful cancel', async () => {
+    mockRepo.findById.mockResolvedValue(SAMPLE_ROW);
     mockCancelDownload.mockResolvedValue(true);
     const { status, body } = await req(
       buildApp(),
@@ -289,5 +310,93 @@ describe('POST /api/embedded-llm/downloads/:id/cancel', () => {
     );
     expect(status).toBe(200);
     expect(body['ok']).toBe(true);
+  });
+
+  it('returns 404 when download not found', async () => {
+    mockRepo.findById.mockResolvedValue(null);
+    const { status } = await req(
+      buildApp(),
+      'POST',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}/cancel`,
+    );
+    expect(status).toBe(404);
+    expect(mockCancelDownload).not.toHaveBeenCalled();
+  });
+});
+
+describe('cross-user access is forbidden', () => {
+  const OTHER_USER_ID = '11111111-2222-3333-4444-555555555555';
+
+  it('POST /downloads/start rejects when body userId differs from authenticated user', async () => {
+    const { status } = await req(
+      buildApp(USER_ID),
+      'POST',
+      '/api/embedded-llm/downloads/start',
+      { userId: OTHER_USER_ID, modelId: 'qwen-2.5-3b-q4' },
+    );
+    expect(status).toBe(403);
+    expect(mockStartDownload).not.toHaveBeenCalled();
+  });
+
+  it('GET /downloads/:id rejects when row belongs to another user', async () => {
+    mockRepo.findById.mockResolvedValue({ ...SAMPLE_ROW, user_id: OTHER_USER_ID });
+    const { status } = await req(
+      buildApp(USER_ID),
+      'GET',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}`,
+    );
+    expect(status).toBe(403);
+  });
+
+  it('POST /downloads/:id/pause rejects when row belongs to another user', async () => {
+    mockRepo.findById.mockResolvedValue({ ...SAMPLE_ROW, user_id: OTHER_USER_ID });
+    const { status } = await req(
+      buildApp(USER_ID),
+      'POST',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}/pause`,
+    );
+    expect(status).toBe(403);
+    expect(mockPauseDownload).not.toHaveBeenCalled();
+  });
+
+  it('POST /downloads/:id/resume rejects when row belongs to another user', async () => {
+    mockRepo.findById.mockResolvedValue({ ...SAMPLE_ROW, user_id: OTHER_USER_ID });
+    const { status } = await req(
+      buildApp(USER_ID),
+      'POST',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}/resume`,
+    );
+    expect(status).toBe(403);
+    expect(mockStartDownload).not.toHaveBeenCalled();
+  });
+
+  it('POST /downloads/:id/cancel rejects when row belongs to another user', async () => {
+    mockRepo.findById.mockResolvedValue({ ...SAMPLE_ROW, user_id: OTHER_USER_ID });
+    const { status } = await req(
+      buildApp(USER_ID),
+      'POST',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}/cancel`,
+    );
+    expect(status).toBe(403);
+    expect(mockCancelDownload).not.toHaveBeenCalled();
+  });
+
+  it('GET /downloads/user/:userId rejects when path userId differs from authenticated user', async () => {
+    const { status } = await req(
+      buildApp(USER_ID),
+      'GET',
+      `/api/embedded-llm/downloads/user/${OTHER_USER_ID}`,
+    );
+    expect(status).toBe(403);
+  });
+
+  it('dev bypass (no authenticatedUserId) allows access', async () => {
+    mockRepo.findById.mockResolvedValue({ ...SAMPLE_ROW, user_id: OTHER_USER_ID });
+    const { status } = await req(
+      buildApp(null),
+      'GET',
+      `/api/embedded-llm/downloads/${DOWNLOAD_ID}`,
+    );
+    expect(status).toBe(200);
   });
 });

--- a/apps/api/src/embedded-llm/downloader.ts
+++ b/apps/api/src/embedded-llm/downloader.ts
@@ -8,7 +8,7 @@ import {
   statSync,
   unlinkSync,
 } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -218,13 +218,20 @@ async function runDownload(download: ModelDownloadRow): Promise<void> {
   }
 
   const partialPath = partialPathFor(download.target_path);
+  // Only resume from the partial if THIS row had progress recorded.
+  // A fresh row (bytes_downloaded === 0) finding a partial on disk
+  // means the previous attempt didn't clean up — e.g., a cancel that
+  // failed to unlink on Windows. Resuming from those stale bytes
+  // would corrupt the download.
   let resumeFrom = 0;
-  if (existsSync(partialPath)) {
+  if (download.bytes_downloaded > 0 && existsSync(partialPath)) {
     try {
       resumeFrom = statSync(partialPath).size;
     } catch {
       resumeFrom = 0;
     }
+  } else if (existsSync(partialPath)) {
+    try { unlinkSync(partialPath); } catch { /* best effort */ }
   }
 
   const controller = new AbortController();
@@ -336,7 +343,13 @@ async function runDownload(download: ModelDownloadRow): Promise<void> {
     return;
   }
 
-  inFlight.delete(download.id);
+  // Bail if the user clicked Cancel during the byte transfer. The
+  // network stream finishes after a controller.abort(), so we may
+  // arrive here with handle.cancelled already true.
+  if (handle.cancelled) {
+    inFlight.delete(download.id);
+    return;
+  }
   await modelDownloadRepository.setStatus(download.id, 'verifying', {
     bytesDownloaded: totalBytes,
   });
@@ -352,10 +365,18 @@ async function runDownload(download: ModelDownloadRow): Promise<void> {
     // Stream the file through the hash — multi-GB GGUFs would OOM the
     // API process if we readFile()'d the whole thing into memory.
     const actual = await computeSha256(partialPath);
+    // Cancel can fire mid-hash. If it did, cancelDownload() already
+    // marked the row 'cancelled' and removed the partial — don't
+    // overwrite that with verify's outcome.
+    if (handle.cancelled) {
+      inFlight.delete(download.id);
+      return;
+    }
     if (actual !== expectedHash) {
       // Corrupt download. Delete the partial — user should retry,
       // and we don't want a half-bad GGUF lingering on disk.
       try { unlinkSync(partialPath); } catch { /* best effort */ }
+      inFlight.delete(download.id);
       await modelDownloadRepository.setStatus(download.id, 'failed', {
         error: `sha256 mismatch: expected ${expectedHash}, got ${actual}`,
         bytesDownloaded: 0,
@@ -364,18 +385,26 @@ async function runDownload(download: ModelDownloadRow): Promise<void> {
     }
   }
 
+  if (handle.cancelled) {
+    inFlight.delete(download.id);
+    return;
+  }
   await modelDownloadRepository.setStatus(download.id, 'installing');
   // Atomic rename — partial → final. Same filesystem so this is O(1).
   try {
     if (existsSync(download.target_path)) unlinkSync(download.target_path);
     renameSync(partialPath, download.target_path);
   } catch (err) {
+    inFlight.delete(download.id);
+    if (handle.cancelled) return;
     await modelDownloadRepository.setStatus(download.id, 'failed', {
       error: `install (rename) failed: ${err instanceof Error ? err.message : String(err)}`,
     });
     return;
   }
 
+  inFlight.delete(download.id);
+  if (handle.cancelled) return;
   await modelDownloadRepository.setStatus(download.id, 'complete');
   log.info('Model download complete', {
     downloadId: download.id,
@@ -401,15 +430,6 @@ export async function recoverOnBoot(): Promise<void> {
       error: err instanceof Error ? err.message : String(err),
     });
   }
-}
-
-/**
- * Helper used by the dirname-only check in tests. Exported so the
- * route handler doesn't need to import `node:path` separately.
- */
-export function ensureDirectory(filePath: string): void {
-  const dir = dirname(filePath);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 }
 
 /**

--- a/apps/api/src/embedded-llm/downloader.ts
+++ b/apps/api/src/embedded-llm/downloader.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import {
+  createReadStream,
   createWriteStream,
   existsSync,
   mkdirSync,
@@ -97,13 +98,34 @@ export async function startDownload(
     download = existing;
     resumed = existing.bytes_downloaded > 0;
   } else {
-    download = await modelDownloadRepository.create({
-      userId,
-      modelId,
-      targetPath,
-      totalBytes: model.approxBytes,
-      sha256Expected: model.sha256,
-    });
+    try {
+      download = await modelDownloadRepository.create({
+        userId,
+        modelId,
+        targetPath,
+        totalBytes: model.approxBytes,
+        sha256Expected: model.sha256,
+      });
+    } catch (err) {
+      // The DB-level unique partial index can reject concurrent inserts
+      // that both passed findActive(). Re-fetch and treat as resumed.
+      if (isUniqueViolation(err)) {
+        const refetch = await modelDownloadRepository.findActive(userId, modelId);
+        if (refetch === null) throw err;
+        download = refetch;
+        resumed = refetch.bytes_downloaded > 0;
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  // If a runner is already executing for this row, skip kicking off a
+  // second one — two concurrent .partial writers would corrupt the
+  // file. The active runner will keep streaming and the caller polls
+  // for progress on the same row.
+  if (inFlight.has(download.id)) {
+    return { download, resumed };
   }
 
   // Kick off the async transfer. Caller doesn't await this — it polls
@@ -116,6 +138,12 @@ export async function startDownload(
   });
 
   return { download, resumed };
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const code = (err as { code?: unknown }).code;
+  return code === '23505';
 }
 
 /**
@@ -244,6 +272,9 @@ async function runDownload(download: ModelDownloadRow): Promise<void> {
     if (existsSync(partialPath)) {
       try { unlinkSync(partialPath); } catch { /* best effort */ }
     }
+    // Persist the reset immediately so the polling UI doesn't briefly
+    // report a stale `bytes_downloaded` until the next 1MB flush.
+    await modelDownloadRepository.updateProgress(download.id, 0);
   }
   if (response.body === null) {
     inFlight.delete(download.id);
@@ -262,10 +293,7 @@ async function runDownload(download: ModelDownloadRow): Promise<void> {
     if (Number.isFinite(len) && len > 0) {
       const totalFromServer = response.status === 206 ? resumeFrom + len : len;
       if (Math.abs(totalFromServer - download.total_bytes) > 1024 * 1024) {
-        // Drift > 1MB — update so progress bar isn't lying.
-        await modelDownloadRepository.setStatus(download.id, 'downloading', {
-          bytesDownloaded: resumeFrom,
-        });
+        await modelDownloadRepository.updateTotalBytes(download.id, totalFromServer);
       }
     }
   }
@@ -321,9 +349,9 @@ async function runDownload(download: ModelDownloadRow): Promise<void> {
   const expectedHash = model.sha256.toLowerCase();
   const isPlaceholder = /^0+$/.test(expectedHash);
   if (!isPlaceholder) {
-    const fs = await import('node:fs/promises');
-    const buf = await fs.readFile(partialPath);
-    const actual = createHash('sha256').update(buf).digest('hex');
+    // Stream the file through the hash — multi-GB GGUFs would OOM the
+    // API process if we readFile()'d the whole thing into memory.
+    const actual = await computeSha256(partialPath);
     if (actual !== expectedHash) {
       // Corrupt download. Delete the partial — user should retry,
       // and we don't want a half-bad GGUF lingering on disk.
@@ -382,4 +410,16 @@ export async function recoverOnBoot(): Promise<void> {
 export function ensureDirectory(filePath: string): void {
   const dir = dirname(filePath);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+/**
+ * Stream the file through a SHA-256 hash. Multi-GB GGUFs would OOM
+ * the API process if we loaded them into memory whole.
+ */
+async function computeSha256(path: string): Promise<string> {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(path)) {
+    hash.update(chunk as Buffer);
+  }
+  return hash.digest('hex');
 }

--- a/apps/api/src/embedded-llm/downloader.ts
+++ b/apps/api/src/embedded-llm/downloader.ts
@@ -1,0 +1,385 @@
+import { createHash } from 'node:crypto';
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import {
+  modelDownloadRepository,
+  type ModelDownloadRow,
+} from '@skytwin/db';
+import { findById as findModelById } from '@skytwin/embedded-llm';
+import { createLogger } from '@skytwin/core';
+
+const log = createLogger('api:embedded-llm:downloader');
+
+/**
+ * Default model directory when `SKYTWIN_LLAMA_MODELS` is unset:
+ * `~/.skytwin/models/llama`. Created lazily on first download.
+ *
+ * The runtime detector (#187 AC#1) reads `SKYTWIN_LLAMA_MODELS` to find
+ * GGUFs; we honor that env var as the override but provide a sensible
+ * default so a fresh install doesn't need any environment configuration.
+ */
+export function resolveModelDir(): string {
+  const fromEnv = process.env['SKYTWIN_LLAMA_MODELS'];
+  if (fromEnv !== undefined && fromEnv !== '') return fromEnv;
+  return join(homedir(), '.skytwin', 'models', 'llama');
+}
+
+/**
+ * Compute the absolute target path for a registry model. The basename
+ * is `<modelId>.gguf`. We never use the registry's URL filename — that
+ * could be anything (or could change over time without our control).
+ */
+export function targetPathFor(modelId: string): string {
+  return join(resolveModelDir(), `${modelId}.gguf`);
+}
+
+function partialPathFor(targetPath: string): string {
+  return `${targetPath}.partial`;
+}
+
+/**
+ * In-flight download registry. Lets `pause` flip a flag the streamer
+ * checks per chunk, and lets `cancel` abort the underlying request.
+ *
+ * Survives only the lifetime of the API process. Crash → DB row stays
+ * in 'downloading'; boot-time `recoverOrphanedDownloads` flips those
+ * to 'paused' so the user can manually resume.
+ */
+interface InFlightDownload {
+  controller: AbortController;
+  paused: boolean;
+  cancelled: boolean;
+}
+const inFlight = new Map<string, InFlightDownload>();
+
+export interface StartDownloadResult {
+  download: ModelDownloadRow;
+  resumed: boolean;
+}
+
+/**
+ * Start (or resume) a download. Idempotent on (userId, modelId): a
+ * pending/downloading/paused row is reused; only complete/failed/
+ * cancelled rows let a fresh start happen.
+ *
+ * The actual byte transfer runs asynchronously — caller gets the
+ * created/resumed row immediately and polls `/downloads/:id` for
+ * progress.
+ */
+export async function startDownload(
+  userId: string,
+  modelId: string,
+): Promise<StartDownloadResult> {
+  const model = findModelById(modelId);
+  if (!model) {
+    throw new Error(`unknown model id: ${modelId}`);
+  }
+
+  const dir = resolveModelDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const targetPath = targetPathFor(modelId);
+
+  const existing = await modelDownloadRepository.findActive(userId, modelId);
+  let download: ModelDownloadRow;
+  let resumed = false;
+
+  if (existing !== null) {
+    download = existing;
+    resumed = existing.bytes_downloaded > 0;
+  } else {
+    download = await modelDownloadRepository.create({
+      userId,
+      modelId,
+      targetPath,
+      totalBytes: model.approxBytes,
+      sha256Expected: model.sha256,
+    });
+  }
+
+  // Kick off the async transfer. Caller doesn't await this — it polls
+  // the row for status. Errors land in `error` + status='failed'.
+  void runDownload(download).catch((err) => {
+    log.warn('download runner threw', {
+      downloadId: download.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+
+  return { download, resumed };
+}
+
+/**
+ * Pause an in-flight download. Sets the in-memory flag (the streamer
+ * checks it per-chunk) and updates the DB row to 'paused'. The
+ * `<target_path>.partial` file stays on disk for resume.
+ *
+ * Pausing a non-active download (already complete / failed / cancelled
+ * / not-yet-started) is a no-op that returns `false`.
+ */
+export async function pauseDownload(downloadId: string): Promise<boolean> {
+  const row = await modelDownloadRepository.findById(downloadId);
+  if (!row) return false;
+  if (row.status !== 'downloading' && row.status !== 'pending') return false;
+
+  const handle = inFlight.get(downloadId);
+  if (handle) {
+    handle.paused = true;
+    handle.controller.abort();
+    inFlight.delete(downloadId);
+  }
+  await modelDownloadRepository.setStatus(downloadId, 'paused');
+  return true;
+}
+
+/**
+ * Cancel and clean up. Aborts in-flight transfer, deletes the
+ * `<target_path>.partial` file, marks the row 'cancelled'.
+ */
+export async function cancelDownload(downloadId: string): Promise<boolean> {
+  const row = await modelDownloadRepository.findById(downloadId);
+  if (!row) return false;
+  if (row.status === 'complete' || row.status === 'cancelled') return false;
+
+  const handle = inFlight.get(downloadId);
+  if (handle) {
+    handle.cancelled = true;
+    handle.controller.abort();
+    inFlight.delete(downloadId);
+  }
+
+  const partial = partialPathFor(row.target_path);
+  if (existsSync(partial)) {
+    try {
+      unlinkSync(partial);
+    } catch (err) {
+      log.warn('failed to delete partial file on cancel', {
+        downloadId,
+        partial,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  await modelDownloadRepository.setStatus(downloadId, 'cancelled');
+  return true;
+}
+
+/**
+ * Async byte transfer. Reads any existing `.partial` size, sends a
+ * Range request from there, streams to disk, updates progress every
+ * ~1MB. On EOF: SHA-256 verify (if registry hash isn't placeholder),
+ * atomic rename to final path, mark complete.
+ */
+async function runDownload(download: ModelDownloadRow): Promise<void> {
+  const model = findModelById(download.model_id);
+  if (!model) {
+    await modelDownloadRepository.setStatus(download.id, 'failed', {
+      error: `unknown model id: ${download.model_id}`,
+    });
+    return;
+  }
+
+  const partialPath = partialPathFor(download.target_path);
+  let resumeFrom = 0;
+  if (existsSync(partialPath)) {
+    try {
+      resumeFrom = statSync(partialPath).size;
+    } catch {
+      resumeFrom = 0;
+    }
+  }
+
+  const controller = new AbortController();
+  const handle: InFlightDownload = { controller, paused: false, cancelled: false };
+  inFlight.set(download.id, handle);
+
+  await modelDownloadRepository.setStatus(download.id, 'downloading', {
+    bytesDownloaded: resumeFrom,
+  });
+
+  let response: Response;
+  try {
+    const headers: Record<string, string> = {};
+    if (resumeFrom > 0) headers['Range'] = `bytes=${resumeFrom}-`;
+    response = await fetch(model.downloadUrl, {
+      headers,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    inFlight.delete(download.id);
+    if (handle.paused || handle.cancelled) return; // status already set
+    await modelDownloadRepository.setStatus(download.id, 'failed', {
+      error: `fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    return;
+  }
+
+  // 206 Partial Content (resume) or 200 OK (full). Any other status
+  // is a hard failure — the registry URL changed, was rate-limited,
+  // or the host is down.
+  if (response.status !== 200 && response.status !== 206) {
+    inFlight.delete(download.id);
+    await modelDownloadRepository.setStatus(download.id, 'failed', {
+      error: `HTTP ${response.status} from ${model.downloadUrl}`,
+    });
+    return;
+  }
+  // Range requests on a server that doesn't support them return 200
+  // with the whole body — start over from 0.
+  if (resumeFrom > 0 && response.status === 200) {
+    log.info('Server ignored Range header — restarting from 0', {
+      downloadId: download.id,
+    });
+    resumeFrom = 0;
+    if (existsSync(partialPath)) {
+      try { unlinkSync(partialPath); } catch { /* best effort */ }
+    }
+  }
+  if (response.body === null) {
+    inFlight.delete(download.id);
+    await modelDownloadRepository.setStatus(download.id, 'failed', {
+      error: 'response body was null',
+    });
+    return;
+  }
+
+  // Update total_bytes from Content-Length when the registry's
+  // approxBytes was off — the UI uses total_bytes for the progress bar
+  // denominator, so it should match what we're actually fetching.
+  const contentLength = response.headers.get('content-length');
+  if (contentLength !== null) {
+    const len = parseInt(contentLength, 10);
+    if (Number.isFinite(len) && len > 0) {
+      const totalFromServer = response.status === 206 ? resumeFrom + len : len;
+      if (Math.abs(totalFromServer - download.total_bytes) > 1024 * 1024) {
+        // Drift > 1MB — update so progress bar isn't lying.
+        await modelDownloadRepository.setStatus(download.id, 'downloading', {
+          bytesDownloaded: resumeFrom,
+        });
+      }
+    }
+  }
+
+  const PROGRESS_FLUSH_BYTES = 1024 * 1024; // flush DB every 1MB
+  let bytesSinceFlush = 0;
+  let totalBytes = resumeFrom;
+  const out = createWriteStream(partialPath, {
+    flags: resumeFrom > 0 ? 'a' : 'w',
+  });
+
+  // Convert the web-stream Response.body into a Node Readable so
+  // pipeline + abort signal work uniformly.
+  const nodeStream = Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]);
+
+  try {
+    nodeStream.on('data', (chunk: Buffer) => {
+      totalBytes += chunk.length;
+      bytesSinceFlush += chunk.length;
+      if (bytesSinceFlush >= PROGRESS_FLUSH_BYTES) {
+        bytesSinceFlush = 0;
+        // Fire-and-forget — don't await per-chunk writes
+        void modelDownloadRepository.updateProgress(download.id, totalBytes).catch(() => {});
+      }
+    });
+    await pipeline(nodeStream, out);
+  } catch (err) {
+    inFlight.delete(download.id);
+    if (handle.paused) {
+      await modelDownloadRepository.setStatus(download.id, 'paused', {
+        bytesDownloaded: totalBytes,
+      });
+      return;
+    }
+    if (handle.cancelled) return; // status already set by cancelDownload
+    await modelDownloadRepository.setStatus(download.id, 'failed', {
+      error: `transfer failed at ${totalBytes}/${download.total_bytes} bytes: ${err instanceof Error ? err.message : String(err)}`,
+      bytesDownloaded: totalBytes,
+    });
+    return;
+  }
+
+  inFlight.delete(download.id);
+  await modelDownloadRepository.setStatus(download.id, 'verifying', {
+    bytesDownloaded: totalBytes,
+  });
+
+  // Verify SHA-256 unless the registry hash is the placeholder. The v1
+  // registry ships with all-zeros sha256 fields pending real artifact
+  // measurement; we still ship the verification path because the field
+  // will get filled in upstream and we don't want a "the day we fill
+  // in real hashes" code change.
+  const expectedHash = model.sha256.toLowerCase();
+  const isPlaceholder = /^0+$/.test(expectedHash);
+  if (!isPlaceholder) {
+    const fs = await import('node:fs/promises');
+    const buf = await fs.readFile(partialPath);
+    const actual = createHash('sha256').update(buf).digest('hex');
+    if (actual !== expectedHash) {
+      // Corrupt download. Delete the partial — user should retry,
+      // and we don't want a half-bad GGUF lingering on disk.
+      try { unlinkSync(partialPath); } catch { /* best effort */ }
+      await modelDownloadRepository.setStatus(download.id, 'failed', {
+        error: `sha256 mismatch: expected ${expectedHash}, got ${actual}`,
+        bytesDownloaded: 0,
+      });
+      return;
+    }
+  }
+
+  await modelDownloadRepository.setStatus(download.id, 'installing');
+  // Atomic rename — partial → final. Same filesystem so this is O(1).
+  try {
+    if (existsSync(download.target_path)) unlinkSync(download.target_path);
+    renameSync(partialPath, download.target_path);
+  } catch (err) {
+    await modelDownloadRepository.setStatus(download.id, 'failed', {
+      error: `install (rename) failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    return;
+  }
+
+  await modelDownloadRepository.setStatus(download.id, 'complete');
+  log.info('Model download complete', {
+    downloadId: download.id,
+    modelId: download.model_id,
+    targetPath: download.target_path,
+  });
+}
+
+/**
+ * Boot-time recovery. Called once on API startup before any download
+ * route is served — flips orphaned 'downloading' rows to 'paused' so
+ * the user can resume.
+ */
+export async function recoverOnBoot(): Promise<void> {
+  try {
+    const recovered = await modelDownloadRepository.recoverOrphanedDownloads();
+    if (recovered > 0) {
+      log.info('Recovered orphaned model downloads to paused', { count: recovered });
+    }
+  } catch (err) {
+    // Don't crash the API if recovery fails — just log.
+    log.warn('Failed to recover orphaned downloads', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Helper used by the dirname-only check in tests. Exported so the
+ * route handler doesn't need to import `node:path` separately.
+ */
+export function ensureDirectory(filePath: string): void {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -40,6 +40,7 @@ import { createFederationRouter } from './routes/federation.js';
 import { createVoiceRouter } from './routes/voice.js';
 import { createCrisisModesRouter } from './routes/crisis-modes.js';
 import { createEmbeddedLlmRouter } from './routes/embedded-llm.js';
+import { recoverOnBoot as recoverEmbeddedLlmDownloads } from './embedded-llm/downloader.js';
 import { getExecutionRouter } from './execution-setup.js';
 import { startMdnsAdvertisement, stopMdnsAdvertisement } from './mdns.js';
 import { closePool, mcpServerMetricsRepository } from '@skytwin/db';
@@ -85,6 +86,15 @@ if (configErrors.length > 0) {
 // Initialize the execution router early to log adapter registration
 getExecutionRouter().catch((err) =>
   log.error('Failed to initialize execution router', {
+    error: err instanceof Error ? err.message : String(err),
+  }),
+);
+
+// Boot-time recovery for orphaned model downloads (#187 AC#2). Any row
+// stuck in 'downloading' from a prior process flips to 'paused' so the
+// user can resume manually. Best-effort — never blocks startup.
+recoverEmbeddedLlmDownloads().catch((err) =>
+  log.warn('Failed to recover orphaned model downloads', {
     error: err instanceof Error ? err.message : String(err),
   }),
 );

--- a/apps/api/src/routes/embedded-llm.ts
+++ b/apps/api/src/routes/embedded-llm.ts
@@ -5,31 +5,42 @@ import {
   recommendDefault,
   type RamBracket,
 } from '@skytwin/embedded-llm';
+import { modelDownloadRepository } from '@skytwin/db';
 import { bindUserIdParamOwnership } from '../middleware/require-ownership.js';
+import {
+  cancelDownload,
+  pauseDownload,
+  resolveModelDir,
+  startDownload,
+} from '../embedded-llm/downloader.js';
 
 /**
- * Embedded LLM model registry routes (#187 AC#5).
+ * Embedded LLM routes (#187 AC#2 + AC#5).
  *
+ * Catalog (AC#5):
  *   GET  /api/embedded-llm/registry
- *     Returns the curated model list grouped by RAM bracket.
- *
  *   GET  /api/embedded-llm/upgrade-check?currentId=<id>
- *     Returns `{ upgrade: UpgradeRecommendation | null }`. Clients call
- *     this on app start to decide whether to surface the "your twin can
- *     be N% smarter" prompt.
+ *   GET  /api/embedded-llm/recommend-default?bracket=<bucket>
  *
- *   GET  /api/embedded-llm/recommend-default?bracket=<4gb|8gb|16gb|32gb-plus>
- *     Returns the highest-quality model in the bracket — used by the
- *     first-run flow.
- *
- * The registry itself is a static, hand-curated list shipped with the
- * `@skytwin/embedded-llm` package. No external HTTP. The downloader UI
- * (#187 AC#2) consumes the `downloadUrl` field; this API just exposes
- * the catalog.
+ * Downloader (AC#2):
+ *   GET  /api/embedded-llm/model-dir
+ *     Reports the resolved model directory the API will write to —
+ *     useful for "where's my model going?" debugging UX.
+ *   POST /api/embedded-llm/downloads/start    body: { userId, modelId }
+ *     Idempotent on (userId, modelId). Returns the row + `resumed` flag.
+ *   GET  /api/embedded-llm/downloads/:id
+ *     Polled by the UI every ~1s during active download.
+ *   GET  /api/embedded-llm/downloads/user/:userId
+ *     List for a user — surfaces "in progress" + "completed" history.
+ *   POST /api/embedded-llm/downloads/:id/pause
+ *   POST /api/embedded-llm/downloads/:id/resume
+ *   POST /api/embedded-llm/downloads/:id/cancel
  */
 export function createEmbeddedLlmRouter(): Router {
   const router = Router();
   bindUserIdParamOwnership(router);
+
+  // ── Catalog (AC#5) ────────────────────────────────────────────
 
   router.get('/registry', (_req, res) => {
     res.json({ models: MODEL_REGISTRY });
@@ -56,5 +67,139 @@ export function createEmbeddedLlmRouter(): Router {
     res.json({ model });
   });
 
+  // ── Downloader (AC#2) ─────────────────────────────────────────
+
+  router.get('/model-dir', (_req, res) => {
+    res.json({ modelDir: resolveModelDir() });
+  });
+
+  router.post('/downloads/start', async (req, res, next) => {
+    try {
+      const body = req.body as Record<string, unknown>;
+      const userId = body['userId'];
+      const modelId = body['modelId'];
+      if (typeof userId !== 'string' || userId.length === 0) {
+        res.status(400).json({ error: 'userId required' });
+        return;
+      }
+      if (typeof modelId !== 'string' || modelId.length === 0) {
+        res.status(400).json({ error: 'modelId required' });
+        return;
+      }
+      try {
+        const result = await startDownload(userId, modelId);
+        res.json({
+          download: rowToJson(result.download),
+          resumed: result.resumed,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (/^unknown model id/.test(msg)) {
+          res.status(404).json({ error: msg });
+          return;
+        }
+        throw err;
+      }
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/downloads/user/:userId', async (req, res, next) => {
+    try {
+      const { userId } = req.params;
+      if (!userId) { res.status(400).json({ error: 'userId required' }); return; }
+      const rows = await modelDownloadRepository.listForUser(userId);
+      res.json({ downloads: rows.map(rowToJson) });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/downloads/:id', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      if (!id) { res.status(400).json({ error: 'id required' }); return; }
+      const row = await modelDownloadRepository.findById(id);
+      if (!row) { res.status(404).json({ error: 'download not found' }); return; }
+      res.json({ download: rowToJson(row) });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/downloads/:id/pause', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      if (!id) { res.status(400).json({ error: 'id required' }); return; }
+      const ok = await pauseDownload(id);
+      res.json({ ok });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/downloads/:id/resume', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      if (!id) { res.status(400).json({ error: 'id required' }); return; }
+      const row = await modelDownloadRepository.findById(id);
+      if (!row) { res.status(404).json({ error: 'download not found' }); return; }
+      // Resume re-runs `startDownload` for this row's (userId, modelId).
+      // The function's idempotent-on-active-row behavior picks up the
+      // existing row and continues from `bytes_downloaded`.
+      const result = await startDownload(row.user_id, row.model_id);
+      res.json({ download: rowToJson(result.download), resumed: result.resumed });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/downloads/:id/cancel', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      if (!id) { res.status(400).json({ error: 'id required' }); return; }
+      const ok = await cancelDownload(id);
+      res.json({ ok });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   return router;
+}
+
+interface DownloadJson {
+  id: string;
+  modelId: string;
+  targetPath: string;
+  totalBytes: number;
+  bytesDownloaded: number;
+  status: string;
+  error: string | null;
+  startedAt: string;
+  pausedAt: string | null;
+  completedAt: string | null;
+  percent: number;
+}
+
+function rowToJson(r: import('@skytwin/db').ModelDownloadRow): DownloadJson {
+  const totalBytes = Number(r.total_bytes);
+  const bytesDownloaded = Number(r.bytes_downloaded);
+  const percent = totalBytes > 0
+    ? Math.min(100, Math.round((bytesDownloaded / totalBytes) * 100))
+    : 0;
+  return {
+    id: r.id,
+    modelId: r.model_id,
+    targetPath: r.target_path,
+    totalBytes,
+    bytesDownloaded,
+    status: r.status,
+    error: r.error,
+    startedAt: r.started_at.toISOString(),
+    pausedAt: r.paused_at?.toISOString() ?? null,
+    completedAt: r.completed_at?.toISOString() ?? null,
+    percent,
+  };
 }

--- a/apps/api/src/routes/embedded-llm.ts
+++ b/apps/api/src/routes/embedded-llm.ts
@@ -1,18 +1,50 @@
-import { Router } from 'express';
+import { Router, type Request, type Response } from 'express';
 import {
   MODEL_REGISTRY,
   checkForUpgrade,
   recommendDefault,
   type RamBracket,
 } from '@skytwin/embedded-llm';
-import { modelDownloadRepository } from '@skytwin/db';
-import { bindUserIdParamOwnership } from '../middleware/require-ownership.js';
+import { modelDownloadRepository, type ModelDownloadRow } from '@skytwin/db';
+import {
+  bindUserIdParamOwnership,
+  requireOwnership,
+} from '../middleware/require-ownership.js';
 import {
   cancelDownload,
   pauseDownload,
   resolveModelDir,
   startDownload,
 } from '../embedded-llm/downloader.js';
+
+/**
+ * Fetch a download row and enforce that the authenticated user owns
+ * it. In dev-bypass mode (`req.authenticatedUserId === undefined`) the
+ * ownership check is skipped, matching `requireOwnership`'s contract.
+ *
+ * Returns the row on success, or null if the response has already been
+ * sent (404 / 403).
+ */
+async function loadOwnedDownload(
+  req: Request,
+  res: Response,
+  id: string,
+): Promise<ModelDownloadRow | null> {
+  const row = await modelDownloadRepository.findById(id);
+  if (!row) {
+    res.status(404).json({ error: 'download not found' });
+    return null;
+  }
+  const authUserId = req.authenticatedUserId;
+  if (authUserId !== undefined && authUserId !== row.user_id) {
+    res.status(403).json({
+      error: 'Forbidden',
+      message: 'You do not have access to this resource.',
+    });
+    return null;
+  }
+  return row;
+}
 
 /**
  * Embedded LLM routes (#187 AC#2 + AC#5).
@@ -73,7 +105,7 @@ export function createEmbeddedLlmRouter(): Router {
     res.json({ modelDir: resolveModelDir() });
   });
 
-  router.post('/downloads/start', async (req, res, next) => {
+  router.post('/downloads/start', requireOwnership, async (req, res, next) => {
     try {
       const body = req.body as Record<string, unknown>;
       const userId = body['userId'];
@@ -120,8 +152,8 @@ export function createEmbeddedLlmRouter(): Router {
     try {
       const { id } = req.params;
       if (!id) { res.status(400).json({ error: 'id required' }); return; }
-      const row = await modelDownloadRepository.findById(id);
-      if (!row) { res.status(404).json({ error: 'download not found' }); return; }
+      const row = await loadOwnedDownload(req, res, id);
+      if (!row) return;
       res.json({ download: rowToJson(row) });
     } catch (err) {
       next(err);
@@ -132,6 +164,8 @@ export function createEmbeddedLlmRouter(): Router {
     try {
       const { id } = req.params;
       if (!id) { res.status(400).json({ error: 'id required' }); return; }
+      const row = await loadOwnedDownload(req, res, id);
+      if (!row) return;
       const ok = await pauseDownload(id);
       res.json({ ok });
     } catch (err) {
@@ -143,8 +177,8 @@ export function createEmbeddedLlmRouter(): Router {
     try {
       const { id } = req.params;
       if (!id) { res.status(400).json({ error: 'id required' }); return; }
-      const row = await modelDownloadRepository.findById(id);
-      if (!row) { res.status(404).json({ error: 'download not found' }); return; }
+      const row = await loadOwnedDownload(req, res, id);
+      if (!row) return;
       // Resume re-runs `startDownload` for this row's (userId, modelId).
       // The function's idempotent-on-active-row behavior picks up the
       // existing row and continues from `bytes_downloaded`.
@@ -159,6 +193,8 @@ export function createEmbeddedLlmRouter(): Router {
     try {
       const { id } = req.params;
       if (!id) { res.status(400).json({ error: 'id required' }); return; }
+      const row = await loadOwnedDownload(req, res, id);
+      if (!row) return;
       const ok = await cancelDownload(id);
       res.json({ ok });
     } catch (err) {

--- a/apps/web/public/js/api-client.js
+++ b/apps/web/public/js/api-client.js
@@ -893,6 +893,53 @@ export function unpairFederationPeer(userId, peerId) {
   );
 }
 
+// ── Embedded LLM downloads (#187 AC#2) ────────────────────────────────────────
+
+export function fetchEmbeddedLlmRegistry() {
+  return fetchJSON(`${API}/embedded-llm/registry`);
+}
+
+export function fetchEmbeddedLlmModelDir() {
+  return fetchJSON(`${API}/embedded-llm/model-dir`);
+}
+
+export function recommendEmbeddedDefault(bracket) {
+  return fetchJSON(`${API}/embedded-llm/recommend-default?bracket=${encodeURIComponent(bracket)}`);
+}
+
+export function startModelDownload(userId, modelId) {
+  return fetchJSON(`${API}/embedded-llm/downloads/start`, {
+    method: 'POST',
+    body: JSON.stringify({ userId, modelId }),
+  });
+}
+
+export function fetchModelDownload(downloadId) {
+  return fetchJSON(`${API}/embedded-llm/downloads/${encodeURIComponent(downloadId)}`);
+}
+
+export function listUserModelDownloads(userId) {
+  return fetchJSON(`${API}/embedded-llm/downloads/user/${encodeURIComponent(userId)}`);
+}
+
+export function pauseModelDownload(downloadId) {
+  return fetchJSON(`${API}/embedded-llm/downloads/${encodeURIComponent(downloadId)}/pause`, {
+    method: 'POST',
+  });
+}
+
+export function resumeModelDownload(downloadId) {
+  return fetchJSON(`${API}/embedded-llm/downloads/${encodeURIComponent(downloadId)}/resume`, {
+    method: 'POST',
+  });
+}
+
+export function cancelModelDownload(downloadId) {
+  return fetchJSON(`${API}/embedded-llm/downloads/${encodeURIComponent(downloadId)}/cancel`, {
+    method: 'POST',
+  });
+}
+
 // ── Onboarding (issue #181) ───────────────────────────────────────────────────
 
 export function fetchOnboardingState(userId) {

--- a/apps/web/public/js/components/embedded-llm-card.js
+++ b/apps/web/public/js/components/embedded-llm-card.js
@@ -22,7 +22,18 @@ import {
   resumeModelDownload,
   startModelDownload,
 } from '../api-client.js';
+import { KEY_USER_ID } from '../storage-keys.js';
 import { showErrorToast, showSavedToast } from '../toast.js';
+
+const CARD_TARGET_ID = 'embedded-llm-card-target';
+
+function getCurrentUserId() {
+  try {
+    return localStorage.getItem(KEY_USER_ID) || '';
+  } catch {
+    return '';
+  }
+}
 
 const ACTIVE_STATUSES = new Set(['pending', 'downloading', 'verifying', 'installing']);
 
@@ -105,11 +116,11 @@ function downloadCardHtml(download, modelName) {
     <div style="margin-top: 0.75rem;">
       <div style="display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; margin-bottom: 0.4rem;">
         <span style="font-weight: 500;">${escapeHtml(modelName)}</span>
-        <span style="font-size: 0.8rem; color: ${isError ? 'var(--danger)' : 'var(--text-muted)'};">${escapeHtml(statusLabel(status))}</span>
+        <span data-role="embedded-llm-status" style="font-size: 0.8rem; color: ${isError ? 'var(--danger)' : 'var(--text-muted)'};">${escapeHtml(statusLabel(status))}</span>
       </div>
       ${progressBarHtml(percent)}
       <div style="display: flex; justify-content: space-between; align-items: center; margin-top: 0.4rem; font-size: 0.75rem; color: var(--text-muted);">
-        <span>${bytesSoFar} / ${totalSize} · ${percent}%</span>
+        <span data-role="embedded-llm-progress-text">${bytesSoFar} / ${totalSize} · ${percent}%</span>
         <span style="display: flex; gap: 0.4rem;">${actionButtons}</span>
       </div>
       ${isError && download.error ? `<div style="margin-top: 0.5rem; font-size: 0.75rem; color: var(--danger);">${escapeHtml(download.error)}</div>` : ''}
@@ -215,21 +226,17 @@ function startPolling(container, userId, downloadId) {
         return;
       }
       // Active mid-download: just update the visible progress without
-      // re-fetching the registry.
+      // re-fetching the registry. Targeted updates via data-role
+      // selectors so the action-button span isn't disturbed.
       const fillEl = container.querySelector('.confidence-fill');
       if (fillEl instanceof HTMLElement) {
         fillEl.style.width = `${dl.percent}%`;
       }
       const bar = container.querySelector('[role="progressbar"]');
       if (bar) bar.setAttribute('aria-valuenow', String(dl.percent));
-      const labelLine = container.querySelector('#embedded-llm-card div[style*="font-size: 0.75rem"]');
-      if (labelLine) {
-        labelLine.firstElementChild?.replaceWith?.(document.createTextNode(''));
-        // Simpler: replace the size+percent text node only
-        const sizeSpan = labelLine.querySelector('span');
-        if (sizeSpan) {
-          sizeSpan.textContent = `${formatBytes(dl.bytesDownloaded)} / ${formatBytes(dl.totalBytes)} · ${dl.percent}%`;
-        }
+      const progressText = container.querySelector('[data-role="embedded-llm-progress-text"]');
+      if (progressText) {
+        progressText.textContent = `${formatBytes(dl.bytesDownloaded)} / ${formatBytes(dl.totalBytes)} · ${dl.percent}%`;
       }
     } catch {
       // Best-effort poll. The next render will pick up state.
@@ -246,10 +253,15 @@ function stopPolling() {
 }
 
 let _listenerWired = false;
-function ensureListener(container, userId) {
+function ensureListener() {
   if (_listenerWired) return;
   _listenerWired = true;
 
+  // Singleton document-level delegator. We deliberately don't close
+  // over `container` or `userId` — `renderSettings()` creates a new
+  // `#embedded-llm-card-target` element on every navigation, and a
+  // captured reference would point at a detached DOM node. Both are
+  // re-derived inside the handler from the current document state.
   document.addEventListener('click', async (e) => {
     const hash = (window.location.hash || '').split('?')[0];
     if (hash !== '#/settings') return;
@@ -258,6 +270,11 @@ function ensureListener(container, userId) {
     const el = target.closest('[data-action]');
     if (!el) return;
     const action = el.getAttribute('data-action');
+
+    const container = document.getElementById(CARD_TARGET_ID);
+    if (!container) return;
+    const userId = getCurrentUserId();
+    if (!userId) return;
 
     if (action === 'embedded-start-download') {
       const sel = container.querySelector('#embedded-model-select');
@@ -318,6 +335,6 @@ function ensureListener(container, userId) {
  */
 export async function mountEmbeddedLlmCard(container, userId) {
   if (!container) return;
-  ensureListener(container, userId);
+  ensureListener();
   await renderCardInto(container, userId);
 }

--- a/apps/web/public/js/components/embedded-llm-card.js
+++ b/apps/web/public/js/components/embedded-llm-card.js
@@ -1,0 +1,323 @@
+/**
+ * Settings → Local AI brain card (#187 AC#2).
+ *
+ * Shows detected runtime, currently-installed model (or "no model yet"),
+ * recommends a default for the user's RAM bracket, and surfaces an
+ * in-progress download with progress bar + pause/resume/cancel.
+ *
+ * Polling cadence: while a download is active (status in
+ * downloading/verifying/installing), poll every 1s. Otherwise no
+ * polling — the card re-fetches on every settings render.
+ */
+
+import {
+  cancelModelDownload,
+  escapeHtml,
+  fetchEmbeddedLlmModelDir,
+  fetchEmbeddedLlmRegistry,
+  fetchModelDownload,
+  listUserModelDownloads,
+  pauseModelDownload,
+  recommendEmbeddedDefault,
+  resumeModelDownload,
+  startModelDownload,
+} from '../api-client.js';
+import { showErrorToast, showSavedToast } from '../toast.js';
+
+const ACTIVE_STATUSES = new Set(['pending', 'downloading', 'verifying', 'installing']);
+
+const POLL_INTERVAL_MS = 1000;
+
+let _pollTimer = null;
+let _activeDownloadId = null;
+
+/**
+ * Estimate the user's RAM bracket. Browsers don't expose system RAM
+ * directly; `navigator.deviceMemory` reports a coarse Gigabyte value
+ * (4, 8, 16, 32) but is missing on Safari. Fall back to '8gb' — the
+ * most common bucket for a 2024-era laptop.
+ */
+function detectBracket() {
+  const dm = typeof navigator !== 'undefined' ? navigator.deviceMemory : undefined;
+  if (typeof dm !== 'number') return '8gb';
+  if (dm <= 4) return '4gb';
+  if (dm <= 8) return '8gb';
+  if (dm <= 16) return '16gb';
+  return '32gb-plus';
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function statusLabel(status) {
+  switch (status) {
+    case 'pending': return 'Starting…';
+    case 'downloading': return 'Downloading';
+    case 'paused': return 'Paused';
+    case 'verifying': return 'Verifying integrity…';
+    case 'installing': return 'Installing…';
+    case 'complete': return 'Ready';
+    case 'failed': return 'Failed';
+    case 'cancelled': return 'Cancelled';
+    default: return status;
+  }
+}
+
+function progressBarHtml(percent) {
+  const clamped = Math.max(0, Math.min(100, Math.round(percent)));
+  return `
+    <div class="confidence-bar" role="progressbar" aria-valuenow="${clamped}" aria-valuemin="0" aria-valuemax="100" aria-label="Download progress">
+      <div class="confidence-fill high" style="width: ${clamped}%;"></div>
+    </div>
+  `;
+}
+
+function downloadCardHtml(download, modelName) {
+  const status = download.status;
+  const percent = download.percent ?? 0;
+  const bytesSoFar = formatBytes(download.bytesDownloaded);
+  const totalSize = formatBytes(download.totalBytes);
+  const isActive = ACTIVE_STATUSES.has(status);
+  const isPaused = status === 'paused';
+  const isError = status === 'failed';
+
+  const actionButtons = (() => {
+    if (isActive) {
+      return `<button class="btn btn-outline btn-sm" data-action="embedded-pause-download" data-download-id="${escapeHtml(download.id)}">Pause</button>
+              <button class="btn btn-outline btn-sm" data-action="embedded-cancel-download" data-download-id="${escapeHtml(download.id)}">Cancel</button>`;
+    }
+    if (isPaused) {
+      return `<button class="btn btn-primary btn-sm" data-action="embedded-resume-download" data-download-id="${escapeHtml(download.id)}">Resume</button>
+              <button class="btn btn-outline btn-sm" data-action="embedded-cancel-download" data-download-id="${escapeHtml(download.id)}">Cancel</button>`;
+    }
+    if (isError) {
+      return `<button class="btn btn-primary btn-sm" data-action="embedded-resume-download" data-download-id="${escapeHtml(download.id)}">Retry</button>`;
+    }
+    return '';
+  })();
+
+  return `
+    <div style="margin-top: 0.75rem;">
+      <div style="display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; margin-bottom: 0.4rem;">
+        <span style="font-weight: 500;">${escapeHtml(modelName)}</span>
+        <span style="font-size: 0.8rem; color: ${isError ? 'var(--danger)' : 'var(--text-muted)'};">${escapeHtml(statusLabel(status))}</span>
+      </div>
+      ${progressBarHtml(percent)}
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-top: 0.4rem; font-size: 0.75rem; color: var(--text-muted);">
+        <span>${bytesSoFar} / ${totalSize} · ${percent}%</span>
+        <span style="display: flex; gap: 0.4rem;">${actionButtons}</span>
+      </div>
+      ${isError && download.error ? `<div style="margin-top: 0.5rem; font-size: 0.75rem; color: var(--danger);">${escapeHtml(download.error)}</div>` : ''}
+    </div>
+  `;
+}
+
+/**
+ * Render the entire card. Idempotent — call again any time state
+ * changes and the DOM gets replaced atomically.
+ */
+async function renderCardInto(container, userId) {
+  const [registryRes, dirRes, listRes] = await Promise.allSettled([
+    fetchEmbeddedLlmRegistry(),
+    fetchEmbeddedLlmModelDir(),
+    listUserModelDownloads(userId),
+  ]);
+  const models = registryRes.status === 'fulfilled' && Array.isArray(registryRes.value?.models)
+    ? registryRes.value.models
+    : [];
+  const modelDir = dirRes.status === 'fulfilled' ? dirRes.value?.modelDir ?? '' : '';
+  const downloads = listRes.status === 'fulfilled' && Array.isArray(listRes.value?.downloads)
+    ? listRes.value.downloads
+    : [];
+
+  const active = downloads.find((d) => ACTIVE_STATUSES.has(d.status))
+    ?? downloads.find((d) => d.status === 'paused' || d.status === 'failed');
+  const completed = downloads.find((d) => d.status === 'complete');
+
+  const bracket = detectBracket();
+  let recommended = null;
+  try {
+    const rec = await recommendEmbeddedDefault(bracket);
+    recommended = rec?.model ?? null;
+  } catch { /* leave null */ }
+
+  const recommendedSize = recommended
+    ? `${(recommended.approxBytes / (1024 ** 3)).toFixed(1)} GB`
+    : '';
+  const modelOptionsHtml = models.map((m) => {
+    const sizeGb = (m.approxBytes / (1024 ** 3)).toFixed(1);
+    const isRec = recommended && m.id === recommended.id;
+    return `<option value="${escapeHtml(m.id)}" ${isRec ? 'selected' : ''}>${escapeHtml(m.displayName)} · ${sizeGb} GB · ${escapeHtml(m.ramBracket)}${isRec ? ' (recommended)' : ''}</option>`;
+  }).join('');
+
+  let body = '';
+  if (completed && !active) {
+    body = `
+      <div style="padding: 0.75rem; background: var(--bg); border-radius: var(--radius-sm);">
+        <div style="font-weight: 500; color: var(--success);">✓ Your twin's brain is installed</div>
+        <div style="font-size: 0.8rem; color: var(--text-muted); margin-top: 0.25rem;">
+          ${escapeHtml(completed.modelId)} · saved to <code>${escapeHtml(completed.targetPath)}</code>
+        </div>
+      </div>
+    `;
+  } else if (active) {
+    const modelMeta = models.find((m) => m.id === active.modelId);
+    body = downloadCardHtml(active, modelMeta?.displayName ?? active.modelId);
+  } else {
+    body = `
+      <div style="font-size: 0.85rem; color: var(--text-muted); margin-bottom: 0.75rem;">
+        Your twin works fully offline once a brain is installed. We'll download it once and save it to <code>${escapeHtml(modelDir)}</code>. No API keys, no per-message costs.
+      </div>
+      <div style="display: flex; gap: 0.5rem; align-items: stretch;">
+        <select class="form-input" id="embedded-model-select" style="flex: 1;">
+          ${modelOptionsHtml}
+        </select>
+        <button class="btn btn-primary btn-sm" data-action="embedded-start-download">Download</button>
+      </div>
+      ${recommended ? `<div style="font-size: 0.75rem; color: var(--text-muted); margin-top: 0.5rem;">Recommended for your machine: <strong>${escapeHtml(recommended.displayName)}</strong> (${recommendedSize}).</div>` : ''}
+    `;
+  }
+
+  container.innerHTML = `
+    <div class="card" id="embedded-llm-card">
+      <div class="card-header">
+        <span class="card-title">Local AI brain</span>
+      </div>
+      ${body}
+    </div>
+  `;
+
+  // Manage polling: poll while we have an active download.
+  if (active && ACTIVE_STATUSES.has(active.status)) {
+    startPolling(container, userId, active.id);
+  } else {
+    stopPolling();
+  }
+}
+
+function startPolling(container, userId, downloadId) {
+  if (_activeDownloadId === downloadId && _pollTimer !== null) return;
+  stopPolling();
+  _activeDownloadId = downloadId;
+  _pollTimer = setInterval(async () => {
+    try {
+      const data = await fetchModelDownload(downloadId);
+      const dl = data?.download;
+      if (!dl || !ACTIVE_STATUSES.has(dl.status)) {
+        // Status changed — re-render entire card (transitions to
+        // verifying / installing / complete / failed).
+        await renderCardInto(container, userId);
+        return;
+      }
+      // Active mid-download: just update the visible progress without
+      // re-fetching the registry.
+      const fillEl = container.querySelector('.confidence-fill');
+      if (fillEl instanceof HTMLElement) {
+        fillEl.style.width = `${dl.percent}%`;
+      }
+      const bar = container.querySelector('[role="progressbar"]');
+      if (bar) bar.setAttribute('aria-valuenow', String(dl.percent));
+      const labelLine = container.querySelector('#embedded-llm-card div[style*="font-size: 0.75rem"]');
+      if (labelLine) {
+        labelLine.firstElementChild?.replaceWith?.(document.createTextNode(''));
+        // Simpler: replace the size+percent text node only
+        const sizeSpan = labelLine.querySelector('span');
+        if (sizeSpan) {
+          sizeSpan.textContent = `${formatBytes(dl.bytesDownloaded)} / ${formatBytes(dl.totalBytes)} · ${dl.percent}%`;
+        }
+      }
+    } catch {
+      // Best-effort poll. The next render will pick up state.
+    }
+  }, POLL_INTERVAL_MS);
+}
+
+function stopPolling() {
+  if (_pollTimer !== null) {
+    clearInterval(_pollTimer);
+    _pollTimer = null;
+  }
+  _activeDownloadId = null;
+}
+
+let _listenerWired = false;
+function ensureListener(container, userId) {
+  if (_listenerWired) return;
+  _listenerWired = true;
+
+  document.addEventListener('click', async (e) => {
+    const hash = (window.location.hash || '').split('?')[0];
+    if (hash !== '#/settings') return;
+    const target = e.target instanceof Element ? e.target : null;
+    if (!target) return;
+    const el = target.closest('[data-action]');
+    if (!el) return;
+    const action = el.getAttribute('data-action');
+
+    if (action === 'embedded-start-download') {
+      const sel = container.querySelector('#embedded-model-select');
+      const modelId = sel instanceof HTMLSelectElement ? sel.value : '';
+      if (!modelId) return;
+      try {
+        await startModelDownload(userId, modelId);
+        showSavedToast('Download started');
+        await renderCardInto(container, userId);
+      } catch (err) {
+        showErrorToast(`Couldn't start download: ${err?.friendlyMessage || err?.message || 'unknown error'}`);
+      }
+      return;
+    }
+    if (action === 'embedded-pause-download') {
+      const id = el.getAttribute('data-download-id');
+      if (!id) return;
+      try {
+        await pauseModelDownload(id);
+        showSavedToast('Paused');
+        await renderCardInto(container, userId);
+      } catch (err) {
+        showErrorToast(`Couldn't pause: ${err?.message ?? 'unknown error'}`);
+      }
+      return;
+    }
+    if (action === 'embedded-resume-download') {
+      const id = el.getAttribute('data-download-id');
+      if (!id) return;
+      try {
+        await resumeModelDownload(id);
+        showSavedToast('Resumed');
+        await renderCardInto(container, userId);
+      } catch (err) {
+        showErrorToast(`Couldn't resume: ${err?.message ?? 'unknown error'}`);
+      }
+      return;
+    }
+    if (action === 'embedded-cancel-download') {
+      const id = el.getAttribute('data-download-id');
+      if (!id) return;
+      if (!confirm('Cancel the download? The partial file will be deleted.')) return;
+      try {
+        await cancelModelDownload(id);
+        showSavedToast('Cancelled');
+        await renderCardInto(container, userId);
+      } catch (err) {
+        showErrorToast(`Couldn't cancel: ${err?.message ?? 'unknown error'}`);
+      }
+      return;
+    }
+  });
+}
+
+/**
+ * Mount the card into a container. Settings page calls this once per
+ * render. Idempotent listener wiring + replaceable polling.
+ */
+export async function mountEmbeddedLlmCard(container, userId) {
+  if (!container) return;
+  ensureListener(container, userId);
+  await renderCardInto(container, userId);
+}

--- a/apps/web/public/js/components/embedded-llm-card.js
+++ b/apps/web/public/js/components/embedded-llm-card.js
@@ -35,7 +35,14 @@ function getCurrentUserId() {
   }
 }
 
+// Statuses that mean "something is in flight" — drives the polling
+// loop and keeps the card showing a progress UI rather than the picker.
 const ACTIVE_STATUSES = new Set(['pending', 'downloading', 'verifying', 'installing']);
+// Subset where the backend can actually pause. pauseDownload() returns
+// ok:false for verifying/installing, so we hide the Pause button there.
+// Cancel still works through verify/install — the runner checks the
+// cancelled flag at phase boundaries.
+const PAUSABLE_STATUSES = new Set(['pending', 'downloading']);
 
 const POLL_INTERVAL_MS = 1000;
 
@@ -94,12 +101,16 @@ function downloadCardHtml(download, modelName) {
   const bytesSoFar = formatBytes(download.bytesDownloaded);
   const totalSize = formatBytes(download.totalBytes);
   const isActive = ACTIVE_STATUSES.has(status);
+  const isPausable = PAUSABLE_STATUSES.has(status);
   const isPaused = status === 'paused';
   const isError = status === 'failed';
 
   const actionButtons = (() => {
     if (isActive) {
-      return `<button class="btn btn-outline btn-sm" data-action="embedded-pause-download" data-download-id="${escapeHtml(download.id)}">Pause</button>
+      const pauseBtn = isPausable
+        ? `<button class="btn btn-outline btn-sm" data-action="embedded-pause-download" data-download-id="${escapeHtml(download.id)}">Pause</button>`
+        : '';
+      return `${pauseBtn}
               <button class="btn btn-outline btn-sm" data-action="embedded-cancel-download" data-download-id="${escapeHtml(download.id)}">Cancel</button>`;
     }
     if (isPaused) {

--- a/apps/web/public/js/pages/settings.js
+++ b/apps/web/public/js/pages/settings.js
@@ -1,5 +1,6 @@
 import { fetchUser, updateTrustTier, fetchOAuthStatus, getGoogleAuthUrl, disconnectProvider, escapeHtml, fetchSettings, updateAutonomySettings, updateIronClawChannel, upsertDomainPolicy, deleteDomainPolicy, createEscalationTrigger, deleteEscalationTrigger, createSession, fetchSessions, revokeSession, saveAIProviders, testAIProvider, fetchRoutines, deleteRoutine, startFederationPairing, completeFederationPairing, listFederationPeers, unpairFederationPeer } from '../api-client.js';
 import { mountThemeSwitcher } from '../theme-switcher.js';
+import { mountEmbeddedLlmCard } from '../components/embedded-llm-card.js';
 import {
   getTextScale, setTextScale,
   getReducedMotion, setReducedMotion,
@@ -113,6 +114,8 @@ export async function renderSettings(container, userId) {
       </div>
       <div id="theme-switcher-target"></div>
     </div>
+
+    <div id="embedded-llm-card-target"></div>
 
     <div class="card" id="a11y-settings-card">
       <div class="card-header">
@@ -473,6 +476,14 @@ export async function renderSettings(container, userId) {
   // selection (no stale state across save-induced re-renders).
   const themeTarget = document.getElementById('theme-switcher-target');
   if (themeTarget) mountThemeSwitcher(themeTarget);
+
+  // Mount the embedded-LLM card (#187 AC#2). Async fetches the
+  // registry + current download state and renders into its target.
+  // No-await — render shouldn't block the rest of the settings page.
+  const embeddedTarget = document.getElementById('embedded-llm-card-target');
+  if (embeddedTarget) {
+    void mountEmbeddedLlmCard(embeddedTarget, userId).catch(() => { /* best-effort */ });
+  }
 
   // Hydrate the launch-at-login toggle from the desktop API. Skipped in
   // pure-web mode (no skytwinDesktop). The fetch is best-effort — if it

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -148,6 +148,13 @@ export {
 } from './repositories/index.js';
 export type { RecoveryCodeRow } from './repositories/index.js';
 
+export { modelDownloadRepository } from './repositories/index.js';
+export type {
+  ModelDownloadRow,
+  ModelDownloadStatus,
+  CreateModelDownloadInput,
+} from './repositories/index.js';
+
 export { mcpServerMetricsRepository } from './repositories/index.js';
 
 export { credentialVaultMetaRepository } from './repositories/index.js';

--- a/packages/db/src/migrations/039-model-downloads.sql
+++ b/packages/db/src/migrations/039-model-downloads.sql
@@ -1,0 +1,48 @@
+-- 039-model-downloads.sql
+-- Model download tracking for embedded LLM auto-fetch (#187 AC#2).
+--
+-- Each row tracks one download of a GGUF artifact named in the
+-- `@skytwin/embedded-llm` registry. The downloader streams in chunks,
+-- updates `bytes_downloaded` periodically, and survives API restart
+-- via DB persistence: any row with status='downloading' on boot is
+-- transitioned to 'paused' so the user can manually resume.
+--
+-- Why DB-backed and not just in-memory: 2-9GB downloads can run for
+-- 10+ minutes. An API restart mid-download (deploy, OOM, crash) would
+-- otherwise lose all progress. With this table the user sees a
+-- "paused — click resume" UX and the partial bytes on disk are still
+-- valid (Range request resumes from where we left off).
+
+CREATE TABLE IF NOT EXISTS model_downloads (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  -- Registry id (e.g. 'qwen-2.5-3b-q4'). Not a foreign key — the
+  -- registry lives in the `@skytwin/embedded-llm` package, not in DB.
+  model_id STRING NOT NULL,
+  -- Absolute path on the API host's filesystem where the final GGUF
+  -- will land. We download to `<target_path>.partial` and atomically
+  -- rename on success.
+  target_path STRING NOT NULL,
+  -- Total bytes per registry (matches registry.approxBytes at start;
+  -- gets corrected to Content-Length on first response if different).
+  total_bytes INT8 NOT NULL,
+  bytes_downloaded INT8 NOT NULL DEFAULT 0,
+  -- SHA-256 hex (64 chars) from registry. Verified after download
+  -- completes; mismatch → status='failed'. Empty / all-zeros = skip
+  -- verification (placeholder hashes in v1 registry).
+  sha256_expected STRING NOT NULL,
+  status STRING NOT NULL CHECK (status IN (
+    'pending', 'downloading', 'paused', 'verifying', 'installing', 'complete', 'failed', 'cancelled'
+  )),
+  error STRING,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  paused_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS model_downloads_user_active_idx
+  ON model_downloads (user_id, started_at DESC)
+  WHERE status NOT IN ('complete', 'failed', 'cancelled');
+
+CREATE INDEX IF NOT EXISTS model_downloads_user_all_idx
+  ON model_downloads (user_id, started_at DESC);

--- a/packages/db/src/migrations/039-model-downloads.sql
+++ b/packages/db/src/migrations/039-model-downloads.sql
@@ -40,9 +40,13 @@ CREATE TABLE IF NOT EXISTS model_downloads (
   completed_at TIMESTAMPTZ
 );
 
-CREATE INDEX IF NOT EXISTS model_downloads_user_active_idx
-  ON model_downloads (user_id, started_at DESC)
-  WHERE status NOT IN ('complete', 'failed', 'cancelled');
-
 CREATE INDEX IF NOT EXISTS model_downloads_user_all_idx
   ON model_downloads (user_id, started_at DESC);
+
+-- Partial UNIQUE index enforces "at most one active download per (user,
+-- model)" at the DB level. Without this, two concurrent /downloads/start
+-- calls can both pass the application-layer findActive() check and
+-- INSERT two rows that race on the same .partial file.
+CREATE UNIQUE INDEX IF NOT EXISTS model_downloads_user_active_uniq
+  ON model_downloads (user_id, model_id)
+  WHERE status NOT IN ('complete', 'failed', 'cancelled');

--- a/packages/db/src/repositories/index.ts
+++ b/packages/db/src/repositories/index.ts
@@ -198,3 +198,10 @@ export {
 export type { RecoveryCodeRow } from './recovery-code-repository.js';
 
 export { vacationModeRepository } from './vacation-mode-repository.js';
+
+export { modelDownloadRepository } from './model-download-repository.js';
+export type {
+  ModelDownloadRow,
+  ModelDownloadStatus,
+  CreateModelDownloadInput,
+} from './model-download-repository.js';

--- a/packages/db/src/repositories/model-download-repository.ts
+++ b/packages/db/src/repositories/model-download-repository.ts
@@ -104,6 +104,15 @@ export const modelDownloadRepository = {
     );
   },
 
+  async updateTotalBytes(id: string, totalBytes: number): Promise<void> {
+    await query(
+      `UPDATE model_downloads
+       SET total_bytes = $2
+       WHERE id = $1`,
+      [id, totalBytes],
+    );
+  },
+
   async setStatus(
     id: string,
     status: ModelDownloadStatus,

--- a/packages/db/src/repositories/model-download-repository.ts
+++ b/packages/db/src/repositories/model-download-repository.ts
@@ -1,0 +1,154 @@
+import { query } from '../connection.js';
+
+export type ModelDownloadStatus =
+  | 'pending'
+  | 'downloading'
+  | 'paused'
+  | 'verifying'
+  | 'installing'
+  | 'complete'
+  | 'failed'
+  | 'cancelled';
+
+export interface ModelDownloadRow {
+  id: string;
+  user_id: string;
+  model_id: string;
+  target_path: string;
+  total_bytes: number;
+  bytes_downloaded: number;
+  sha256_expected: string;
+  status: ModelDownloadStatus;
+  error: string | null;
+  started_at: Date;
+  paused_at: Date | null;
+  completed_at: Date | null;
+}
+
+export interface CreateModelDownloadInput {
+  userId: string;
+  modelId: string;
+  targetPath: string;
+  totalBytes: number;
+  sha256Expected: string;
+}
+
+/**
+ * Repository for `model_downloads` (#187 AC#2).
+ *
+ * One row per download attempt. Resumable: a row in 'paused' state with
+ * `bytes_downloaded > 0` keeps its `<target_path>.partial` file on disk
+ * and can be restarted via Range request from `bytes_downloaded`.
+ */
+export const modelDownloadRepository = {
+  async create(input: CreateModelDownloadInput): Promise<ModelDownloadRow> {
+    const result = await query<ModelDownloadRow>(
+      `INSERT INTO model_downloads
+         (user_id, model_id, target_path, total_bytes, sha256_expected, status)
+       VALUES ($1, $2, $3, $4, $5, 'pending')
+       RETURNING *`,
+      [
+        input.userId,
+        input.modelId,
+        input.targetPath,
+        input.totalBytes,
+        input.sha256Expected,
+      ],
+    );
+    const row = result.rows[0];
+    if (!row) throw new Error('model download create returned no row');
+    return row;
+  },
+
+  async findById(id: string): Promise<ModelDownloadRow | null> {
+    const result = await query<ModelDownloadRow>(
+      `SELECT * FROM model_downloads WHERE id = $1 LIMIT 1`,
+      [id],
+    );
+    return result.rows[0] ?? null;
+  },
+
+  async listForUser(userId: string): Promise<ModelDownloadRow[]> {
+    const result = await query<ModelDownloadRow>(
+      `SELECT * FROM model_downloads
+       WHERE user_id = $1
+       ORDER BY started_at DESC
+       LIMIT 50`,
+      [userId],
+    );
+    return result.rows;
+  },
+
+  /**
+   * Find the active (non-terminal) download for a given (user, model)
+   * pair. Used to prevent double-starting the same download.
+   */
+  async findActive(userId: string, modelId: string): Promise<ModelDownloadRow | null> {
+    const result = await query<ModelDownloadRow>(
+      `SELECT * FROM model_downloads
+       WHERE user_id = $1 AND model_id = $2
+         AND status NOT IN ('complete', 'failed', 'cancelled')
+       ORDER BY started_at DESC
+       LIMIT 1`,
+      [userId, modelId],
+    );
+    return result.rows[0] ?? null;
+  },
+
+  async updateProgress(id: string, bytesDownloaded: number): Promise<void> {
+    await query(
+      `UPDATE model_downloads
+       SET bytes_downloaded = $2
+       WHERE id = $1`,
+      [id, bytesDownloaded],
+    );
+  },
+
+  async setStatus(
+    id: string,
+    status: ModelDownloadStatus,
+    extra: { error?: string; bytesDownloaded?: number } = {},
+  ): Promise<void> {
+    const sets: string[] = ['status = $2'];
+    const params: unknown[] = [id, status];
+    let i = 3;
+
+    if (extra.error !== undefined) {
+      sets.push(`error = $${i++}`);
+      params.push(extra.error);
+    }
+    if (extra.bytesDownloaded !== undefined) {
+      sets.push(`bytes_downloaded = $${i++}`);
+      params.push(extra.bytesDownloaded);
+    }
+    if (status === 'paused') {
+      sets.push(`paused_at = now()`);
+    }
+    if (status === 'downloading') {
+      sets.push(`paused_at = NULL`);
+    }
+    if (status === 'complete') {
+      sets.push(`completed_at = now()`);
+    }
+
+    await query(
+      `UPDATE model_downloads SET ${sets.join(', ')} WHERE id = $1`,
+      params,
+    );
+  },
+
+  /**
+   * Boot-time recovery: any download that was 'downloading' when the
+   * API process died gets transitioned to 'paused' so the user can
+   * choose to resume. The on-disk `<target_path>.partial` file is
+   * preserved.
+   */
+  async recoverOrphanedDownloads(): Promise<number> {
+    const result = await query(
+      `UPDATE model_downloads
+       SET status = 'paused', paused_at = now()
+       WHERE status = 'downloading'`,
+    );
+    return result.rowCount ?? 0;
+  },
+};

--- a/packages/db/src/schemas/schema.sql
+++ b/packages/db/src/schemas/schema.sql
@@ -318,3 +318,25 @@ CREATE INDEX IF NOT EXISTS recovery_codes_user_all_idx
   ON recovery_codes (user_id, created_at DESC);
 
 ALTER TABLE users ADD COLUMN IF NOT EXISTS vacation_mode_until TIMESTAMPTZ;
+
+CREATE TABLE IF NOT EXISTS model_downloads (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  model_id STRING NOT NULL,
+  target_path STRING NOT NULL,
+  total_bytes INT8 NOT NULL,
+  bytes_downloaded INT8 NOT NULL DEFAULT 0,
+  sha256_expected STRING NOT NULL,
+  status STRING NOT NULL CHECK (status IN (
+    'pending', 'downloading', 'paused', 'verifying', 'installing', 'complete', 'failed', 'cancelled'
+  )),
+  error STRING,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  paused_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS model_downloads_user_active_idx
+  ON model_downloads (user_id, started_at DESC)
+  WHERE status NOT IN ('complete', 'failed', 'cancelled');
+CREATE INDEX IF NOT EXISTS model_downloads_user_all_idx
+  ON model_downloads (user_id, started_at DESC);

--- a/packages/db/src/schemas/schema.sql
+++ b/packages/db/src/schemas/schema.sql
@@ -335,8 +335,10 @@ CREATE TABLE IF NOT EXISTS model_downloads (
   paused_at TIMESTAMPTZ,
   completed_at TIMESTAMPTZ
 );
-CREATE INDEX IF NOT EXISTS model_downloads_user_active_idx
-  ON model_downloads (user_id, started_at DESC)
-  WHERE status NOT IN ('complete', 'failed', 'cancelled');
 CREATE INDEX IF NOT EXISTS model_downloads_user_all_idx
   ON model_downloads (user_id, started_at DESC);
+-- Enforces "at most one active download per (user, model)" at the DB
+-- level so concurrent /downloads/start can't race past findActive().
+CREATE UNIQUE INDEX IF NOT EXISTS model_downloads_user_active_uniq
+  ON model_downloads (user_id, model_id)
+  WHERE status NOT IN ('complete', 'failed', 'cancelled');


### PR DESCRIPTION
## Summary

The launch-gating piece. A non-technical user opening SkyTwin previously hit a wall: configure llama.cpp + GGUF + env vars, or buy API keys. With this PR: open Settings → "Local AI brain" card detects RAM bracket via `navigator.deviceMemory`, recommends the highest-quality model that fits, click Download → 3-15 minutes later the twin works fully offline. No API keys, no per-message cost, no manual install.

The registry shipped in #246 told us *which* model to download. This PR makes it actually happen — with pause / resume / cancel and persistence across API restarts.

## What ships

- `039-model-downloads.sql` migration + `modelDownloadRepository`
- `apps/api/src/embedded-llm/downloader.ts` — fetch + Range + atomic rename + SHA-256 verify + AbortController-based pause/cancel + boot-time orphan recovery
- `/api/embedded-llm/downloads/{start,:id,user/:userId,pause,resume,cancel}` endpoints
- `apps/web/public/js/components/embedded-llm-card.js` — Settings card, polls every 1s during active download, reuses `.confidence-bar` styles
- 14 new route tests; api total **477 passing** (24 skipped)

## Why this fits the theme

Pure boring-deterministic infrastructure: `fetch()`+Range, SHA-256, atomic rename. No LLM in the cryptography or the download path. Every byte accounted for; every state transition reflected in the row; every button has a deterministic backend consequence.

## Closes for #187

- ✅ AC#1 runtime
- ✅ AC#2 download with pause/resume
- ☐ AC#1 default GGUF in installer payload (separate distribution work)
- ✅ AC#3 STT runtime
- ☐ AC#4 Piper TTS (binary not installed)
- ✅ AC#5 model registry
- ☐ AC#6 mode-switch UI
- ✅ AC#7 same prompts
- AC#8 cost dashboard — implicitly satisfied

5 of 8 ACs closed. Remaining are distribution (AC#1 bundling), missing binary (AC#4), or small UI follow-ups.

## Test plan

- [x] `pnpm build` clean across all 34 packages
- [x] `pnpm --filter @skytwin/api test` — 477 passing
- [x] `vi.mock` ensures tests never touch real HTTP / filesystem
- [ ] CI green
- [ ] Manual: open Settings → click Download → watch progress

## Out of scope

- Real SHA-256 hashes (registry currently has placeholders; downloader skips verify when hash is all-zeros)
- First-run dashboard integration (card lives in Settings; promoting to dashboard "you have no model yet" prompt is small follow-up)
- Paused-on-restart proactive toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)