### PR TITLE
feat(#251 Layer 1 + Layer 3 minimal): stamp authoring tier on email signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Memory bootstrap: stamp every signal with an authoring tier (#251 Layer 1)
+
+The first slice of #251. Layer 1 only labels the data — no retrieval-side
+weighting yet (that's Layer 2, gated on `realistic-retrieval.test.ts`
+improving) — so this PR is reversible and observable on its own.
+
+- **New: `AuthoringTier` enum + classifier in `@skytwin/connectors`.**
+  Six tiers (`user_sent_originated`, `user_sent_reply`, `inbox_personal`,
+  `inbox_broadcast`, `inbox_newsletter`, `inbox_automated`) capturing the
+  asymmetry between mail the user authored vs. merely received. The field
+  name is channel-agnostic on purpose (`authoringTier`, not
+  `gmailLabel`/`senderTier`); Slack/Notion connectors can extend the enum
+  later without rebuilding the memory schema.
+
+- **Gmail connector fetches the headers needed to classify.** Added
+  `To`, `Cc`, `In-Reply-To`, `List-Unsubscribe` to the
+  `metadataHeaders=` URL on `messages/<id>?format=metadata`. One extra
+  HTTP-header byte per message; the rest of the payload is unchanged.
+  Every emitted `RawSignal` carries `data.authoringTier`.
+
+- **Embedded gbrain port projects `authoringTier` onto
+  `brain_pages.metadata`.** When a connector stamps the field, the page
+  metadata gets `{ signalSource, signalType, authoringTier }`; when the
+  field is missing or non-string the page metadata falls back to the
+  previous two-key shape. No schema migration — `metadata` is JSONB.
+
+- **Layer 3 minimal: sent-first bootstrap ordering.** The first poll
+  for a new user now lists `in:sent newer_than:7d` BEFORE
+  `is:unread newer_than:1d` and deduplicates by message id. The user's
+  first brain pages lead with things they wrote, not the inbox noise that
+  happens to be unread. Failure on either list query degrades gracefully
+  to the other; both empty falls back to `/users/me/profile` for the
+  cursor exactly as before.
+
+Tests: 18 new unit tests for the classifier (`authoring-tier.test.ts`),
+6 new tests for the Gmail signal pipeline (tier stamping for each of the
+six tiers), 1 new test for sent-first bootstrap ordering, and 3 new tests
+for the embedded-port metadata projection. Full workspace test run:
+70 tasks, all green.
+
+What this doesn't ship (deliberate, deferred to follow-ups):
+
+- **Layer 2 retrieval weighting.** The RRF fold and `DecisionMaker`
+  pattern boost still read `brain_pages` uniformly. Wiring those to the
+  new tier requires re-running `realistic-retrieval.test.ts` with
+  candidate weight schedules and accepting whichever schedule moves R@5
+  up (or holds it constant) on the labeled corpus. That gate is the
+  whole point of Layer 2 being a separate PR.
+- **Migration backfilling tier on existing pages.** Tier is only stamped
+  on signals written after this lands. A backfill migration is cheap to
+  write (re-read the Gmail label + From header for stored signal rows)
+  but is a separate concern from the live ingest path.
+
 ## [unreleased] — Embedded LLM downloader: round-3 review fixes (#187 AC#2 follow-up)
 
 Copilot's third-round review of PR #247 landed after merge — four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@ All notable changes to SkyTwin will be documented in this file.
 
 ## [unreleased] — Memory bootstrap: stamp every signal with an authoring tier (#251 Layer 1)
 
+### Fixed (post-Copilot review)
+
+- `listMessageIds()` no longer swallows all errors. Non-transient
+  failures (persistent auth, 4xx other than 404, malformed account
+  state) propagate so the worker surfaces "your Google connection has
+  a problem" rather than silently bootstrapping zero signals forever.
+  Only `RetryableHttpError` (rate-limit / 5xx after retries) still
+  degrades to `[]` so one transient list failure doesn't take out the
+  other batch.
+- `AUTOMATED_DOMAIN_PATTERNS` doc comment now accurately describes
+  the deliberate asymmetry: most entries are end-anchored at the
+  apex domain (`$`), but `noreply\.` is intentionally NOT end-
+  anchored so the `noreply.<vendor>.com` long tail is caught.
+
+### Original change
+
 The first slice of #251. Layer 1 only labels the data — no retrieval-side
 weighting yet (that's Layer 2, gated on `realistic-retrieval.test.ts`
 improving) — so this PR is reversible and observable on its own.

--- a/packages/connectors/src/__tests__/authoring-tier.test.ts
+++ b/packages/connectors/src/__tests__/authoring-tier.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyEmailAuthoringTier,
+  extractBareAddress,
+  isAutomatedSender,
+  splitAddressList,
+} from '../authoring-tier.js';
+
+describe('extractBareAddress', () => {
+  it('strips display name + angle brackets', () => {
+    expect(extractBareAddress('Acme <noreply@acme.com>')).toBe('noreply@acme.com');
+  });
+
+  it('lowercases the result', () => {
+    expect(extractBareAddress('JANE@EXAMPLE.COM')).toBe('jane@example.com');
+  });
+
+  it('returns the raw input when no angle brackets are present', () => {
+    expect(extractBareAddress('jane@example.com')).toBe('jane@example.com');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(extractBareAddress('')).toBe('');
+  });
+});
+
+describe('splitAddressList', () => {
+  it('splits a comma-separated list and extracts bare addresses', () => {
+    const out = splitAddressList('"Jane" <jane@example.com>, joe@example.com');
+    expect(out).toEqual(['jane@example.com', 'joe@example.com']);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(splitAddressList('')).toEqual([]);
+  });
+
+  it('drops empty fragments produced by trailing commas', () => {
+    expect(splitAddressList('a@x.com, ,b@x.com')).toEqual(['a@x.com', 'b@x.com']);
+  });
+});
+
+describe('isAutomatedSender', () => {
+  it('flags noreply / no-reply local parts', () => {
+    expect(isAutomatedSender('noreply@acme.com')).toBe(true);
+    expect(isAutomatedSender('no-reply@acme.com')).toBe(true);
+    expect(isAutomatedSender('do-not-reply@acme.com')).toBe(true);
+  });
+
+  it('flags subaddressed automated senders', () => {
+    expect(isAutomatedSender('noreply+thread-42@acme.com')).toBe(true);
+    expect(isAutomatedSender('notifications.thread-42@github.com')).toBe(true);
+  });
+
+  it('flags known transactional sender domains', () => {
+    expect(isAutomatedSender('hello@sub.mailchimp.com')).toBe(true);
+    expect(isAutomatedSender('list@amazonses.com')).toBe(true);
+    expect(isAutomatedSender('updates@noreply.vendor.com')).toBe(true);
+  });
+
+  it('does NOT flag human-looking senders', () => {
+    expect(isAutomatedSender('jane@acme.com')).toBe(false);
+    expect(isAutomatedSender('support@acme.com')).toBe(false);
+    expect(isAutomatedSender('hello@acme.com')).toBe(false);
+  });
+
+  it('handles display names', () => {
+    expect(isAutomatedSender('"Acme Alerts" <alerts@acme.com>')).toBe(true);
+  });
+
+  it('handles malformed addresses without throwing', () => {
+    expect(isAutomatedSender('')).toBe(false);
+    expect(isAutomatedSender('not-an-email')).toBe(false);
+  });
+});
+
+describe('classifyEmailAuthoringTier', () => {
+  const base = {
+    labels: [] as string[],
+    fromAddress: 'someone@example.com',
+    toAddresses: ['user@example.com'],
+    ccAddresses: [] as string[],
+    hasInReplyTo: false,
+    hasListUnsubscribe: false,
+    listId: '',
+  };
+
+  it('classifies SENT + no In-Reply-To as user_sent_originated', () => {
+    expect(classifyEmailAuthoringTier({ ...base, labels: ['SENT'] })).toBe(
+      'user_sent_originated',
+    );
+  });
+
+  it('classifies SENT + In-Reply-To as user_sent_reply', () => {
+    expect(
+      classifyEmailAuthoringTier({ ...base, labels: ['SENT'], hasInReplyTo: true }),
+    ).toBe('user_sent_reply');
+  });
+
+  it('treats SENT as dominant even when other tier signals fire', () => {
+    // List-Unsubscribe on a SENT message is rare (e.g. mailing-list moderator
+    // sending a list-relayed message). It should still count as user_sent_*.
+    expect(
+      classifyEmailAuthoringTier({
+        ...base,
+        labels: ['SENT'],
+        hasListUnsubscribe: true,
+        listId: 'something.list',
+      }),
+    ).toBe('user_sent_originated');
+  });
+
+  it('classifies List-Unsubscribe inbox mail as inbox_newsletter', () => {
+    expect(
+      classifyEmailAuthoringTier({ ...base, hasListUnsubscribe: true }),
+    ).toBe('inbox_newsletter');
+  });
+
+  it('classifies List-Id inbox mail as inbox_newsletter', () => {
+    expect(classifyEmailAuthoringTier({ ...base, listId: 'rangers.list' })).toBe(
+      'inbox_newsletter',
+    );
+  });
+
+  it('classifies CATEGORY_PROMOTIONS as inbox_newsletter', () => {
+    expect(
+      classifyEmailAuthoringTier({ ...base, labels: ['INBOX', 'CATEGORY_PROMOTIONS'] }),
+    ).toBe('inbox_newsletter');
+  });
+
+  it('classifies noreply senders as inbox_automated', () => {
+    expect(
+      classifyEmailAuthoringTier({ ...base, fromAddress: 'noreply@stripe.com' }),
+    ).toBe('inbox_automated');
+  });
+
+  it('prefers newsletter over automated when both fire', () => {
+    // A mailchimp-relayed newsletter has both a List-Unsubscribe header AND
+    // a sending domain that matches the automated regex. Newsletter wins.
+    expect(
+      classifyEmailAuthoringTier({
+        ...base,
+        fromAddress: 'news@sub.mailchimp.com',
+        hasListUnsubscribe: true,
+      }),
+    ).toBe('inbox_newsletter');
+  });
+
+  it('classifies multi-recipient inbox mail as inbox_broadcast', () => {
+    expect(
+      classifyEmailAuthoringTier({
+        ...base,
+        toAddresses: ['user@example.com', 'other@example.com'],
+      }),
+    ).toBe('inbox_broadcast');
+  });
+
+  it('counts To + Cc together for the broadcast threshold', () => {
+    expect(
+      classifyEmailAuthoringTier({
+        ...base,
+        toAddresses: ['user@example.com'],
+        ccAddresses: ['observer@example.com'],
+      }),
+    ).toBe('inbox_broadcast');
+  });
+
+  it('defaults single-recipient human mail to inbox_personal', () => {
+    expect(classifyEmailAuthoringTier(base)).toBe('inbox_personal');
+  });
+
+  it('returns inbox_personal for zero-recipient edge case', () => {
+    // Defensive: malformed headers occasionally drop To. Don't claim
+    // broadcast for a message with no parseable recipients.
+    expect(
+      classifyEmailAuthoringTier({ ...base, toAddresses: [], ccAddresses: [] }),
+    ).toBe('inbox_personal');
+  });
+});

--- a/packages/connectors/src/__tests__/gmail-connector.test.ts
+++ b/packages/connectors/src/__tests__/gmail-connector.test.ts
@@ -204,6 +204,118 @@ describe('GmailConnector.messageToSignal', () => {
     expect(sig.data.from).toBe('');
     expect(sig.data.subject).toBe('');
   });
+
+  // #251 Layer 1: messageToSignal stamps `data.authoringTier` so downstream
+  // memory writers can project it onto brain_pages.metadata without re-
+  // reading raw Gmail headers.
+  it('stamps authoringTier=user_sent_originated for SENT mail with no In-Reply-To', () => {
+    const msg = {
+      id: 'm-sent',
+      threadId: 't-sent',
+      labelIds: ['SENT'],
+      snippet: '',
+      payload: {
+        headers: [
+          { name: 'From', value: 'me@example.com' },
+          { name: 'To', value: 'friend@example.com' },
+        ],
+      },
+      internalDate: '1735689600000',
+    };
+    const sig = toSignal(msg) as { data: { authoringTier: string } };
+    expect(sig.data.authoringTier).toBe('user_sent_originated');
+  });
+
+  it('stamps authoringTier=user_sent_reply when In-Reply-To is present', () => {
+    const msg = {
+      id: 'm-sent-reply',
+      threadId: 't-sent-reply',
+      labelIds: ['SENT'],
+      snippet: '',
+      payload: {
+        headers: [
+          { name: 'From', value: 'me@example.com' },
+          { name: 'To', value: 'friend@example.com' },
+          { name: 'In-Reply-To', value: '<original-id@mail.example.com>' },
+        ],
+      },
+      internalDate: '1735689600000',
+    };
+    const sig = toSignal(msg) as { data: { authoringTier: string } };
+    expect(sig.data.authoringTier).toBe('user_sent_reply');
+  });
+
+  it('stamps authoringTier=inbox_newsletter when List-Unsubscribe is present', () => {
+    const msg = {
+      id: 'm-news',
+      threadId: 't-news',
+      labelIds: ['INBOX'],
+      snippet: '',
+      payload: {
+        headers: [
+          { name: 'From', value: 'updates@vendor.com' },
+          { name: 'List-Unsubscribe', value: '<mailto:unsubscribe@vendor.com>' },
+        ],
+      },
+      internalDate: '1735689600000',
+    };
+    const sig = toSignal(msg) as { data: { authoringTier: string } };
+    expect(sig.data.authoringTier).toBe('inbox_newsletter');
+  });
+
+  it('stamps authoringTier=inbox_automated for noreply senders without list semantics', () => {
+    const msg = {
+      id: 'm-auto',
+      threadId: 't-auto',
+      labelIds: ['INBOX'],
+      snippet: '',
+      payload: {
+        headers: [
+          { name: 'From', value: 'noreply@stripe.com' },
+          { name: 'To', value: 'me@example.com' },
+        ],
+      },
+      internalDate: '1735689600000',
+    };
+    const sig = toSignal(msg) as { data: { authoringTier: string } };
+    expect(sig.data.authoringTier).toBe('inbox_automated');
+  });
+
+  it('stamps authoringTier=inbox_broadcast when To has multiple recipients', () => {
+    const msg = {
+      id: 'm-bcast',
+      threadId: 't-bcast',
+      labelIds: ['INBOX'],
+      snippet: '',
+      payload: {
+        headers: [
+          { name: 'From', value: 'leader@example.com' },
+          { name: 'To', value: 'me@example.com, other@example.com' },
+        ],
+      },
+      internalDate: '1735689600000',
+    };
+    const sig = toSignal(msg) as { data: { authoringTier: string } };
+    expect(sig.data.authoringTier).toBe('inbox_broadcast');
+  });
+
+  it('defaults inbox single-recipient mail to authoringTier=inbox_personal', () => {
+    const msg = {
+      id: 'm-personal',
+      threadId: 't-personal',
+      labelIds: ['INBOX'],
+      snippet: '',
+      payload: {
+        headers: [
+          { name: 'From', value: 'friend@example.com' },
+          { name: 'To', value: 'me@example.com' },
+        ],
+      },
+      internalDate: '1735689600000',
+    };
+    const sig = toSignal(msg) as { data: { authoringTier: string } };
+    expect(sig.data.authoringTier).toBe('inbox_personal');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -433,5 +545,72 @@ describe('GmailConnector History API', () => {
     const conn = new GmailConnector('user-1', makeFreshTokenStore());
     await conn.connect();
     await expect(conn.poll()).resolves.toEqual([]);
+  });
+
+  // #251 Layer 3 (minimal): bootstrap emits sent mail FIRST so the user's
+  // first-impression brain pages lead with things they wrote rather than
+  // whatever happened to be unread. Layer 1 above stamps the tier; this
+  // test verifies the ordering side of the contract.
+  it('bootstrap emits in:sent results before is:unread, deduped by id', async () => {
+    const listCalls: string[] = [];
+    vi.stubGlobal('fetch', makeFetchRouter({
+      '/users/me/messages?q=': (url) => {
+        listCalls.push(url);
+        if (url.includes('in%3Asent')) {
+          return jsonResponse({ messages: [{ id: 'sent-1' }, { id: 'shared' }] });
+        }
+        // is:unread branch
+        return jsonResponse({ messages: [{ id: 'shared' }, { id: 'unread-1' }] });
+      },
+      '/users/me/messages/sent-1': () => jsonResponse({
+        id: 'sent-1',
+        threadId: 't-sent-1',
+        labelIds: ['SENT'],
+        snippet: '',
+        payload: { headers: [{ name: 'From', value: 'me@example.com' }] },
+        internalDate: '1735689600000',
+        historyId: '1100',
+      }),
+      '/users/me/messages/shared': () => jsonResponse({
+        id: 'shared',
+        threadId: 't-shared',
+        labelIds: ['SENT', 'INBOX'],
+        snippet: '',
+        payload: { headers: [{ name: 'From', value: 'me@example.com' }] },
+        internalDate: '1735689600000',
+        historyId: '1200',
+      }),
+      '/users/me/messages/unread-1': () => jsonResponse({
+        id: 'unread-1',
+        threadId: 't-unread-1',
+        labelIds: ['INBOX'],
+        snippet: '',
+        payload: { headers: [{ name: 'From', value: 'friend@example.com' }] },
+        internalDate: '1735689600000',
+        historyId: '1300',
+      }),
+    }));
+
+    const cursor = makeMemoryCursor();
+    const conn = new GmailConnector('user-1', makeFreshTokenStore(), cursor);
+    await conn.connect();
+    const signals = await conn.poll();
+
+    // Both list queries hit (sent-first), and unread is fetched even though
+    // the sent list already covered one of its ids.
+    expect(listCalls.length).toBe(2);
+    expect(listCalls[0]).toContain('in%3Asent');
+    expect(listCalls[1]).toContain('is%3Aunread');
+
+    // Sent ids appear first; shared id is deduped to its sent-list position;
+    // unread-only id appears last.
+    expect(signals.map((s) => s.id)).toEqual([
+      'sig_gmail_sent-1',
+      'sig_gmail_shared',
+      'sig_gmail_unread-1',
+    ]);
+
+    // Highest historyId observed across all three messages wins the cursor.
+    expect(cursor.snapshot['user-1:gmail:history_id']).toBe('1300');
   });
 });

--- a/packages/connectors/src/authoring-tier.ts
+++ b/packages/connectors/src/authoring-tier.ts
@@ -65,9 +65,15 @@ const AUTOMATED_LOCAL_PARTS = new Set<string>([
 
 /**
  * Known transactional sender-domain patterns. These are domains that
- * structurally do not host humans — only system-generated mail. Anchored to
- * the end of the host so subdomains of legitimate human mail providers don't
- * false-match.
+ * structurally do not host humans — only system-generated mail.
+ *
+ * Most patterns are anchored at BOTH the host-component boundary
+ * `(^|\.)` and the end of the host `$` so subdomains of legitimate
+ * human mail providers don't false-match. The `noreply\.` pattern is
+ * deliberately NOT end-anchored: it matches the `noreply.<anything>`
+ * subdomain alias pattern SaaS apps use (e.g. `noreply.github.com`,
+ * `noreply.acme.com`). The trade-off is intentional and Copilot
+ * called it out on PR #252.
  */
 const AUTOMATED_DOMAIN_PATTERNS: RegExp[] = [
   /(^|\.)mailchimp\.com$/i,
@@ -76,9 +82,9 @@ const AUTOMATED_DOMAIN_PATTERNS: RegExp[] = [
   /(^|\.)amazonses\.com$/i,
   /(^|\.)sparkpostmail\.com$/i,
   /(^|\.)mailgun\.org$/i,
-  // GitHub notifications: from `notifications@github.com`, but the local-part
-  // match already catches that. The subdomain `noreply.` catch covers the
-  // long tail of `noreply.<vendor>.com` aliases used by SaaS apps.
+  // Subdomain-prefix anchor only: catches the `noreply.<vendor>.com`
+  // long tail. Intentional asymmetry with the end-anchored entries
+  // above, which target a specific apex domain.
   /(^|\.)noreply\./i,
 ];
 

--- a/packages/connectors/src/authoring-tier.ts
+++ b/packages/connectors/src/authoring-tier.ts
@@ -1,0 +1,185 @@
+/**
+ * Authoring-tier classification for inbound signals (#251 Layer 1).
+ *
+ * Every email signal is labelled with an `AuthoringTier` at write time so the
+ * downstream memory layer (`brain_pages.metadata.authoringTier`) carries a
+ * stable hint about whether the user authored the content or merely received
+ * it. Layer 2 (retrieval weighting) reads this metadata; Layer 1 only writes
+ * it. The classifier is intentionally side-effect-free so it can be unit-tested
+ * without spinning up a connector.
+ *
+ * The vocabulary is email-shaped but the field name (`authoringTier`) is
+ * deliberately channel-agnostic — when Slack/Notion/etc. connectors land they
+ * can extend `AuthoringTier` with `authored_originated` / `received_personal`
+ * / etc. without rebuilding the memory schema.
+ */
+
+export type AuthoringTier =
+  | 'user_sent_originated'
+  | 'user_sent_reply'
+  | 'inbox_personal'
+  | 'inbox_broadcast'
+  | 'inbox_newsletter'
+  | 'inbox_automated';
+
+export interface EmailAuthoringInputs {
+  /** Gmail labelIds on the message (e.g. `SENT`, `INBOX`, `CATEGORY_PROMOTIONS`). */
+  labels: string[];
+  /** Raw `From:` value (display name + address). */
+  fromAddress: string;
+  /** Bare addresses extracted from the `To:` header. */
+  toAddresses: string[];
+  /** Bare addresses extracted from the `Cc:` header. */
+  ccAddresses: string[];
+  /** True when an `In-Reply-To:` header is present (i.e. this is a reply, not a fresh thread). */
+  hasInReplyTo: boolean;
+  /** True when a `List-Unsubscribe:` header is present. */
+  hasListUnsubscribe: boolean;
+  /** Parsed `List-Id:` value (e.g. `rangers.lists.example.org`) or `''`. */
+  listId: string;
+}
+
+/**
+ * Local parts that almost always indicate an automated/transactional sender.
+ * Matches exactly OR `<part>+...` (Gmail subaddressing) OR `<part>.<digits>...`
+ * (e.g. `notifications.123` for thread-specific reply-tos). Deliberately
+ * conservative — `support@`, `hello@`, `team@` are not included because they
+ * are often staffed by humans.
+ */
+const AUTOMATED_LOCAL_PARTS = new Set<string>([
+  'noreply',
+  'no-reply',
+  'donotreply',
+  'do-not-reply',
+  'notifications',
+  'notification',
+  'alerts',
+  'alert',
+  'mailer-daemon',
+  'postmaster',
+  'auto-confirm',
+  'automated',
+  'auto-reply',
+  'autoreply',
+]);
+
+/**
+ * Known transactional sender-domain patterns. These are domains that
+ * structurally do not host humans — only system-generated mail. Anchored to
+ * the end of the host so subdomains of legitimate human mail providers don't
+ * false-match.
+ */
+const AUTOMATED_DOMAIN_PATTERNS: RegExp[] = [
+  /(^|\.)mailchimp\.com$/i,
+  /(^|\.)sendgrid\.net$/i,
+  /(^|\.)mandrillapp\.com$/i,
+  /(^|\.)amazonses\.com$/i,
+  /(^|\.)sparkpostmail\.com$/i,
+  /(^|\.)mailgun\.org$/i,
+  // GitHub notifications: from `notifications@github.com`, but the local-part
+  // match already catches that. The subdomain `noreply.` catch covers the
+  // long tail of `noreply.<vendor>.com` aliases used by SaaS apps.
+  /(^|\.)noreply\./i,
+];
+
+/**
+ * Strip display name and angle brackets from an RFC 5322 address. Falls back
+ * to the raw input if no angle-bracketed address is present. Lowercased.
+ *
+ * `"Acme <noreply@acme.com>"` → `noreply@acme.com`
+ * `noreply@acme.com`          → `noreply@acme.com`
+ * `""`                         → `""`
+ */
+export function extractBareAddress(raw: string): string {
+  if (!raw) return '';
+  const angle = raw.match(/<([^>]+)>/);
+  if (angle && angle[1]) return angle[1].trim().toLowerCase();
+  return raw.trim().toLowerCase();
+}
+
+/**
+ * Split an address-list header value (`To:`, `Cc:`) into bare addresses.
+ * RFC 5322 allows commas inside quoted display names, but the headers we
+ * care about here come from Gmail's API which serializes them cleanly. A
+ * simple comma-split with bare-address extraction is good enough for tier
+ * classification — false positives just push us toward `inbox_broadcast`,
+ * which is the safer side.
+ */
+export function splitAddressList(raw: string): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((part) => extractBareAddress(part))
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Return true if the address looks automated (no-reply / mailer / vendor
+ * sending infrastructure). The classifier uses this only when the message is
+ * NOT in `SENT` and is NOT already classified as newsletter/list mail —
+ * automated senders that ALSO ship `List-Unsubscribe` (typical) are caught
+ * by the earlier newsletter branch.
+ */
+export function isAutomatedSender(rawFrom: string): boolean {
+  const addr = extractBareAddress(rawFrom);
+  if (!addr) return false;
+  const at = addr.indexOf('@');
+  if (at === -1) return false;
+  const local = addr.slice(0, at);
+  const domain = addr.slice(at + 1);
+
+  // Exact-match local-part hits (the common case: `noreply@acme.com`).
+  if (AUTOMATED_LOCAL_PARTS.has(local)) return true;
+  // Gmail subaddressing variant: `noreply+thread-id@acme.com`.
+  const plus = local.indexOf('+');
+  if (plus > 0 && AUTOMATED_LOCAL_PARTS.has(local.slice(0, plus))) return true;
+  // Dot-delimited variant: `notifications.42@github.com`.
+  const dot = local.indexOf('.');
+  if (dot > 0 && AUTOMATED_LOCAL_PARTS.has(local.slice(0, dot))) return true;
+
+  return AUTOMATED_DOMAIN_PATTERNS.some((re) => re.test(domain));
+}
+
+/**
+ * Classify an email signal into one of the six authoring tiers.
+ *
+ * Order of checks is significant:
+ *
+ *   1. `SENT` label dominates everything — anything the user typed is in the
+ *      top two tiers regardless of who it was to or what it looked like.
+ *      Reply vs. fresh thread is decided by `In-Reply-To`.
+ *   2. Newsletter / list mail beats everything else in inbox — list senders
+ *      that happen to look automated should still be labelled `newsletter`
+ *      (the user can subscribe to genuinely valuable lists; `automated` is
+ *      reserved for transactional / system mail with no list semantics).
+ *   3. Automated / transactional comes next so receipts and notifications
+ *      don't slip into `personal` just because they don't have a List-Id.
+ *   4. Broadcast: multi-recipient mail the user is one of several recipients
+ *      on. Threshold is `> 1` total addressees across To+Cc.
+ *   5. Default: one-to-one human mail.
+ */
+export function classifyEmailAuthoringTier(input: EmailAuthoringInputs): AuthoringTier {
+  const labelSet = new Set(input.labels);
+
+  if (labelSet.has('SENT')) {
+    return input.hasInReplyTo ? 'user_sent_reply' : 'user_sent_originated';
+  }
+
+  if (
+    input.hasListUnsubscribe ||
+    input.listId.length > 0 ||
+    labelSet.has('CATEGORY_PROMOTIONS')
+  ) {
+    return 'inbox_newsletter';
+  }
+
+  if (isAutomatedSender(input.fromAddress)) {
+    return 'inbox_automated';
+  }
+
+  if (input.toAddresses.length + input.ccAddresses.length > 1) {
+    return 'inbox_broadcast';
+  }
+
+  return 'inbox_personal';
+}

--- a/packages/connectors/src/gmail-connector.ts
+++ b/packages/connectors/src/gmail-connector.ts
@@ -1,6 +1,11 @@
 import type { SignalConnector, RawSignal, SignalHandler } from './connector-interface.js';
 import type { OAuthTokenStore } from './oauth/token-store.js';
 import { withRetry, RetryableHttpError, parseRetryAfter, normalizeSenderAddress } from '@skytwin/core';
+import {
+  classifyEmailAuthoringTier,
+  splitAddressList,
+  type AuthoringTier,
+} from './authoring-tier.js';
 
 const GMAIL_API = 'https://gmail.googleapis.com/gmail/v1';
 
@@ -129,15 +134,33 @@ export class GmailConnector implements SignalConnector {
   // ── First-run bootstrap ───────────────────────────────────────────────
 
   /**
-   * No cursor yet — list recent unread, emit them as signals, then store
-   * the highest historyId we observed so the next poll switches to
-   * incremental mode.
+   * No cursor yet — bootstrap by listing recent sent + unread mail, emit
+   * them as signals, then store the highest historyId we observed so the
+   * next poll switches to incremental mode.
+   *
+   * #251 Layer 3 (minimal): sent mail is fetched FIRST so the user's first-
+   * impression brain pages lead with things they wrote themselves rather
+   * than with whatever happened to be unread in the inbox. The two batches
+   * are deduped by message id, sent ids are processed first, and
+   * historyId-derived cursor advancement is unchanged (the cursor still
+   * picks the max across all observed messages).
    */
   private async bootstrapAndEmit(accessToken: string): Promise<RawSignal[]> {
-    const listUrl = `${GMAIL_API}/users/me/messages?q=${encodeURIComponent('is:unread newer_than:1d')}&maxResults=10`;
-    const listResp = await this.gmailGet(listUrl, accessToken, 'list');
-    const listJson = await listResp.json() as { messages?: Array<{ id: string }> };
-    const ids = (listJson.messages ?? []).map((m) => m.id);
+    const sentUrl = `${GMAIL_API}/users/me/messages?q=${encodeURIComponent('in:sent newer_than:7d')}&maxResults=10`;
+    const unreadUrl = `${GMAIL_API}/users/me/messages?q=${encodeURIComponent('is:unread newer_than:1d')}&maxResults=10`;
+
+    const sentIds = await this.listMessageIds(sentUrl, accessToken);
+    const unreadIds = await this.listMessageIds(unreadUrl, accessToken);
+
+    // Dedupe while preserving sent-first ordering.
+    const seen = new Set<string>();
+    const ids: string[] = [];
+    for (const id of [...sentIds, ...unreadIds]) {
+      if (!seen.has(id)) {
+        seen.add(id);
+        ids.push(id);
+      }
+    }
 
     if (ids.length === 0) {
       // Even with no messages we want a cursor for next poll. Use the
@@ -150,6 +173,26 @@ export class GmailConnector implements SignalConnector {
     const { signals, maxHistoryId } = await this.fetchAndConvert(ids, accessToken);
     if (maxHistoryId) await this.persistCursor(maxHistoryId);
     return signals;
+  }
+
+  /**
+   * Helper: GET a `users/me/messages?q=...` listing and return the message
+   * ids, swallowing network errors as an empty list (Layer 3 bootstrap should
+   * never hard-fail just because one of the two list queries returned 500 —
+   * the other batch can still serve the first-impression need).
+   */
+  private async listMessageIds(url: string, accessToken: string): Promise<string[]> {
+    try {
+      const resp = await this.gmailGet(url, accessToken, 'list');
+      const body = await resp.json() as { messages?: Array<{ id: string }> };
+      return (body.messages ?? []).map((m) => m.id);
+    } catch (err) {
+      console.warn(
+        `[gmail] Bootstrap list failed (${url}):`,
+        err instanceof Error ? err.message : String(err),
+      );
+      return [];
+    }
   }
 
   // ── Incremental polling ───────────────────────────────────────────────
@@ -309,7 +352,12 @@ export class GmailConnector implements SignalConnector {
     messageId: string,
     accessToken: string,
   ): Promise<GmailMessage | null> {
-    const url = `${GMAIL_API}/users/me/messages/${messageId}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date&metadataHeaders=List-Id`;
+    // #251 Layer 1: classifier reads To/Cc (recipient count → broadcast vs.
+    // personal), In-Reply-To (originated vs. reply for SENT mail), and
+    // List-Unsubscribe (newsletter detection beyond CATEGORY_PROMOTIONS).
+    // Adding these to metadataHeaders is cheap — Gmail returns one extra
+    // header value per requested name and we only fetch when present.
+    const url = `${GMAIL_API}/users/me/messages/${messageId}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date&metadataHeaders=List-Id&metadataHeaders=To&metadataHeaders=Cc&metadataHeaders=In-Reply-To&metadataHeaders=List-Unsubscribe`;
     try {
       const response = await this.gmailGet(url, accessToken, 'detail');
       return response.json() as Promise<GmailMessage>;
@@ -334,6 +382,15 @@ export class GmailConnector implements SignalConnector {
     const subject = getHeader('Subject');
     const listId = parseListId(getHeader('List-Id'));
     const type = this.inferEmailType(from, subject, message.labelIds);
+    const authoringTier: AuthoringTier = classifyEmailAuthoringTier({
+      labels: message.labelIds ?? [],
+      fromAddress: from,
+      toAddresses: splitAddressList(getHeader('To')),
+      ccAddresses: splitAddressList(getHeader('Cc')),
+      hasInReplyTo: getHeader('In-Reply-To').trim().length > 0,
+      hasListUnsubscribe: getHeader('List-Unsubscribe').trim().length > 0,
+      listId,
+    });
 
     return {
       id: `sig_gmail_${message.id}`,
@@ -347,6 +404,7 @@ export class GmailConnector implements SignalConnector {
         snippet: message.snippet,
         labels: message.labelIds,
         listId,
+        authoringTier,
         receivedAt: new Date(parseInt(message.internalDate, 10)).toISOString(),
         requiresResponse: type === 'work_email' || type === 'meeting_invite',
       },
@@ -441,3 +499,4 @@ export function parseListId(raw: string): string {
   // Some senders ship the bare identifier with no angle brackets.
   return raw.trim().toLowerCase();
 }
+

--- a/packages/connectors/src/gmail-connector.ts
+++ b/packages/connectors/src/gmail-connector.ts
@@ -306,8 +306,16 @@ export class GmailConnector implements SignalConnector {
       const resp = await this.gmailGet(`${GMAIL_API}/users/me/profile`, accessToken, 'profile');
       const body = await resp.json() as { historyId?: string };
       return body.historyId ?? null;
-    } catch {
-      return null;
+    } catch (err) {
+      // Symmetric with listMessageIds: transient failures degrade
+      // to null (the caller writes no cursor and re-tries next poll);
+      // non-transient failures (persistent auth, 4xx) propagate so a
+      // broken token/scope surfaces as a hard failure rather than an
+      // infinite "bootstrap returns [] with no cursor" loop. Copilot
+      // round-2 on PR #252 flagged the prior `catch { return null }`
+      // for hiding auth errors.
+      if (err instanceof RetryableHttpError) return null;
+      throw err;
     }
   }
 

--- a/packages/connectors/src/gmail-connector.ts
+++ b/packages/connectors/src/gmail-connector.ts
@@ -177,9 +177,12 @@ export class GmailConnector implements SignalConnector {
 
   /**
    * Helper: GET a `users/me/messages?q=...` listing and return the message
-   * ids, swallowing network errors as an empty list (Layer 3 bootstrap should
-   * never hard-fail just because one of the two list queries returned 500 —
-   * the other batch can still serve the first-impression need).
+   * ids. Only transient failures (rate-limit / 5xx after retries) degrade
+   * to `[]` so Layer 3 bootstrap can still serve the first-impression need
+   * from the other batch. Non-transient failures (persistent auth, 4xx
+   * other than 404, malformed account state) propagate so the worker
+   * surfaces "your Google connection has a problem" instead of silently
+   * doing nothing forever — Copilot caught this on PR #252.
    */
   private async listMessageIds(url: string, accessToken: string): Promise<string[]> {
     try {
@@ -187,11 +190,13 @@ export class GmailConnector implements SignalConnector {
       const body = await resp.json() as { messages?: Array<{ id: string }> };
       return (body.messages ?? []).map((m) => m.id);
     } catch (err) {
-      console.warn(
-        `[gmail] Bootstrap list failed (${url}):`,
-        err instanceof Error ? err.message : String(err),
-      );
-      return [];
+      if (err instanceof RetryableHttpError) {
+        console.warn(
+          `[gmail] Transient bootstrap list failure (${url}): ${err.message}`,
+        );
+        return [];
+      }
+      throw err;
     }
   }
 

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -18,6 +18,13 @@ export { MockCalendarConnector } from './mock-calendar-connector.js';
 // Real connector implementations
 export { GmailConnector, normalizeSenderAddress, parseListId } from './gmail-connector.js';
 export type { CursorStore, LabelObserver } from './gmail-connector.js';
+export {
+  classifyEmailAuthoringTier,
+  extractBareAddress,
+  isAutomatedSender,
+  splitAddressList,
+} from './authoring-tier.js';
+export type { AuthoringTier, EmailAuthoringInputs } from './authoring-tier.js';
 export { GoogleCalendarConnector } from './google-calendar-connector.js';
 
 // OAuth

--- a/packages/memory-gbrain/src/__tests__/embedded-port.test.ts
+++ b/packages/memory-gbrain/src/__tests__/embedded-port.test.ts
@@ -71,6 +71,67 @@ describe('EmbeddedGbrainMemoryPort — recordSignal', () => {
     await port.recordSignal(sig);
     await expect(port.recordSignal(sig)).rejects.toThrow(/duplicate/);
   });
+
+  // #251 Layer 1: when a connector stamps `data.authoringTier`, the embedded
+  // port projects it onto `brain_pages.metadata.authoringTier` so Layer 2
+  // retrieval weighting can read it without a join back to the signal row.
+  it('projects data.authoringTier onto brain_pages.metadata', async () => {
+    const sig: RawSignal = {
+      id: 'sig-tier',
+      source: 'gmail',
+      type: 'email',
+      timestamp: new Date('2026-05-01'),
+      data: {
+        subject: 'Re: Q2 plan',
+        from: 'me@example.com',
+        authoringTier: 'user_sent_reply',
+      },
+    };
+    await port.recordSignal(sig);
+    const pages = store.getAllPages(USER);
+    expect(pages).toHaveLength(1);
+    expect(pages[0]!.metadata).toMatchObject({
+      signalSource: 'gmail',
+      signalType: 'email',
+      authoringTier: 'user_sent_reply',
+    });
+  });
+
+  it('omits authoringTier from metadata when the connector did not stamp one', async () => {
+    const sig: RawSignal = {
+      id: 'sig-no-tier',
+      source: 'cal',
+      type: 'event',
+      timestamp: new Date('2026-05-01'),
+      data: { subject: 'Lunch' },
+    };
+    await port.recordSignal(sig);
+    const pages = store.getAllPages(USER);
+    expect(pages).toHaveLength(1);
+    expect(pages[0]!.metadata).toEqual({
+      signalSource: 'cal',
+      signalType: 'event',
+    });
+    expect((pages[0]!.metadata as Record<string, unknown>)['authoringTier']).toBeUndefined();
+  });
+
+  it('ignores non-string authoringTier values defensively', async () => {
+    const sig: RawSignal = {
+      id: 'sig-bad-tier',
+      source: 'gmail',
+      type: 'email',
+      timestamp: new Date('2026-05-01'),
+      data: {
+        subject: 'X',
+        // Deliberately wrong shape to exercise the defensive non-string check
+        // in buildPageMetadata. `data: Record<string, unknown>` accepts this.
+        authoringTier: 42,
+      },
+    };
+    await port.recordSignal(sig);
+    const pages = store.getAllPages(USER);
+    expect((pages[0]!.metadata as Record<string, unknown>)['authoringTier']).toBeUndefined();
+  });
 });
 
 describe('EmbeddedGbrainMemoryPort — searchSemantic', () => {

--- a/packages/memory-gbrain/src/embedded-port.ts
+++ b/packages/memory-gbrain/src/embedded-port.ts
@@ -136,6 +136,12 @@ export class EmbeddedGbrainMemoryPort implements MemoryPort {
   async recordSignal(s: RawSignal): Promise<void> {
     const data = s.data ?? {};
     const summaryText = this.summariseSignal(s);
+    // #251 Layer 1: connectors stamp `data.authoringTier` (whether the user
+    // wrote the content or merely received it). Project it onto the brain
+    // page metadata so Layer 2 retrieval weighting can read it without a
+    // join back to the signal row. No-op when the connector didn't stamp it
+    // (e.g. calendar signals, custom event ingests).
+    const pageMetadata = this.buildPageMetadata(s, data);
     if (this.backend === 'memory') {
       this.store!.insertSignal({
         id: s.id,
@@ -157,7 +163,7 @@ export class EmbeddedGbrainMemoryPort implements MemoryPort {
         content: summaryText,
         source: 'signal',
         sourceRef: s.id,
-        metadata: { signalSource: s.source, signalType: s.type },
+        metadata: pageMetadata,
         ...(embedding ? { embedding, embeddingModel: this.embedding.model } : {}),
       });
       return;
@@ -185,9 +191,28 @@ export class EmbeddedGbrainMemoryPort implements MemoryPort {
       content: summaryText,
       source: 'signal',
       sourceRef: s.id,
-      metadata: { signalSource: s.source, signalType: s.type },
+      metadata: pageMetadata,
       ...(embedding ? { embedding, embeddingModel: this.embedding.model } : {}),
     });
+  }
+
+  /**
+   * Build the `brain_pages.metadata` object for a signal-derived page.
+   * Always carries `signalSource` / `signalType`; carries `authoringTier`
+   * only when the connector stamped one on `data.authoringTier`. Kept
+   * tolerant of unknown shapes — defensive against future connectors that
+   * may pass an object or null instead of a tier string.
+   */
+  private buildPageMetadata(s: RawSignal, data: Record<string, unknown>): Record<string, unknown> {
+    const metadata: Record<string, unknown> = {
+      signalSource: s.source,
+      signalType: s.type,
+    };
+    const tier = data['authoringTier'];
+    if (typeof tier === 'string' && tier.length > 0) {
+      metadata['authoringTier'] = tier;
+    }
+    return metadata;
   }
 
   async recordEntity(e: KnowledgeEntity): Promise<void> {


### PR DESCRIPTION
## Summary

First slice of #251. Every inbound Gmail signal is now classified into one of six `AuthoringTier` buckets at write time and stamped onto `RawSignal.data.authoringTier`. The embedded gbrain port projects that field onto `brain_pages.metadata` so the downstream retrieval layer can read it without joining back to the signal row.

**Closes (partial): #251 Layer 1 + minimal Layer 3.** Layer 2 (retrieval weighting) is intentionally NOT in this PR — that one is gated on `realistic-retrieval.test.ts` improving and ships separately.

## What changed

- `packages/connectors/src/authoring-tier.ts` (NEW) — `AuthoringTier` type + `classifyEmailAuthoringTier()` classifier. Six tiers: `user_sent_originated`, `user_sent_reply`, `inbox_personal`, `inbox_broadcast`, `inbox_newsletter`, `inbox_automated`. Field name is channel-agnostic so Slack/Notion connectors can extend the enum later without a schema change.
- `packages/connectors/src/gmail-connector.ts` —
  - Adds `To`, `Cc`, `In-Reply-To`, `List-Unsubscribe` to the `metadataHeaders=` URL on `messages/<id>?format=metadata`.
  - `messageToSignal()` calls the classifier and stamps `data.authoringTier` on every emitted `RawSignal`.
  - **Layer 3 minimal:** `bootstrapAndEmit()` now lists `in:sent newer_than:7d` BEFORE `is:unread newer_than:1d` and dedupes by id. First-impression brain pages lead with what the user wrote rather than what happened to be unread. Either list failing degrades gracefully to the other.
- `packages/memory-gbrain/src/embedded-port.ts` — `recordSignal()` reads `data.authoringTier` and projects it onto `brain_pages.metadata.authoringTier` when present. Falls back to the prior `{ signalSource, signalType }` shape when missing or non-string (defensive against future connectors).
- CHANGELOG entry explaining what shipped and what's deferred.

## What this PR deliberately does NOT do

- **Layer 2 retrieval weighting.** The RRF fold and `DecisionMaker` pattern boost still read pages uniformly. Layer 2 lands as a separate PR after running labeled-relevant-doc evals — if R@5 doesn't improve, the weights don't ship.
- **Migration backfill.** Tier is only stamped on signals written after this lands. A backfill migration is cheap to write (re-read Gmail label + From header from stored signal rows) but is a separate concern from the live ingest path.

## Test plan

- [x] 18 classifier unit tests in `authoring-tier.test.ts` covering all 6 tiers, edge cases (empty input, malformed addresses, SENT-dominance, newsletter-beats-automated when both fire, To+Cc summed for broadcast threshold).
- [x] 6 new tests in `gmail-connector.test.ts` covering the end-to-end tier stamping path (SENT originated, SENT reply, newsletter via List-Unsubscribe, automated via noreply sender, broadcast via multi-recipient To, personal default).
- [x] 1 new test for sent-first bootstrap ordering (`bootstrap emits in:sent results before is:unread, deduped by id`).
- [x] 3 new tests for embedded-port metadata projection (string tier projected, missing tier omitted, non-string tier defensively dropped).
- [x] Full workspace test run: 70 tasks, all green.
- [x] Workspace build clean (`pnpm build --concurrency=1`).
- [x] No lint errors (`tsc --noEmit` in affected packages).

## Notes for reviewers

- The classifier is intentionally email-shaped today but uses channel-agnostic naming (`AuthoringTier`, `authoringTier`) so a future cross-channel reshape (`authored_originated` / `received_personal`) is a values change, not a schema change.
- The bootstrap dual-list adds one extra Gmail API call on first poll only; subsequent polls go through `history.list` exactly as before. Quota cost is two `messages?q=` calls + N `messages/<id>` detail fetches vs. one + N previously — negligible.
- No retrieval behavior change. `brain_pages.metadata` is JSONB; the new field is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)