### PR TITLE
feat(#187 AC#6 + AC#8): Smart/Smarter mode toggle + zero-cost helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@ All notable changes to SkyTwin will be documented in this file.
 
 ## [unreleased] — Smart / Smarter mode toggle + zero-cost helper (#187 AC#6 + AC#8)
 
+### Fixed (post-Copilot review)
+
+- Cost rate table was off by 100× — the original draft stored
+  `{ input: 8, output: 40 }` for Anthropic and called it "deci-cents
+  per 1M" when the conversion is actually `$0.80 → 80¢ → 800
+  deci-cents`. The table now stores `{ input: 800, output: 4000 }`
+  for Anthropic and the corresponding corrected values for OpenAI and
+  Google. The unit tests now pin the expected dollar-equivalent
+  outputs ($4.80 for 1M+1M Anthropic, $0.60 for 1M output OpenAI,
+  $0.30 for 1M output Google) so the unit conversion can't silently
+  regress again. Embedded + Ollama still return 0¢ at any volume.
+- `PUT /api/settings/:userId/ai` now accepts `embedded` as a valid
+  provider. The Smart mode toggle inserts an `embedded` entry; the
+  pre-existing validation set only allowed `anthropic` / `openai`
+  / `google` / `ollama`, so clicking "Use Smart mode" round-tripped
+  through `applySmartMode` and then 400'd at the API.
+- `switchAIBrainMode` rolls back the optimistic UI state on save
+  failure. Previously the pill + provider chain stayed in the
+  reordered state with only an error banner — visually implying the
+  switch succeeded when the server actually rejected it.
+- "Smarter" pill copy now says "paid API or Ollama" — the
+  `SMARTER_PROVIDERS` set includes Ollama (local, free) and the
+  earlier copy would have confused users running Ollama into thinking
+  the option didn't apply to them.
+
+### Original change
+
 Two pieces close out the user-visible side of the embedded LLM story:
 
 - **AC#6 — Smart / Smarter mode toggle in the AI brain card.** A two-pill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Smart / Smarter mode toggle + zero-cost helper (#187 AC#6 + AC#8)
+
+Two pieces close out the user-visible side of the embedded LLM story:
+
+- **AC#6 — Smart / Smarter mode toggle in the AI brain card.** A two-pill
+  row at the top of Settings → AI brain shows the user which mode is
+  active (computed from their provider chain: top-priority enabled =
+  `embedded` → Smart; hosted / Ollama → Smarter; nothing enabled →
+  none). Clicking the inactive pill reorders priorities and auto-saves
+  through the existing `PUT /api/settings/:userId/ai` round-trip.
+  Switching to Smart adds an `embedded` entry with `model: 'auto'` if
+  the chain doesn't have one yet — first-time-Smart users get a working
+  configuration in one click. Switching to Smarter when no paid
+  provider exists routes to a `switch-to-smarter-blocked` action that
+  focuses the "+ Add a provider…" dropdown so the user's eye is drawn
+  to the next step instead of failing silently.
+
+  Pure helpers (`detectAIMode`, `applySmartMode`, `applySmarterMode`)
+  factored out at the top of `apps/web/public/js/pages/settings.js`
+  with module exports so the mode pill, the action handler, and any
+  future audit route all agree on one definition. 16 cases smoke-tested
+  via Node ESM import; toggle visually verified in Chrome across three
+  scenarios (Smart-active, Smarter-active, no-paid-provider).
+
+- **AC#8 — `estimateLlmCostCents()` helper in `@skytwin/llm-client`.**
+  Provider-keyed rate table (Anthropic / OpenAI / Google list-price
+  cheapest model) plus an absolute zero for `embedded` and `ollama`.
+  Rounds up to the nearest cent everywhere so spend-cap enforcement
+  stays conservative — the failure direction is "approval required,"
+  never "silently exceeded the cap." Exposed as
+  `estimateLlmCostCents(provider, tokensIn, tokensOut)` and
+  `isZeroCostProvider(provider)`. 10 unit tests; the load-bearing one
+  asserts `embedded` and `ollama` return 0 regardless of token volume.
+  The future spend-recording call site can compute
+  `costCents = estimateLlmCostCents(response.provider, tokensIn,
+  tokensOut)` and trust that local-runtime calls record zero — no
+  embedded-special-case branch needed at the recording site.
+
 ## [unreleased] — Memory bootstrap: stamp every signal with an authoring tier (#251 Layer 1)
 
 ### Fixed (post-Copilot review)

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -372,7 +372,13 @@ export function createSettingsRouter(): Router {
         return;
       }
 
-      const validProviders = new Set(['anthropic', 'openai', 'google', 'ollama']);
+      // #187 AC#6 / AC#7: `embedded` is a first-class provider in the
+      // LlmClient chain (landed in PR #241) and the Smart-mode toggle in
+      // settings.js relies on PUT-ing an `embedded` entry here. Pre-AC#6
+      // this set only listed hosted + ollama, so the Smart pill round-
+      // tripped through `applySmartMode` and then 400'd at the API.
+      // Copilot caught this on PR #253.
+      const validProviders = new Set(['anthropic', 'openai', 'google', 'ollama', 'embedded']);
       const seenProviders = new Set<string>();
       for (const p of providers) {
         if (!validProviders.has(p.provider)) {

--- a/apps/web/public/js/pages/settings.js
+++ b/apps/web/public/js/pages/settings.js
@@ -232,6 +232,9 @@ export async function renderSettings(container, userId) {
             ? `Out of the box your twin uses the local AI on your machine plus built-in rules — that's enough for most decisions. Add a paid provider here if you want sharper reasoning on the tricky calls. Multiple are tried in order with automatic fallback.`
             : `<strong>The Chat surface needs at least one AI provider configured here</strong> to generate replies. Other features (decisions, approvals) work without one — they fall back to local AI + built-in rules. Multiple providers are tried in priority order with automatic fallback.`}
         </div>
+        <div id="ai-mode-toggle">
+          ${renderModeToggle(aiProviders)}
+        </div>
         <div id="ai-provider-chain">
           ${renderProviderChain(aiProviders)}
         </div>
@@ -766,6 +769,19 @@ function ensureSettingsListener() {
       case 'save-ai-providers':
         window.saveAIProvidersHandler(uid);
         return;
+      case 'switch-to-smart':
+        window.switchAIBrainMode(uid, 'smart');
+        return;
+      case 'switch-to-smarter':
+        window.switchAIBrainMode(uid, 'smarter');
+        return;
+      case 'switch-to-smarter-blocked':
+        // Visual feedback only — Smarter mode needs a paid provider in
+        // the chain first. The pill helper text already says this; on
+        // click we just flash the provider-add dropdown so the user's
+        // eye is drawn there.
+        document.getElementById('add-provider-select')?.focus();
+        return;
       case 'delete-routine': {
         const routineId = el.getAttribute('data-routine-id');
         if (routineId) window.deleteRoutineHandler(routineId, uid);
@@ -1205,8 +1221,143 @@ const PROVIDER_LABELS = {
   embedded: 'Embedded (llama.cpp)',
 };
 
+// #187 AC#6: providers that count as "Smarter" — i.e. external paid APIs
+// the user is choosing to delegate the harder thinking to. `ollama` lives
+// on a third rail: it's local like `embedded` but the user installed it
+// themselves, so we treat it as Smarter too (the operator chose it
+// deliberately and may have a beefier model than the embedded default).
+const SMARTER_PROVIDERS = new Set(['anthropic', 'openai', 'google', 'ollama']);
+
+/**
+ * Determine the user's current AI mode from their provider chain.
+ *
+ *   'smart'    — top enabled provider is `embedded` (Smart mode default
+ *                per #187 AC#6).
+ *   'smarter'  — top enabled provider is hosted / Ollama (BYO API path).
+ *   'none'     — no enabled providers; the LlmClient will return null and
+ *                callers fall back to local AI + built-in rules.
+ *
+ * Pure helper so the mode pill, the action handler, and any future audit
+ * route all agree on one definition.
+ */
+export function detectAIMode(chain) {
+  const enabled = chain.filter((p) => p.enabled !== false);
+  if (enabled.length === 0) return 'none';
+  const top = enabled.slice().sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))[0];
+  if (!top) return 'none';
+  if (top.provider === 'embedded') return 'smart';
+  if (SMARTER_PROVIDERS.has(top.provider)) return 'smarter';
+  return 'none';
+}
+
+/**
+ * Reorder the chain so `embedded` is the top-priority enabled provider.
+ * Adds an `embedded` entry if one doesn't exist yet so first-time-Smart
+ * users get a working configuration in one click. Returns the new chain
+ * (does not mutate the input).
+ *
+ * The embedded entry uses `'auto'` as the model so the runtime resolves
+ * the first GGUF in the detected modelDir — matching the convention
+ * `apps/web/public/js/components/embedded-llm-card.js` uses for fresh
+ * installs.
+ */
+export function applySmartMode(chain) {
+  const next = chain.map((p) => ({ ...p }));
+  let embedded = next.find((p) => p.provider === 'embedded');
+  if (!embedded) {
+    embedded = {
+      provider: 'embedded',
+      model: 'auto',
+      apiKey: '',
+      baseUrl: undefined,
+      priority: 0,
+      enabled: true,
+      hasApiKey: false,
+      apiKeyPreview: '',
+    };
+    next.push(embedded);
+  } else {
+    embedded.enabled = true;
+  }
+  // Rebuild priorities so embedded is at 0 and the rest preserve their
+  // relative order. This is the contract the API expects (priorities are
+  // unique sequential integers).
+  const others = next.filter((p) => p !== embedded);
+  others.sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+  return [embedded, ...others].map((p, i) => ({ ...p, priority: i }));
+}
+
+/**
+ * Reorder the chain so the first non-embedded enabled provider becomes
+ * top-priority. Returns null if there's nothing to switch to (caller
+ * should surface a "configure a paid provider first" message).
+ */
+export function applySmarterMode(chain) {
+  const next = chain.map((p) => ({ ...p }));
+  next.sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+  const smarterIdx = next.findIndex((p) => SMARTER_PROVIDERS.has(p.provider));
+  if (smarterIdx === -1) return null;
+  const target = next[smarterIdx];
+  target.enabled = true;
+  const others = next.filter((p) => p !== target);
+  return [target, ...others].map((p, i) => ({ ...p, priority: i }));
+}
+
 // In-memory state for the current chain being edited
 let _aiChain = [];
+
+/**
+ * #187 AC#6: render the Smart / Smarter mode pill above the provider
+ * chain. Active mode is highlighted; clicking the inactive pill reorders
+ * priorities and auto-saves.
+ *
+ * Disabled states (rendered as helper text under the inactive pill):
+ *   - Switch-to-Smarter is disabled when no hosted/Ollama provider exists
+ *     in the chain (we don't auto-add one because the user has to supply
+ *     an API key).
+ *   - Switch-to-Smart is always available — if no embedded entry exists
+ *     yet, `applySmartMode` adds one with `model: 'auto'` so the runtime
+ *     picks up the first GGUF in the detected model directory.
+ */
+function renderModeToggle(providers) {
+  const mode = detectAIMode(providers);
+  const hasSmarterCandidate = providers.some((p) => SMARTER_PROVIDERS.has(p.provider));
+
+  const pill = (label, isActive, action, helperText) => `
+    <div style="flex: 1; min-width: 0;">
+      <button class="btn ${isActive ? 'btn-primary' : 'btn-outline'} btn-sm"
+              style="width: 100%; padding: 0.5rem 0.75rem; font-size: 0.85rem;"
+              data-action="${action}"
+              ${isActive ? 'disabled' : ''}>
+        ${isActive ? '✓ ' : ''}${label}${isActive ? '' : ' →'}
+      </button>
+      ${helperText ? `<div style="font-size: 0.7rem; color: var(--text-dim); margin-top: 0.25rem;">${helperText}</div>` : ''}
+    </div>
+  `;
+
+  return `
+    <div style="display: flex; gap: 0.5rem; margin-bottom: 0.75rem;">
+      ${pill(
+        'Smart (free, on-device)',
+        mode === 'smart',
+        'switch-to-smart',
+        mode === 'smart'
+          ? 'Embedded model is your top choice.'
+          : 'No API costs, runs offline.',
+      )}
+      ${pill(
+        'Smarter (paid API)',
+        mode === 'smarter',
+        hasSmarterCandidate ? 'switch-to-smarter' : 'switch-to-smarter-blocked',
+        mode === 'smarter'
+          ? 'Your paid provider is the top choice.'
+          : hasSmarterCandidate
+            ? 'Sharper reasoning on tricky calls.'
+            : 'Add a paid provider below first.',
+      )}
+    </div>
+  `;
+}
 
 function renderProviderChain(providers) {
   _aiChain = providers.map((p, i) => ({ ...p, priority: i }));
@@ -1334,6 +1485,53 @@ window.aiTestProvider = async function(idx, userId) {
     }
   } catch (err) {
     resultEl.innerHTML = `<span style="font-size: 0.75rem; color: var(--danger);">Error: ${escapeHtml(err instanceof Error ? err.message : String(err))}</span>`;
+  }
+};
+
+/**
+ * #187 AC#6: click handler for the Smart / Smarter mode pills. Applies
+ * the priority reorder locally, then auto-saves through the same
+ * `saveAIProviders` round-trip the manual "Save" button uses. After save
+ * the settings page re-renders so the pill state and the provider chain
+ * agree.
+ */
+window.switchAIBrainMode = async function(userId, target) {
+  const next = target === 'smart'
+    ? applySmartMode(_aiChain)
+    : applySmarterMode(_aiChain);
+  if (!next) {
+    // applySmarterMode returned null — no paid provider in the chain.
+    // The `switch-to-smarter-blocked` action handles the focus-the-add-
+    // dropdown UX; this branch is defense in depth in case the action
+    // gets routed here anyway.
+    return;
+  }
+  _aiChain = next;
+  // Re-render the pill + provider chain optimistically so the click
+  // produces an immediate visual change while the save round-trips.
+  document.getElementById('ai-mode-toggle').innerHTML = renderModeToggle(_aiChain);
+  document.getElementById('ai-provider-chain').innerHTML = renderProviderChain(_aiChain);
+
+  try {
+    await saveAIProviders(userId, _aiChain.map((p, i) => ({
+      provider: p.provider,
+      apiKey: p.apiKey || '',
+      model: p.model,
+      baseUrl: p.baseUrl,
+      priority: i,
+      enabled: p.enabled !== false,
+    })));
+    // Re-fetch from the server so the pill reflects the persisted state
+    // (handles edge cases like an existing-but-disabled embedded entry
+    // that was re-enabled by applySmartMode, where the server response
+    // may carry extra fields not in our optimistic copy).
+    const { renderSettings } = await import('./settings.js');
+    await renderSettings(document.getElementById('page-content'), userId);
+  } catch (err) {
+    document.getElementById('page-content').insertAdjacentHTML(
+      'afterbegin',
+      `<div class="error-banner">Failed to switch mode: ${escapeHtml(err.message)}</div>`,
+    );
   }
 };
 

--- a/apps/web/public/js/pages/settings.js
+++ b/apps/web/public/js/pages/settings.js
@@ -1288,9 +1288,18 @@ export function applySmartMode(chain) {
 }
 
 /**
- * Reorder the chain so the first non-embedded enabled provider becomes
- * top-priority. Returns null if there's nothing to switch to (caller
- * should surface a "configure a paid provider first" message).
+ * Reorder the chain so the first hosted/Ollama provider (by priority)
+ * becomes top-priority. The selected provider is force-enabled — a
+ * deliberately-disabled hosted entry is treated as "configured but
+ * paused," and switching to Smarter re-enables it. Returns null when
+ * no hosted/Ollama provider exists in the chain at all (caller
+ * surfaces "configure a paid provider first").
+ *
+ * Note: this scans the full chain regardless of `enabled` state, then
+ * force-enables the chosen entry. The previous docstring said "first
+ * non-embedded *enabled* provider" — that wording implied a filter
+ * we don't actually apply. Doc updated to match behavior; Copilot
+ * round-2 on PR #253 caught the mismatch.
  */
 export function applySmarterMode(chain) {
   const next = chain.map((p) => ({ ...p }));
@@ -1540,9 +1549,14 @@ window.switchAIBrainMode = async function(userId, target) {
     _aiChain = prev;
     document.getElementById('ai-mode-toggle').innerHTML = renderModeToggle(_aiChain);
     document.getElementById('ai-provider-chain').innerHTML = renderProviderChain(_aiChain);
+    // Defensive `err.message` access — a non-Error rejection (string,
+    // object, undefined) would otherwise produce "Failed to switch
+    // mode: undefined" on the banner. Copilot round-2 on PR #253
+    // flagged the prior direct-access.
+    const msg = err instanceof Error ? err.message : String(err);
     document.getElementById('page-content').insertAdjacentHTML(
       'afterbegin',
-      `<div class="error-banner">Failed to switch mode: ${escapeHtml(err.message)}</div>`,
+      `<div class="error-banner">Failed to switch mode: ${escapeHtml(msg)}</div>`,
     );
   }
 };

--- a/apps/web/public/js/pages/settings.js
+++ b/apps/web/public/js/pages/settings.js
@@ -1346,14 +1346,14 @@ function renderModeToggle(providers) {
           : 'No API costs, runs offline.',
       )}
       ${pill(
-        'Smarter (paid API)',
+        'Smarter (paid API or Ollama)',
         mode === 'smarter',
         hasSmarterCandidate ? 'switch-to-smarter' : 'switch-to-smarter-blocked',
         mode === 'smarter'
-          ? 'Your paid provider is the top choice.'
+          ? 'Your hosted provider or Ollama is the top choice.'
           : hasSmarterCandidate
             ? 'Sharper reasoning on tricky calls.'
-            : 'Add a paid provider below first.',
+            : 'Add a hosted provider or Ollama below first.',
       )}
     </div>
   `;
@@ -1506,6 +1506,13 @@ window.switchAIBrainMode = async function(userId, target) {
     // gets routed here anyway.
     return;
   }
+  // Snapshot the previous chain so we can roll back the optimistic
+  // render if the save fails. Copilot's review of PR #253 caught that
+  // the prior implementation left the pill + provider list visually
+  // implying success when the server actually rejected the write
+  // (e.g. when the API didn't accept `embedded` yet — see paired fix
+  // in apps/api/src/routes/settings.ts).
+  const prev = _aiChain.map((p) => ({ ...p }));
   _aiChain = next;
   // Re-render the pill + provider chain optimistically so the click
   // produces an immediate visual change while the save round-trips.
@@ -1528,6 +1535,11 @@ window.switchAIBrainMode = async function(userId, target) {
     const { renderSettings } = await import('./settings.js');
     await renderSettings(document.getElementById('page-content'), userId);
   } catch (err) {
+    // Roll back the optimistic state so the user doesn't think the
+    // switch succeeded.
+    _aiChain = prev;
+    document.getElementById('ai-mode-toggle').innerHTML = renderModeToggle(_aiChain);
+    document.getElementById('ai-provider-chain').innerHTML = renderProviderChain(_aiChain);
     document.getElementById('page-content').insertAdjacentHTML(
       'afterbegin',
       `<div class="error-banner">Failed to switch mode: ${escapeHtml(err.message)}</div>`,

--- a/packages/llm-client/src/__tests__/cost.test.ts
+++ b/packages/llm-client/src/__tests__/cost.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { estimateLlmCostCents, isZeroCostProvider } from '../cost.js';
+
+describe('estimateLlmCostCents', () => {
+  // #187 AC#8: this is the load-bearing invariant — when the user is in
+  // Smart mode (embedded provider top of chain), every estimated cost is
+  // zero. The future spend-recording call site relies on this returning
+  // 0 without special-casing.
+  it('returns 0 for embedded provider regardless of token counts', () => {
+    expect(estimateLlmCostCents('embedded', 0, 0)).toBe(0);
+    expect(estimateLlmCostCents('embedded', 1_000_000, 1_000_000)).toBe(0);
+    expect(estimateLlmCostCents('embedded', Number.MAX_SAFE_INTEGER, 0)).toBe(0);
+  });
+
+  it('returns 0 for ollama provider regardless of token counts', () => {
+    expect(estimateLlmCostCents('ollama', 0, 0)).toBe(0);
+    expect(estimateLlmCostCents('ollama', 500_000, 500_000)).toBe(0);
+  });
+
+  it('returns 0 for any provider with zero token counts', () => {
+    expect(estimateLlmCostCents('anthropic')).toBe(0);
+    expect(estimateLlmCostCents('openai')).toBe(0);
+    expect(estimateLlmCostCents('google')).toBe(0);
+  });
+
+  it('estimates anthropic cost in integer cents with safe rounding up', () => {
+    // 1M input + 1M output at 8/40 deci-cents per million → 4.8¢ → 5¢.
+    expect(estimateLlmCostCents('anthropic', 1_000_000, 1_000_000)).toBe(5);
+  });
+
+  it('estimates openai cost in integer cents', () => {
+    // 1M output at 6 deci-cents per million → 0.6¢ → 1¢ (rounded up).
+    expect(estimateLlmCostCents('openai', 0, 1_000_000)).toBe(1);
+  });
+
+  it('estimates google cost in integer cents', () => {
+    // 1M output at 3 deci-cents per million → 0.3¢ → 1¢ (rounded up).
+    expect(estimateLlmCostCents('google', 0, 1_000_000)).toBe(1);
+  });
+
+  it('rounds up so the cap-enforcement direction is always safe', () => {
+    // Anthropic at small token counts (10k input, 10k output) →
+    // (8*10_000 + 40*10_000) / 1_000_000 = 0.48 deci-cents → ceil = 1 →
+    // ceil(1/10) = 1¢. The exact float would be 0.048¢; rounding up
+    // means cap checks see 1¢ instead of zeroing out tiny usage.
+    expect(estimateLlmCostCents('anthropic', 10_000, 10_000)).toBe(1);
+  });
+
+  it('is a pure function — same input twice yields the same output', () => {
+    const a = estimateLlmCostCents('anthropic', 500_000, 250_000);
+    const b = estimateLlmCostCents('anthropic', 500_000, 250_000);
+    expect(a).toBe(b);
+  });
+});
+
+describe('isZeroCostProvider', () => {
+  it('returns true for local-runtime providers', () => {
+    expect(isZeroCostProvider('embedded')).toBe(true);
+    expect(isZeroCostProvider('ollama')).toBe(true);
+  });
+
+  it('returns false for hosted paid APIs', () => {
+    expect(isZeroCostProvider('anthropic')).toBe(false);
+    expect(isZeroCostProvider('openai')).toBe(false);
+    expect(isZeroCostProvider('google')).toBe(false);
+  });
+});

--- a/packages/llm-client/src/__tests__/cost.test.ts
+++ b/packages/llm-client/src/__tests__/cost.test.ts
@@ -9,7 +9,11 @@ describe('estimateLlmCostCents', () => {
   it('returns 0 for embedded provider regardless of token counts', () => {
     expect(estimateLlmCostCents('embedded', 0, 0)).toBe(0);
     expect(estimateLlmCostCents('embedded', 1_000_000, 1_000_000)).toBe(0);
-    expect(estimateLlmCostCents('embedded', Number.MAX_SAFE_INTEGER, 0)).toBe(0);
+    // Largest token count the safe-integer guard accepts. The guard
+    // throws above 2e12, which is far beyond any real prompt; the
+    // embedded path still returns 0 at that boundary because the rate
+    // table entry is { 0, 0 } regardless of token count.
+    expect(estimateLlmCostCents('embedded', 2_000_000_000_000, 0)).toBe(0);
   });
 
   it('returns 0 for ollama provider regardless of token counts', () => {
@@ -64,6 +68,31 @@ describe('estimateLlmCostCents', () => {
     const a = estimateLlmCostCents('anthropic', 500_000, 250_000);
     const b = estimateLlmCostCents('anthropic', 500_000, 250_000);
     expect(a).toBe(b);
+  });
+
+  // #253 round-2: unknown provider must throw rather than report fake-
+  // free usage. `AIProviderName` is the type guard at compile time;
+  // this asserts the runtime fallback for code paths that cast a
+  // string from the DB or an external source.
+  it('throws when given a provider name not in the rate table', () => {
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      estimateLlmCostCents('mystery-provider' as any, 100, 100),
+    ).toThrow(/unknown provider/);
+  });
+
+  // #253 round-2: token counts beyond the safe-integer guard throw so
+  // an untrusted aggregator can't sneak a bogus value past IEEE-754
+  // rounding into a wrong cents value.
+  it('throws on non-finite or negative token counts', () => {
+    expect(() => estimateLlmCostCents('anthropic', Number.NaN, 0)).toThrow();
+    expect(() => estimateLlmCostCents('anthropic', -1, 0)).toThrow();
+    expect(() => estimateLlmCostCents('anthropic', 0, Infinity)).toThrow();
+  });
+
+  it('throws on token counts above the safe-integer guard', () => {
+    // 3e12 is well above the 2e12 guard, far below 2^53.
+    expect(() => estimateLlmCostCents('anthropic', 3_000_000_000_000, 0)).toThrow(/must be/);
   });
 });
 

--- a/packages/llm-client/src/__tests__/cost.test.ts
+++ b/packages/llm-client/src/__tests__/cost.test.ts
@@ -24,26 +24,40 @@ describe('estimateLlmCostCents', () => {
   });
 
   it('estimates anthropic cost in integer cents with safe rounding up', () => {
-    // 1M input + 1M output at 8/40 deci-cents per million → 4.8¢ → 5¢.
-    expect(estimateLlmCostCents('anthropic', 1_000_000, 1_000_000)).toBe(5);
+    // 1M input + 1M output at 800/4000 deci-cents per million →
+    // 4800 deci-cents → 480 cents = $4.80. Locks the corrected
+    // unit conversion (1 cent = 10 deci-cents).
+    expect(estimateLlmCostCents('anthropic', 1_000_000, 1_000_000)).toBe(480);
   });
 
   it('estimates openai cost in integer cents', () => {
-    // 1M output at 6 deci-cents per million → 0.6¢ → 1¢ (rounded up).
-    expect(estimateLlmCostCents('openai', 0, 1_000_000)).toBe(1);
+    // 1M output at 600 deci-cents per million → 600 deci-cents →
+    // 60 cents = $0.60. Matches GPT-4o-mini list price exactly.
+    expect(estimateLlmCostCents('openai', 0, 1_000_000)).toBe(60);
   });
 
   it('estimates google cost in integer cents', () => {
-    // 1M output at 3 deci-cents per million → 0.3¢ → 1¢ (rounded up).
-    expect(estimateLlmCostCents('google', 0, 1_000_000)).toBe(1);
+    // 1M output at 300 deci-cents per million → 300 deci-cents →
+    // 30 cents = $0.30. Matches Gemini 1.5 Flash list price exactly.
+    expect(estimateLlmCostCents('google', 0, 1_000_000)).toBe(30);
   });
 
   it('rounds up so the cap-enforcement direction is always safe', () => {
     // Anthropic at small token counts (10k input, 10k output) →
-    // (8*10_000 + 40*10_000) / 1_000_000 = 0.48 deci-cents → ceil = 1 →
-    // ceil(1/10) = 1¢. The exact float would be 0.048¢; rounding up
-    // means cap checks see 1¢ instead of zeroing out tiny usage.
-    expect(estimateLlmCostCents('anthropic', 10_000, 10_000)).toBe(1);
+    // (800*10_000 + 4000*10_000) / 1_000_000 = 48 deci-cents →
+    // ceil(48/10) = 5 cents. Exact value would be 4.8¢; rounding up
+    // means the cap sees 5¢ instead of dropping the fractional cent.
+    expect(estimateLlmCostCents('anthropic', 10_000, 10_000)).toBe(5);
+  });
+
+  it('rounds up tiny usage to at least 1 cent for non-zero rates', () => {
+    // Regression coverage for the original under-estimation bug
+    // (which had 100×-too-small rates and reported 1¢ for 10k+10k
+    // Anthropic — almost zero usage). With corrected rates, a single
+    // token of OpenAI output still rounds up from
+    // (150 + 600) / 1M ≈ 0.0006 deci-cents to 1¢. Same direction:
+    // the cap can never under-bill.
+    expect(estimateLlmCostCents('openai', 1, 1)).toBe(1);
   });
 
   it('is a pure function — same input twice yields the same output', () => {

--- a/packages/llm-client/src/cost.ts
+++ b/packages/llm-client/src/cost.ts
@@ -24,18 +24,20 @@ import type { AIProviderName } from '@skytwin/shared-types';
  * `embedded === 0 AND ollama === 0`.
  */
 const RATE_DECICENTS_PER_M_TOKENS: Record<AIProviderName, { input: number; output: number }> = {
-  // Anthropic — based on Claude 3.5 Haiku list price ($0.80/$4.00 per
-  // 1M). Deci-cents/M: input 8, output 40.
-  anthropic: { input: 8, output: 40 },
-  // OpenAI — based on GPT-4o-mini list price ($0.15/$0.60 per 1M).
-  // Deci-cents/M: input 1.5 → rounded up to 2 (we use integers and
-  // round UP everywhere so the cap stays conservative), output 6.
-  openai: { input: 2, output: 6 },
-  // Google — based on Gemini 1.5 Flash list price ($0.075/$0.30 per
-  // 1M for prompts <128k tokens). Deci-cents/M: input 1 (rounded up
-  // from 0.75), output 3.
-  google: { input: 1, output: 3 },
-  // Local-runtime: zero by definition.
+  // Conversion sanity check before adjusting any of these: 1 cent =
+  // 10 deci-cents, so $0.80 = 80 cents = 800 deci-cents. A $0.80/1M
+  // input rate stores as 800. An earlier draft of this table was off
+  // by 100× because the dollars→cents step was skipped — Copilot
+  // caught it on PR #253. Tests below pin the corrected values.
+  //
+  // Anthropic — Claude 3.5 Haiku list price ($0.80/$4.00 per 1M).
+  anthropic: { input: 800, output: 4000 },
+  // OpenAI — GPT-4o-mini list price ($0.15/$0.60 per 1M).
+  openai: { input: 150, output: 600 },
+  // Google — Gemini 1.5 Flash list price ($0.075/$0.30 per 1M for
+  // prompts <128k tokens).
+  google: { input: 75, output: 300 },
+  // Local-runtime providers carry zero per-token cost by definition.
   ollama: { input: 0, output: 0 },
   embedded: { input: 0, output: 0 },
 };

--- a/packages/llm-client/src/cost.ts
+++ b/packages/llm-client/src/cost.ts
@@ -1,0 +1,82 @@
+import type { AIProviderName } from '@skytwin/shared-types';
+
+/**
+ * Per-provider per-token cost in tenths of a cent (deci-cents), so an
+ * integer math throughout cents-denominated spend pipelines is safe.
+ * Sourced from each vendor's published list price for the cheapest
+ * model in their family that we currently expose in `PROVIDER_MODELS`;
+ * we deliberately over-estimate the inexpensive option rather than
+ * under-estimate the expensive one — spend-cap enforcement should err
+ * on the side of "approval required" rather than "silently ran past
+ * the cap." Anyone running a premium model will see slightly higher
+ * recorded cost than the model's exact rate; that's the safe direction.
+ *
+ * Local-runtime providers (embedded llama.cpp, user-installed Ollama)
+ * carry zero per-token cost — this is the load-bearing piece of #187
+ * AC#8: cost dashboard shows $0 when on Smart mode. We keep the helper
+ * shape uniform so the eventual spend-recording call site doesn't need
+ * an embedded-special-case branch — `estimateLlmCostCents('embedded',
+ * N, M)` just returns 0 by table lookup.
+ *
+ * Rates are reviewed as part of CHANGELOG sweeps; if pricing shifts and
+ * this table goes stale, the failure mode is over-estimating the bill —
+ * never under-estimating. The unit test enforces the invariant
+ * `embedded === 0 AND ollama === 0`.
+ */
+const RATE_DECICENTS_PER_M_TOKENS: Record<AIProviderName, { input: number; output: number }> = {
+  // Anthropic — based on Claude 3.5 Haiku list price ($0.80/$4.00 per
+  // 1M). Deci-cents/M: input 8, output 40.
+  anthropic: { input: 8, output: 40 },
+  // OpenAI — based on GPT-4o-mini list price ($0.15/$0.60 per 1M).
+  // Deci-cents/M: input 1.5 → rounded up to 2 (we use integers and
+  // round UP everywhere so the cap stays conservative), output 6.
+  openai: { input: 2, output: 6 },
+  // Google — based on Gemini 1.5 Flash list price ($0.075/$0.30 per
+  // 1M for prompts <128k tokens). Deci-cents/M: input 1 (rounded up
+  // from 0.75), output 3.
+  google: { input: 1, output: 3 },
+  // Local-runtime: zero by definition.
+  ollama: { input: 0, output: 0 },
+  embedded: { input: 0, output: 0 },
+};
+
+/**
+ * Estimate the cost of a single LLM call in integer cents, given the
+ * provider and token counts. Rounds up to the nearest cent so the
+ * cap-enforcement direction stays safe.
+ *
+ * Returns 0 for `embedded` and `ollama` regardless of token counts —
+ * see the rate-table docstring. This is the contract #187 AC#8 relies
+ * on: a future spend-recording call site can compute `costCents =
+ * estimateLlmCostCents(response.provider, tokensIn, tokensOut)` and
+ * trust that local-runtime calls record zero.
+ *
+ * Token counts default to 0 so callers that haven't wired up token
+ * accounting yet can pass nothing and still get a consistent answer.
+ */
+export function estimateLlmCostCents(
+  provider: AIProviderName,
+  tokensIn = 0,
+  tokensOut = 0,
+): number {
+  const rate = RATE_DECICENTS_PER_M_TOKENS[provider];
+  if (!rate) return 0;
+  // Deci-cents per million tokens × tokens / 1M = deci-cents.
+  // Cents = ceil(deci-cents / 10). Integer math throughout.
+  const deciCents = (rate.input * tokensIn + rate.output * tokensOut);
+  const tokenScale = 1_000_000;
+  const scaledDeciCents = Math.ceil(deciCents / tokenScale);
+  return Math.ceil(scaledDeciCents / 10);
+}
+
+/**
+ * True when this provider runs entirely on the user's machine and so
+ * carries zero per-token cost regardless of usage volume. Exposed for
+ * future audit / dashboard callers that want to render a "free" badge
+ * or skip cost rendering altogether.
+ */
+export function isZeroCostProvider(provider: AIProviderName): boolean {
+  const rate = RATE_DECICENTS_PER_M_TOKENS[provider];
+  if (!rate) return false;
+  return rate.input === 0 && rate.output === 0;
+}

--- a/packages/llm-client/src/cost.ts
+++ b/packages/llm-client/src/cost.ts
@@ -62,8 +62,36 @@ export function estimateLlmCostCents(
   tokensOut = 0,
 ): number {
   const rate = RATE_DECICENTS_PER_M_TOKENS[provider];
-  if (!rate) return 0;
-  // Deci-cents per million tokens × tokens / 1M = deci-cents.
+  // Unknown provider — fail loud rather than report fake-free usage.
+  // The `AIProviderName` type is the source of truth; if a DB string
+  // bypasses it (cast from `unknown`, etc.) we'd rather throw at the
+  // spend-recording call site than silently mis-bill. Copilot round-2
+  // on PR #253 caught the prior silent-zero behavior.
+  if (!rate) {
+    throw new Error(
+      `estimateLlmCostCents: unknown provider "${String(provider)}". Add it to RATE_DECICENTS_PER_M_TOKENS.`,
+    );
+  }
+  // Deci-cents per million tokens × tokens / 1M = deci-cents. JS
+  // numbers are safe up to 2^53 ≈ 9e15. The intermediate product
+  // (rate.output ≈ 4000) × (tokens ≈ 2^53 / 4000 ≈ 2.2e12) overflows
+  // safe-integer territory only for caller-supplied token counts
+  // above ~2 trillion — orders of magnitude beyond any real prompt.
+  // Guard explicitly so an untrusted input can't silently produce
+  // a wrong cents value through IEEE-754 rounding.
+  const MAX_SAFE_TOKEN_COUNT = 2_000_000_000_000; // 2e12, well below 2^53
+  if (
+    !Number.isFinite(tokensIn) ||
+    !Number.isFinite(tokensOut) ||
+    tokensIn < 0 ||
+    tokensOut < 0 ||
+    tokensIn > MAX_SAFE_TOKEN_COUNT ||
+    tokensOut > MAX_SAFE_TOKEN_COUNT
+  ) {
+    throw new Error(
+      `estimateLlmCostCents: token counts must be finite non-negative integers ≤ ${MAX_SAFE_TOKEN_COUNT}; got tokensIn=${tokensIn}, tokensOut=${tokensOut}.`,
+    );
+  }
   // Cents = ceil(deci-cents / 10). Integer math throughout.
   const deciCents = (rate.input * tokensIn + rate.output * tokensOut);
   const tokenScale = 1_000_000;

--- a/packages/llm-client/src/index.ts
+++ b/packages/llm-client/src/index.ts
@@ -10,3 +10,4 @@ export type {
   ChatMessage,
 } from './types.js';
 export { toMessages, splitSystemAndConversation } from './messages.js';
+export { estimateLlmCostCents, isZeroCostProvider } from './cost.js';


### PR DESCRIPTION
## Summary

Closes the user-visible side of the embedded LLM story. Two pieces:

- **AC#6** — a two-pill Smart/Smarter mode toggle at the top of Settings → AI brain. Active mode is computed from the user's provider chain; clicking the inactive pill reorders priorities and auto-saves.
- **AC#8** — a `estimateLlmCostCents()` helper in `@skytwin/llm-client` that returns 0 for `embedded`/`ollama` and a per-provider rate for hosted APIs. The future spend-recording call site can drop this in without an embedded-special-case branch.

Together these take #187 from 5/8 → 7/8 closed. Remaining: AC#1 bundling (distribution work paired with #188) and AC#4 (Piper TTS, blocked on `piper` on PATH).

## AC#6 — Smart/Smarter mode toggle

**`detectAIMode(chain)` → `'smart' | 'smarter' | 'none'`** based on the top-priority enabled provider:
- `embedded` at top → Smart
- `anthropic` / `openai` / `google` / `ollama` at top → Smarter
- no enabled providers → none

**Click the inactive pill → priorities reorder + auto-save:**
- *Smart click:* `applySmartMode(chain)` promotes `embedded` to priority 0 (adds a fresh `embedded` entry with `model: 'auto'` if missing, re-enables a disabled one).
- *Smarter click:* `applySmarterMode(chain)` promotes the first hosted/Ollama entry to priority 0. Returns `null` if no candidate exists; in that case the action routes to `switch-to-smarter-blocked` which focuses the "+ Add a provider…" dropdown so the user's eye is drawn to the next step instead of failing silently.

After the save round-trip, `renderSettings` re-runs so the pill and the provider chain agree on the persisted state (handles cases like server-side normalization adding fields the optimistic copy didn't have).

**Pure helpers exported from `apps/web/public/js/pages/settings.js`** so the pill, the action handler, and any future audit route all agree on one definition. Same module-level `export function` style other helpers in this file use.

### Screenshot (Smart active, Anthropic configured as fallback)

`✓ Smart (free, on-device)` highlighted; `Smarter (paid API) →` is the call-to-action; helper text under each pill explains what they do.

## AC#8 — `estimateLlmCostCents()` helper

`packages/llm-client/src/cost.ts` exports:

```ts
estimateLlmCostCents(provider: AIProviderName, tokensIn?: number, tokensOut?: number): number
isZeroCostProvider(provider: AIProviderName): boolean
```

Rate table is keyed by provider with deci-cents per million tokens — list-price of the cheapest model we expose in `PROVIDER_MODELS` for each family. Local-runtime providers (`embedded`, `ollama`) carry zero per-token cost; that's the load-bearing piece of AC#8.

**Rounding is `ceil` everywhere** so spend-cap enforcement stays conservative — the failure direction is "approval required," never "silently past the cap."

**No call site wired yet.** The current spend-recording path (`spendRepository.create`) isn't called from any LLM code path today, so AC#8 is trivially satisfied at runtime. This PR adds the helper as a single source of truth so when LLM-cost recording does land (separate issue), it can compute `estimateLlmCostCents(response.provider, tokensIn, tokensOut)` and trust that local-runtime calls record zero.

## Test plan

- [x] 10 new vitest cases for `cost.ts`:
  - `embedded` returns 0 for any token volume (incl. `Number.MAX_SAFE_INTEGER`).
  - `ollama` returns 0.
  - Hosted providers compute expected integer cents with round-up.
  - Pure-function determinism check.
  - `isZeroCostProvider` distinguishes local-runtime from hosted.
- [x] 16 cases smoke-tested for the JS helpers via Node ESM import (`detectAIMode`, `applySmartMode`, `applySmarterMode` across empty/embedded-top/anthropic-top/ollama-top/all-disabled/lower-priority-embedded/skip-disabled scenarios + null-return when no candidate).
- [x] Toggle visually verified in Chrome at `http://localhost:3201/#/settings` across three scenarios:
  - Smart active (embedded at priority 0): Smart pill highlighted, Smarter pill is the CTA.
  - Smarter active (anthropic at priority 0): Smarter pill highlighted, Smart pill is the CTA.
  - No paid provider in chain: Smart pill clickable, Smarter pill routes to `switch-to-smarter-blocked`.
- [x] `pnpm --filter @skytwin/llm-client build` clean.
- [x] `pnpm --filter @skytwin/llm-client test` — 136/136 green.

## Notes for reviewers

- The mode toggle is a *layer* over the existing provider chain, not a replacement. Users who prefer the explicit chain editor still have it; the toggle is a single-click shortcut for the common cases.
- `applySmartMode` adding an embedded entry with `model: 'auto'` mirrors what `embedded-llm-card.js` uses for fresh installs — the runtime resolves the first GGUF in the detected modelDir.
- Cost rates are list prices reviewed at commit time. If pricing shifts and the table goes stale, the failure mode is over-estimating the bill (cap fires earlier) — never under-estimating. The unit test enforces `embedded === 0 AND ollama === 0` as an invariant.
- No JS test infrastructure exists in `apps/web`, so the helpers were smoke-tested via Node ESM import. If/when Playwright lands, the toggle's three-scenario behavior deserves an E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)