### PR TITLE
feat(#187 follow-up): first-run dashboard "needs a brain" prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — First-run dashboard "needs a brain" prompt (#187 follow-up)
+
+A tiny but launch-critical UX gap: a brand-new user lands on the dashboard
+with no AI provider configured and an empty state that offers no path
+forward. They're left to discover Settings → AI brain on their own.
+
+Closes the gap with a banner that surfaces only when (a) the dashboard
+fetch promises resolved successfully (no false-positive on transient API
+errors), (b) zero decisions exist yet, AND (c) zero AI providers are
+enabled. The provider check matches the Settings UI's truthiness rule
+(`p.enabled !== false`), so existing rows without an explicit `enabled`
+field aren't misread as off.
+
+Two CTAs: "Set up the local brain" (routes to Settings → Local AI brain
+card from #187 AC#2) and "Or bring your own API key". Privacy framing
+is per-option (not global): the local-first claim is scoped to the
+local brain row; the API-key row clearly notes "each message goes to
+that provider." Skipped in tour mode (seeded demo user has providers
+pre-configured), so the demo experience stays clean.
+
+Settings is fetched conditionally — only when the cheap prerequisites
+(`!tourMode && recentDecisions.length === 0`) already point at first-run.
+Once the user has any activity, no extra `/api/settings` round-trip per
+SSE-driven dashboard re-render.
+
+Implementation lives in `apps/web/public/js/pages/dashboard.js`. Reuses
+the existing `GET /api/settings/:userId` endpoint via `fetchSettings` —
+no new API. One new card, no other UI changes.
+
 ## [unreleased] — Embedded LLM model downloader (#187 AC#2)
 
 Closes AC#2 of #187. The single piece between "developer tool" and
@@ -142,6 +171,7 @@ model once installed) doesn't change at all.
   toast / banner alerting them proactively is a small follow-up.
 
 
+## [unreleased] — Accessibility: high-contrast + text-scale + voice STT route (#194 Child 4)
 
 Closes the a11y commitments of #194 Child 4. Detailed entry in PR #244.
 

--- a/apps/web/public/js/pages/dashboard.js
+++ b/apps/web/public/js/pages/dashboard.js
@@ -250,11 +250,15 @@ function renderBrainPrompt() {
         <span class="card-title">Your twin needs a brain to start</span>
       </div>
       <div class="card-subtitle" style="margin-bottom: 0.75rem; line-height: 1.5;">
-        SkyTwin runs <strong>locally on your machine</strong> — no API keys, no per-message cost, your data never leaves the device. Pick up a free model in 5 minutes, or bring your own paid provider if you'd rather.
+        Pick how your twin thinks. Either path takes about 5 minutes from Settings.
       </div>
-      <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+      <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.75rem;">
         <a href="#/settings" class="btn btn-primary btn-sm">Set up the local brain</a>
         <a href="#/settings" class="btn btn-outline btn-sm">Or bring your own API key</a>
+      </div>
+      <div style="font-size: 0.8rem; color: var(--text-muted); line-height: 1.5;">
+        <strong>Local brain</strong> — runs on your machine, no API keys, no per-message cost, your data never leaves the device.<br>
+        <strong>API key</strong> — uses Anthropic / OpenAI / Google. Faster on a small laptop, but each message goes to that provider.
       </div>
     </div>
   `;
@@ -295,7 +299,11 @@ export async function renderDashboard(container, userId) {
     fetchBriefing(userId),
     fetchLatestTwinBriefing(userId, 'daily').catch(() => null),
     slowFetch(`lifebooks-${userId}`, fetchLifebooks, [userId]),
-    slowFetch(`settings-${userId}`, fetchSettings, [userId]),
+    // Not slow-cached: a user enabling their first AI provider in
+    // Settings should make the first-run prompt go away on the next
+    // dashboard render, not 30s later. The endpoint is small and
+    // only relevant on first-run renders anyway.
+    fetchSettings(userId),
   ]);
 
   const healthOk = health.status === 'fulfilled';
@@ -359,14 +367,25 @@ export async function renderDashboard(container, userId) {
 
   const tourMode = (() => { try { return localStorage.getItem(KEY_TOUR_MODE) === '1'; } catch { return false; } })();
 
+  // Only show the prompt when we have positive evidence the user is
+  // in the first-run state. If either fetch failed, we don't know
+  // their provider count or decision count — falling back to "show
+  // the prompt" would surface it during transient API errors and
+  // for users who actually have providers but hit a blip.
   // Skip in tour mode — seeded demo user has providers pre-configured.
-  const aiProviders = settingsData?.status === 'fulfilled'
+  const settingsFulfilled = settingsData?.status === 'fulfilled';
+  const decisionsFulfilled = decisions?.status === 'fulfilled';
+  const aiProviders = settingsFulfilled
     ? (settingsData.value?.aiProviders ?? [])
     : [];
   const enabledProviderCount = Array.isArray(aiProviders)
     ? aiProviders.filter((p) => p?.enabled).length
     : 0;
-  const showBrainPrompt = !tourMode && enabledProviderCount === 0 && recentDecisions.length === 0;
+  const showBrainPrompt = !tourMode
+    && settingsFulfilled
+    && decisionsFulfilled
+    && enabledProviderCount === 0
+    && recentDecisions.length === 0;
 
   // "While you were away" — count anything new since the last visit so the
   // user feels like the twin has been working for them, not just sitting

--- a/apps/web/public/js/pages/dashboard.js
+++ b/apps/web/public/js/pages/dashboard.js
@@ -88,6 +88,24 @@ const SLOW_CACHE_TTL_MS = 30 * 1000;
 const _slowCache = new Map();
 let _cacheGeneration = 0;
 
+// Short-TTL cache for the first-run brain-prompt settings lookup.
+// Separate from _slowCache because we want a much shorter TTL (the
+// user enabling a provider should make the prompt vanish near-instant)
+// without changing the 30s default that other consumers rely on.
+const BRAIN_PROMPT_TTL_MS = 5000;
+let _settingsCache = null;
+async function getCachedSettings(userId) {
+  const now = Date.now();
+  if (_settingsCache
+      && _settingsCache.userId === userId
+      && _settingsCache.expiresAt > now) {
+    return _settingsCache.value;
+  }
+  const value = await fetchSettings(userId);
+  _settingsCache = { userId, value, expiresAt: now + BRAIN_PROMPT_TTL_MS };
+  return value;
+}
+
 /**
  * Wrap a fetch function so its result is memoized for SLOW_CACHE_TTL_MS.
  * The cache key combines the supplied id with the function's name, so
@@ -370,11 +388,15 @@ export async function renderDashboard(container, userId) {
   // Provider enablement matches settings.js: a provider is "enabled"
   // unless `enabled === false`, so existing rows without an explicit
   // field are treated as on (same convention the Settings UI uses).
+  // The result is memoized for 5s so the post-OAuth first-scan window
+  // (4s polling) doesn't fire /api/settings on every tick. Short
+  // enough that "user enables a provider in Settings, comes back" is
+  // perceived as instant; long enough to avoid the 4s storm.
   const decisionsFulfilled = decisions?.status === 'fulfilled';
   let showBrainPrompt = false;
   if (!tourMode && decisionsFulfilled && recentDecisions.length === 0) {
     try {
-      const settings = await fetchSettings(userId);
+      const settings = await getCachedSettings(userId);
       const aiProviders = Array.isArray(settings?.aiProviders) ? settings.aiProviders : [];
       const enabledProviderCount = aiProviders.filter((p) => p?.enabled !== false).length;
       showBrainPrompt = enabledProviderCount === 0;

--- a/apps/web/public/js/pages/dashboard.js
+++ b/apps/web/public/js/pages/dashboard.js
@@ -283,7 +283,7 @@ export async function renderDashboard(container, userId) {
   // and user action move them around constantly.
   // Slow-changing data — wrapped in slowFetch so a 4s first-scan tick or
   // a debounced SSE re-render doesn't burn 13 round-trips per cycle.
-  const [health, accuracy, confidence, learning, approvals, decisions, skillGaps, progress, learned, unmetCreds, googleOAuth, credsStatus, briefingData, twinBriefingData, lifebooksData, settingsData] = await Promise.allSettled([
+  const [health, accuracy, confidence, learning, approvals, decisions, skillGaps, progress, learned, unmetCreds, googleOAuth, credsStatus, briefingData, twinBriefingData, lifebooksData] = await Promise.allSettled([
     fetchHealth(),
     fetchAccuracy(userId),
     fetchConfidence(userId),
@@ -299,11 +299,6 @@ export async function renderDashboard(container, userId) {
     fetchBriefing(userId),
     fetchLatestTwinBriefing(userId, 'daily').catch(() => null),
     slowFetch(`lifebooks-${userId}`, fetchLifebooks, [userId]),
-    // Not slow-cached: a user enabling their first AI provider in
-    // Settings should make the first-run prompt go away on the next
-    // dashboard render, not 30s later. The endpoint is small and
-    // only relevant on first-run renders anyway.
-    fetchSettings(userId),
   ]);
 
   const healthOk = health.status === 'fulfilled';
@@ -367,25 +362,28 @@ export async function renderDashboard(container, userId) {
 
   const tourMode = (() => { try { return localStorage.getItem(KEY_TOUR_MODE) === '1'; } catch { return false; } })();
 
-  // Only show the prompt when we have positive evidence the user is
-  // in the first-run state. If either fetch failed, we don't know
-  // their provider count or decision count — falling back to "show
-  // the prompt" would surface it during transient API errors and
-  // for users who actually have providers but hit a blip.
-  // Skip in tour mode — seeded demo user has providers pre-configured.
-  const settingsFulfilled = settingsData?.status === 'fulfilled';
+  // First-run "needs a brain" prompt. Two prerequisites are cheap and
+  // already known here: tour mode (always-off) and recentDecisions
+  // (zero only on first-run-ish accounts). Only when both clear do we
+  // pay for a settings fetch — keeps SSE-driven re-renders from hitting
+  // /api/settings on every tick once the user has any history.
+  // Provider enablement matches settings.js: a provider is "enabled"
+  // unless `enabled === false`, so existing rows without an explicit
+  // field are treated as on (same convention the Settings UI uses).
   const decisionsFulfilled = decisions?.status === 'fulfilled';
-  const aiProviders = settingsFulfilled
-    ? (settingsData.value?.aiProviders ?? [])
-    : [];
-  const enabledProviderCount = Array.isArray(aiProviders)
-    ? aiProviders.filter((p) => p?.enabled).length
-    : 0;
-  const showBrainPrompt = !tourMode
-    && settingsFulfilled
-    && decisionsFulfilled
-    && enabledProviderCount === 0
-    && recentDecisions.length === 0;
+  let showBrainPrompt = false;
+  if (!tourMode && decisionsFulfilled && recentDecisions.length === 0) {
+    try {
+      const settings = await fetchSettings(userId);
+      const aiProviders = Array.isArray(settings?.aiProviders) ? settings.aiProviders : [];
+      const enabledProviderCount = aiProviders.filter((p) => p?.enabled !== false).length;
+      showBrainPrompt = enabledProviderCount === 0;
+    } catch {
+      // Settings fetch failed — don't surface the banner on a transient
+      // error. The next render will retry.
+      showBrainPrompt = false;
+    }
+  }
 
   // "While you were away" — count anything new since the last visit so the
   // user feels like the twin has been working for them, not just sitting

--- a/apps/web/public/js/pages/dashboard.js
+++ b/apps/web/public/js/pages/dashboard.js
@@ -1,4 +1,4 @@
-import { fetchHealth, fetchDecisions, fetchAccuracy, fetchConfidence, fetchLearning, fetchPendingApprovals, fetchSkillGaps, fetchTrustProgress, fetchLearned, fetchUnmetCredentials, fetchOAuthStatus, fetchCredentialsStatus, fetchBriefing, fetchLatestTwinBriefing, fetchLifebooks, escapeHtml } from '../api-client.js';
+import { fetchHealth, fetchDecisions, fetchAccuracy, fetchConfidence, fetchLearning, fetchPendingApprovals, fetchSkillGaps, fetchTrustProgress, fetchLearned, fetchUnmetCredentials, fetchOAuthStatus, fetchCredentialsStatus, fetchBriefing, fetchLatestTwinBriefing, fetchLifebooks, fetchSettings, escapeHtml } from '../api-client.js';
 import { renderTrustProgress } from '../components/progress-bar.js';
 import {
   KEY_USER_ID,
@@ -243,6 +243,23 @@ function renderLifebooksCard(lifebooks) {
   `;
 }
 
+function renderBrainPrompt() {
+  return `
+    <div class="card" style="border-left: 3px solid var(--accent);">
+      <div class="card-header">
+        <span class="card-title">Your twin needs a brain to start</span>
+      </div>
+      <div class="card-subtitle" style="margin-bottom: 0.75rem; line-height: 1.5;">
+        SkyTwin runs <strong>locally on your machine</strong> — no API keys, no per-message cost, your data never leaves the device. Pick up a free model in 5 minutes, or bring your own paid provider if you'd rather.
+      </div>
+      <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+        <a href="#/settings" class="btn btn-primary btn-sm">Set up the local brain</a>
+        <a href="#/settings" class="btn btn-outline btn-sm">Or bring your own API key</a>
+      </div>
+    </div>
+  `;
+}
+
 function formatDashboardTime(d) {
   if (!d) return '';
   const now = new Date();
@@ -262,7 +279,7 @@ export async function renderDashboard(container, userId) {
   // and user action move them around constantly.
   // Slow-changing data — wrapped in slowFetch so a 4s first-scan tick or
   // a debounced SSE re-render doesn't burn 13 round-trips per cycle.
-  const [health, accuracy, confidence, learning, approvals, decisions, skillGaps, progress, learned, unmetCreds, googleOAuth, credsStatus, briefingData, twinBriefingData, lifebooksData] = await Promise.allSettled([
+  const [health, accuracy, confidence, learning, approvals, decisions, skillGaps, progress, learned, unmetCreds, googleOAuth, credsStatus, briefingData, twinBriefingData, lifebooksData, settingsData] = await Promise.allSettled([
     fetchHealth(),
     fetchAccuracy(userId),
     fetchConfidence(userId),
@@ -278,6 +295,7 @@ export async function renderDashboard(container, userId) {
     fetchBriefing(userId),
     fetchLatestTwinBriefing(userId, 'daily').catch(() => null),
     slowFetch(`lifebooks-${userId}`, fetchLifebooks, [userId]),
+    slowFetch(`settings-${userId}`, fetchSettings, [userId]),
   ]);
 
   const healthOk = health.status === 'fulfilled';
@@ -341,6 +359,15 @@ export async function renderDashboard(container, userId) {
 
   const tourMode = (() => { try { return localStorage.getItem(KEY_TOUR_MODE) === '1'; } catch { return false; } })();
 
+  // Skip in tour mode — seeded demo user has providers pre-configured.
+  const aiProviders = settingsData?.status === 'fulfilled'
+    ? (settingsData.value?.aiProviders ?? [])
+    : [];
+  const enabledProviderCount = Array.isArray(aiProviders)
+    ? aiProviders.filter((p) => p?.enabled).length
+    : 0;
+  const showBrainPrompt = !tourMode && enabledProviderCount === 0 && recentDecisions.length === 0;
+
   // "While you were away" — count anything new since the last visit so the
   // user feels like the twin has been working for them, not just sitting
   // there. The baseline is only updated when the user actually leaves
@@ -397,6 +424,7 @@ export async function renderDashboard(container, userId) {
     ${tourMode ? renderTourBanner() : ''}
     ${renderJustConnectedCelebration({ justConnectedProvider, justConnectedAccount, recentDecisionsCount: recentDecisions.length, learnedCount: learn?.totalPreferences ?? 0 })}
     ${sinceLastVisit && !tourMode ? renderSinceLastVisit(sinceLastVisit) : ''}
+    ${showBrainPrompt ? renderBrainPrompt() : ''}
     ${tourMode ? '' : renderConnectGoogleHero({ googleConnected, googleSystemConfigured, userId })}
     ${renderAskTwinWidget({ userId, tourMode })}
     ${showBriefing ? renderBriefingCard({ items: briefingItems, createdAt: briefing.createdAt }) : ''}


### PR DESCRIPTION
## Summary

A tiny but launch-critical UX gap: a brand-new user lands on the dashboard with no AI provider configured and an empty state that offers no path forward. They're left to discover Settings → AI brain on their own.

This PR surfaces a banner when **zero AI providers are enabled AND zero decisions exist yet** — the natural first-run state. Two CTAs route to Settings:

- **Set up the local brain** — where the #187 AC#2 model downloader lives (PR #247)
- **Or bring your own API key** — for users who'd rather use a paid provider

Privacy framing leads: *"SkyTwin runs locally on your machine — no API keys, no per-message cost, your data never leaves the device. Pick up a free model in 5 minutes, or bring your own paid provider if you'd rather."*

That's the real first-run differentiator vs. ChatGPT-style assistants. The dominant first-run fear is "what is this thing going to do with my data?" — leading with local-first answers it before they have to ask.

## Why now

Once #247 (model downloader) lands, the local-brain path is fully self-serve in 5 minutes. But the dashboard didn't tell the user that path exists. This PR closes that gap and means the dashboard works as a first-run surface even before the user opens Settings.

Independent of #247 — this routes to Settings either way. Once #247 merges, the route lands on the model downloader card. Until then, it lands on the AI provider config (still self-serve, just paid).

## Implementation

- `apps/web/public/js/pages/dashboard.js` — new `renderBrainPrompt()`; gated by `enabledProviderCount === 0 && recentDecisions.length === 0` and `!tourMode` (seeded demo user has providers pre-configured)
- Reuses `GET /api/settings/:userId` via `fetchSettings` — **no new API endpoint**
- One new dashboard card, slotted between the "since last visit" banner and the Connect Google hero

## Test plan

- [x] `pnpm --filter @skytwin/web build` — clean
- [ ] New user (no providers, no decisions, not in tour) — banner appears
- [ ] Tour mode user — banner hidden
- [ ] User with 1+ enabled provider — banner hidden
- [ ] User with no providers but ≥1 decision — banner hidden (they got past first-run somehow)
- [ ] CTAs route to `#/settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)