### PR TITLE
fix(#187 AC#2 r3): multi-user partial collision + pause race + zombie polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Embedded LLM downloader: round-3 review fixes (#187 AC#2 follow-up)
+
+Copilot's third-round review of PR #247 landed after merge — four
+substantive findings, addressed in a follow-up PR:
+
+- **Multi-user partial-file collision**: two users on the same API
+  host downloading the same model both wrote to
+  `<modelDir>/<modelId>.gguf.partial`, so concurrent streams could
+  corrupt each other and one user's cancel could delete the other's
+  partial. The final GGUF is content-addressable (SHA-256 verified
+  before rename), so we keep that shared at `<modelDir>/<modelId>.gguf`,
+  but partials now namespace by download row id:
+  `<modelDir>/<modelId>.gguf.<download.id>.partial`.
+
+- **Pause-on-pending was a no-op**: `pauseDownload()` would set DB to
+  `paused`, but the already-scheduled `runDownload()` invocation
+  would start anyway and immediately overwrite back to `downloading`
+  via `setStatus`. Same bug for pending→cancelled. Fixed by
+  re-fetching the row at the top of `runDownload()` and bailing
+  early if status changed to `paused`/`cancelled`/`complete`/`failed`
+  between `startDownload()` returning and the runner picking up.
+
+- **Polling continued after navigating away**: the 1s poll callback
+  in `embedded-llm-card.js` had no termination condition tied to
+  page navigation. A user who started a download and then went to
+  Approvals would keep hitting `/api/embedded-llm/downloads/:id`
+  every second and hold a reference to a detached
+  `#embedded-llm-card-target` node. Now the poll callback checks
+  `window.location.hash !== '#/settings'` and
+  `document.getElementById(CARD_TARGET_ID) !== container` at the
+  top and stops itself when either is true.
+
 ## [unreleased] — First-run dashboard "needs a brain" prompt (#187 follow-up)
 
 A tiny but launch-critical UX gap: a brand-new user lands on the dashboard

--- a/apps/api/src/embedded-llm/downloader.ts
+++ b/apps/api/src/embedded-llm/downloader.ts
@@ -39,13 +39,25 @@ export function resolveModelDir(): string {
  * Compute the absolute target path for a registry model. The basename
  * is `<modelId>.gguf`. We never use the registry's URL filename — that
  * could be anything (or could change over time without our control).
+ *
+ * Final paths are *not* namespaced by user — the GGUF is content-
+ * addressable (we verify SHA-256 before rename), so two users on the
+ * same host downloading the same model land identical bytes at the
+ * same path. The race-prone bit is the in-flight `.partial`, which
+ * `partialPathFor()` namespaces by download row id below.
  */
 export function targetPathFor(modelId: string): string {
   return join(resolveModelDir(), `${modelId}.gguf`);
 }
 
-function partialPathFor(targetPath: string): string {
-  return `${targetPath}.partial`;
+/**
+ * In-flight downloads write to a per-row partial so concurrent downloads
+ * of the same model by different users (or even the same user across
+ * cancel/retry cycles) can't corrupt each other's stream. After verify,
+ * we atomically rename to the shared final path.
+ */
+function partialPathFor(targetPath: string, downloadId: string): string {
+  return `${targetPath}.${downloadId}.partial`;
 }
 
 /**
@@ -185,7 +197,7 @@ export async function cancelDownload(downloadId: string): Promise<boolean> {
     inFlight.delete(downloadId);
   }
 
-  const partial = partialPathFor(row.target_path);
+  const partial = partialPathFor(row.target_path, downloadId);
   if (existsSync(partial)) {
     try {
       unlinkSync(partial);
@@ -217,7 +229,19 @@ async function runDownload(download: ModelDownloadRow): Promise<void> {
     return;
   }
 
-  const partialPath = partialPathFor(download.target_path);
+  // Pause/cancel can fire between startDownload() returning the row
+  // and runDownload() picking up the async kickoff. The DB is the
+  // source of truth for that intent — re-fetch and bail if the user
+  // already changed their mind. Without this, a quick pause-on-pending
+  // would be silently overwritten back to 'downloading'.
+  const current = await modelDownloadRepository.findById(download.id);
+  if (!current) return; // row was deleted somehow
+  if (current.status === 'paused' || current.status === 'cancelled'
+      || current.status === 'complete' || current.status === 'failed') {
+    return;
+  }
+
+  const partialPath = partialPathFor(download.target_path, download.id);
   // Only resume from the partial if THIS row had progress recorded.
   // A fresh row (bytes_downloaded === 0) finding a partial on disk
   // means the previous attempt didn't clean up — e.g., a cancel that

--- a/apps/api/src/embedded-llm/downloader.ts
+++ b/apps/api/src/embedded-llm/downloader.ts
@@ -182,8 +182,9 @@ export async function pauseDownload(downloadId: string): Promise<boolean> {
 }
 
 /**
- * Cancel and clean up. Aborts in-flight transfer, deletes the
- * `<target_path>.partial` file, marks the row 'cancelled'.
+ * Cancel and clean up. Aborts in-flight transfer, deletes this row's
+ * partial (`<target_path>.<downloadId>.partial`), marks the row
+ * 'cancelled'. The shared final GGUF at `<target_path>` is left alone.
  */
 export async function cancelDownload(downloadId: string): Promise<boolean> {
   const row = await modelDownloadRepository.findById(downloadId);
@@ -242,6 +243,15 @@ async function runDownload(download: ModelDownloadRow): Promise<void> {
   }
 
   const partialPath = partialPathFor(download.target_path, download.id);
+  // Migration: PR #247 wrote to a non-namespaced `<target>.partial`.
+  // After this PR, partials are namespaced by download row id. Any
+  // pre-namespacing partial on disk is orphan junk from before the
+  // upgrade — clean it up unconditionally so it doesn't waste space
+  // forever.
+  const legacyPartial = `${download.target_path}.partial`;
+  if (existsSync(legacyPartial)) {
+    try { unlinkSync(legacyPartial); } catch { /* best effort */ }
+  }
   // Only resume from the partial if THIS row had progress recorded.
   // A fresh row (bytes_downloaded === 0) finding a partial on disk
   // means the previous attempt didn't clean up — e.g., a cancel that
@@ -414,17 +424,34 @@ async function runDownload(download: ModelDownloadRow): Promise<void> {
     return;
   }
   await modelDownloadRepository.setStatus(download.id, 'installing');
-  // Atomic rename — partial → final. Same filesystem so this is O(1).
-  try {
-    if (existsSync(download.target_path)) unlinkSync(download.target_path);
-    renameSync(partialPath, download.target_path);
-  } catch (err) {
-    inFlight.delete(download.id);
-    if (handle.cancelled) return;
-    await modelDownloadRepository.setStatus(download.id, 'failed', {
-      error: `install (rename) failed: ${err instanceof Error ? err.message : String(err)}`,
-    });
-    return;
+  // The final target is shared across users (content-addressable —
+  // we just verified SHA-256 above, so any existing file at this
+  // path is by definition the same model). If another download
+  // already installed it (concurrent same-model fetch from a
+  // different user/row), skip the rename entirely and just discard
+  // our partial. The previous "unlink target → rename" sequence had
+  // a window where a renameSync failure could leave the host with
+  // no GGUF after we'd already deleted the good one.
+  if (existsSync(download.target_path)) {
+    try { unlinkSync(partialPath); } catch { /* best effort */ }
+  } else {
+    try {
+      renameSync(partialPath, download.target_path);
+    } catch (err) {
+      // Race fallback: someone else won between our existsSync and
+      // our rename. If the target now exists, treat as installed —
+      // otherwise this is a real install failure.
+      if (existsSync(download.target_path)) {
+        try { unlinkSync(partialPath); } catch { /* best effort */ }
+      } else {
+        inFlight.delete(download.id);
+        if (handle.cancelled) return;
+        await modelDownloadRepository.setStatus(download.id, 'failed', {
+          error: `install (rename) failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+        return;
+      }
+    }
   }
 
   inFlight.delete(download.id);

--- a/apps/web/public/js/components/embedded-llm-card.js
+++ b/apps/web/public/js/components/embedded-llm-card.js
@@ -227,6 +227,20 @@ function startPolling(container, userId, downloadId) {
   stopPolling();
   _activeDownloadId = downloadId;
   _pollTimer = setInterval(async () => {
+    // Stop polling if the user navigated away from Settings or the
+    // card container was detached/replaced (e.g. by a different
+    // settings sub-render). Otherwise we'd keep hitting the API
+    // every second forever and hold a reference to a dead DOM node.
+    const hash = (window.location.hash || '').split('?')[0];
+    if (hash !== '#/settings') {
+      stopPolling();
+      return;
+    }
+    if (typeof document !== 'undefined'
+        && document.getElementById(CARD_TARGET_ID) !== container) {
+      stopPolling();
+      return;
+    }
     try {
       const data = await fetchModelDownload(downloadId);
       const dl = data?.download;


### PR DESCRIPTION
## Summary

Follow-up to PR #247 (the embedded LLM model downloader). Copilot's third-round review landed after I merged — four substantive findings that need fixing.

## Findings addressed

### 1. Multi-user partial-file collision

Two users on the same API host downloading the same model both wrote to `<modelDir>/<modelId>.gguf.partial`. Concurrent streams would corrupt each other; one user's cancel would delete the other's partial.

**Fix**: the final GGUF is content-addressable (we SHA-256 verify before atomic rename), so it stays shared at `<modelDir>/<modelId>.gguf`. Partials now namespace by the download row id: `<modelDir>/<modelId>.gguf.<download.id>.partial`.

### 2. Pause-on-pending was silently overridden

`pauseDownload()` set DB to `paused`, but the already-scheduled `runDownload()` would start anyway and immediately overwrite back to `downloading`. Same path for pending→cancelled — the user's intent got nuked by the async runner picking up the pre-pause row.

**Fix**: at the top of `runDownload()`, re-fetch the row from DB. If status flipped to `paused`/`cancelled`/`complete`/`failed` between `startDownload()` returning and the runner picking up, return early.

### 3. Polling continued after navigating away

The 1s poll callback in `embedded-llm-card.js` had no termination condition tied to page navigation. Going to Approvals while a download was in flight kept hitting `/api/embedded-llm/downloads/:id` every second forever and held a reference to a detached `#embedded-llm-card-target` node.

**Fix**: poll callback now checks `window.location.hash !== '#/settings'` and `document.getElementById(CARD_TARGET_ID) !== container` at the top of each tick, and self-cancels.

### 4. `ensureDirectory()` dead code

Already removed in round-2 fix on PR #247 itself.

## Test plan

- [x] `pnpm build --concurrency=1` clean
- [x] 25 embedded-llm route tests still passing
- [ ] Manual: two simultaneous downloads (different users, same model) don't collide
- [ ] Manual: click Pause on a `pending` row before transfer starts → row stays `paused`
- [ ] Manual: start a download, navigate to Approvals → polling stops within 1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)