### PR TITLE
feat(#193 follow-up): filter the capabilities registry by Lifebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Capabilities: filter the registry by Lifebook (#193 follow-up)
+
+Closes the "capability filter by domain on Capabilities page" item that
+PR #242 (#193 Child 1) explicitly deferred. The Capabilities page now
+carries a Lifebook dropdown alongside the existing category dropdown;
+selecting a Lifebook intersects the registry results with that
+Lifebook's `suggestedCapabilities: registryId[]` set so users browsing
+for a specific life domain see only the capabilities the domain
+extractor actually proposed for it.
+
+**No DB migration required.** The filter is purely client-side: the
+intersection set already lives on `lifebooks.suggested_capabilities`
+(populated by the domain-extraction worker that landed in #242). The
+capabilities page now fetches `/api/lifebooks/:userId` alongside its
+existing data and runs the intersect in `applyLifebookFilter()` — a
+pure helper that's trivial to lift to a vitest harness if/when one
+lands in `apps/web`.
+
+UX details:
+
+- Dropdown shows visible (non-hidden) Lifebooks only. Hidden Lifebooks
+  stay in memory but disappear from this dropdown, matching the
+  "hidden surfaces stay queryable in memory; surface visibility is the
+  user's call" contract Lifebooks already follow.
+- When the user has zero Lifebooks (domain extractor hasn't run, or
+  everything is hidden), the dropdown is omitted entirely — an empty
+  selector with no options would just confuse.
+- Empty-result state when a Lifebook filter narrows everything away
+  surfaces the active Lifebook name in the empty-state copy ("No
+  results found for the 'Health' Lifebook.") so the user can
+  immediately tell *why* nothing's showing.
+- A Lifebook with an empty `suggestedCapabilities: []` array means the
+  extractor proposed nothing yet — the filter shows everything rather
+  than collapsing to zero results, on the principle that "extractor
+  hasn't decided" should not look the same as "extractor decided
+  nothing matches."
+
+Internal cleanup that fell out of the change:
+
+- Three `renderRegistryResults(userId, q, category)` call sites
+  collapsed to `renderRegistryResults(userId, readRegistryFilterState())`
+  via a new pure `readRegistryFilterState()` helper. Adding the
+  Lifebook filter without this would have meant editing five separate
+  call sites. The next filter that lands gets to add itself in two
+  places: the dropdown markup and the state reader.
+
+Test plan: smoke-tested in Chrome with mocked Lifebook + registry data
+— filter toggles correctly across three scenarios (all-Lifebooks, one
+specific Lifebook, switch back to all). `node --check` clean.
+
 ## [unreleased] — Smart / Smarter mode toggle + zero-cost helper (#187 AC#6 + AC#8)
 
 ### Fixed (post-Copilot review)
@@ -133,6 +183,7 @@ What this doesn't ship (deliberate, deferred to follow-ups):
   on signals written after this lands. A backfill migration is cheap to
   write (re-read the Gmail label + From header for stored signal rows)
   but is a separate concern from the live ingest path.
+
 
 ## [unreleased] — Embedded LLM downloader: round-3 review fixes (#187 AC#2 follow-up)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@ All notable changes to SkyTwin will be documented in this file.
 
 ## [unreleased] — Capabilities: filter the registry by Lifebook (#193 follow-up)
 
+### Fixed (post-Copilot review)
+
+- Lifebook visibility filter now uses the correct API field
+  (`hidden: boolean`) instead of the nonexistent `hiddenAt`. The
+  previous filter was a no-op AND would have fail-opened if the
+  endpoint ever returned hidden rows. The server-side `listVisible`
+  call still does the real filtering; the client-side guard is
+  defense in depth.
+- Removed `data-action` from the category and Lifebook `<select>`
+  elements. Each had an explicit `change` listener too, so the
+  global click delegator double-fired `renderRegistryResults` on
+  every dropdown-open. The change listener is now the sole entry
+  point. Dead switch cases (`registry-filter-change`,
+  `registry-category-change`) deleted.
+- `applyLifebookFilter()` is now actually pure — lifebooks is the
+  third argument with a default that pulls from cache only at the
+  call site. The docstring's "pure function" claim no longer
+  requires monkeypatching `_cachedLifebooks` to be true.
+
+### Original change
+
 Closes the "capability filter by domain on Capabilities page" item that
 PR #242 (#193 Child 1) explicitly deferred. The Capabilities page now
 carries a Lifebook dropdown alongside the existing category dropdown;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,10 +62,12 @@ Internal cleanup that fell out of the change:
 
 - Three `renderRegistryResults(userId, q, category)` call sites
   collapsed to `renderRegistryResults(userId, readRegistryFilterState())`
-  via a new pure `readRegistryFilterState()` helper. Adding the
-  Lifebook filter without this would have meant editing five separate
-  call sites. The next filter that lands gets to add itself in two
-  places: the dropdown markup and the state reader.
+  via a new `readRegistryFilterState()` helper. The helper reads the
+  current dropdown/input values from the DOM (not pure, but isolated
+  — one place to change when filters are added). Adding the Lifebook
+  filter without this would have meant editing five separate call
+  sites. The next filter to land gets to add itself in two places:
+  the dropdown markup and the state reader.
 
 Test plan: smoke-tested in Chrome with mocked Lifebook + registry data
 — filter toggles correctly across three scenarios (all-Lifebooks, one

--- a/apps/web/public/js/pages/capabilities.js
+++ b/apps/web/public/js/pages/capabilities.js
@@ -1,6 +1,7 @@
 import {
   fetchCapabilities,
   fetchCapabilityRecipes,
+  fetchLifebooks,
   searchCapabilityRegistry,
   dismissCapabilitySuggestion,
   snoozeCapabilitySuggestion,
@@ -35,6 +36,11 @@ let _cachedSuggestions = [];
 let _cachedDormant = [];
 let _cachedRecipes = [];
 let _cachedPendingOptIns = [];
+// #193 deferred follow-up: lifebooks power the "filter registry by Lifebook"
+// dropdown. Each lifebook carries a `suggestedCapabilities: string[]` (registry
+// ids) — selecting a lifebook intersects registry results with that set so
+// users browsing for a specific life domain don't see the firehose.
+let _cachedLifebooks = [];
 let _lastContainer = null;
 
 function getCurrentUserId() {
@@ -57,12 +63,22 @@ function handleCapabilitiesInput(e) {
     if (_registrySearchTimer) clearTimeout(_registrySearchTimer);
     _registrySearchTimer = setTimeout(() => {
       _registrySearchTimer = null;
-      const q = target.value.trim();
-      const categorySelect = document.getElementById('registry-category');
-      const category = categorySelect ? categorySelect.value : '';
-      renderRegistryResults(getCurrentUserId(), q, category);
+      renderRegistryResults(getCurrentUserId(), readRegistryFilterState());
     }, 400);
   }
+}
+
+/**
+ * Read the three registry filter controls into a single state object. Kept as
+ * a tiny helper so every call site stays in sync when we add or remove a
+ * filter — adding the Lifebook filter without this would have required
+ * editing five separate `renderRegistryResults(...)` call sites.
+ */
+function readRegistryFilterState() {
+  const q = document.getElementById('registry-search')?.value?.trim() ?? '';
+  const category = document.getElementById('registry-category')?.value ?? '';
+  const lifebookDomain = document.getElementById('registry-lifebook')?.value ?? '';
+  return { q, category, lifebookDomain };
 }
 
 function handleCapabilitiesAction(e) {
@@ -100,16 +116,13 @@ function handleCapabilitiesAction(e) {
       if (slug) handleInstallRecipe(slug, userId, btn);
       break;
     }
-    case 'registry-search-submit': {
-      const q = document.getElementById('registry-search')?.value?.trim() || '';
-      const category = document.getElementById('registry-category')?.value || '';
-      renderRegistryResults(userId, q, category);
+    case 'registry-search-submit':
+    case 'registry-filter-change': {
+      renderRegistryResults(userId, readRegistryFilterState());
       break;
     }
     case 'registry-category-change': {
-      const q = document.getElementById('registry-search')?.value?.trim() || '';
-      const category = btn.getAttribute('data-category') || document.getElementById('registry-category')?.value || '';
-      renderRegistryResults(userId, q, category);
+      renderRegistryResults(userId, readRegistryFilterState());
       break;
     }
     case 'install-registry-entry': {
@@ -158,6 +171,7 @@ export async function renderCapabilities(container, userId) {
   let recipesData;
   let optInsData;
 
+  let lifebooksData;
   try {
     [capData, recipesData] = await Promise.all([
       fetchCapabilities(userId),
@@ -179,11 +193,21 @@ export async function renderCapabilities(container, userId) {
     optInsData = { optIns: [] };
   }
 
+  // Best-effort — lifebooks power the Lifebook filter dropdown. If the user
+  // hasn't run the domain extractor yet (or it returned nothing) we degrade
+  // to "no filter offered" rather than blocking the whole capabilities page.
+  try {
+    lifebooksData = await fetchLifebooks(userId);
+  } catch {
+    lifebooksData = { lifebooks: [] };
+  }
+
   _cachedInstalled = capData.installed ?? [];
   _cachedSuggestions = capData.suggestions ?? [];
   _cachedDormant = capData.dormant ?? [];
   _cachedRecipes = recipesData.recipes ?? [];
   _cachedPendingOptIns = optInsData.optIns ?? [];
+  _cachedLifebooks = (lifebooksData?.lifebooks ?? []).filter((lb) => !lb.hiddenAt);
 
   container.innerHTML = `
     <div style="display: flex; flex-direction: column; gap: 1.5rem;">
@@ -209,6 +233,7 @@ export async function renderCapabilities(container, userId) {
             <option value="productivity">Productivity</option>
             <option value="lifestyle">Lifestyle</option>
           </select>
+          ${renderLifebookFilterDropdown(_cachedLifebooks)}
           <button class="btn btn-primary btn-sm" data-action="registry-search-submit">Search</button>
         </div>
         <div id="registry-results">
@@ -223,15 +248,37 @@ export async function renderCapabilities(container, userId) {
     </div>
   `;
 
-  // Wire category change separately since it's on a <select>
-  document.getElementById('registry-category')?.addEventListener('change', (e) => {
-    const q = document.getElementById('registry-search')?.value?.trim() || '';
-    const category = e.target.value || '';
-    renderRegistryResults(userId, q, category);
+  // Wire category + lifebook <select> change events. The singleton-delegator
+  // pattern in `handleCapabilitiesAction` handles clicks via `data-action`,
+  // but native `change` events on form controls don't bubble through the
+  // same path on every browser — wire them explicitly. Using
+  // `readRegistryFilterState()` keeps both selectors agreeing on the state
+  // they hand to renderRegistryResults.
+  document.getElementById('registry-category')?.addEventListener('change', () => {
+    renderRegistryResults(userId, readRegistryFilterState());
+  });
+  document.getElementById('registry-lifebook')?.addEventListener('change', () => {
+    renderRegistryResults(userId, readRegistryFilterState());
   });
 
   // Auto-load all entries on first render
-  renderRegistryResults(userId, '', '');
+  renderRegistryResults(userId, { q: '', category: '', lifebookDomain: '' });
+}
+
+/**
+ * Render the Lifebook filter dropdown options. When the user has no
+ * lifebooks yet (e.g. domain extractor hasn't run, or every lifebook is
+ * hidden), the dropdown is hidden entirely — there's nothing useful to
+ * filter by, and an empty selector would just confuse.
+ */
+function renderLifebookFilterDropdown(lifebooks) {
+  if (!Array.isArray(lifebooks) || lifebooks.length === 0) return '';
+  return `
+    <select class="form-input" id="registry-lifebook" style="flex: 1; min-width: 140px;" data-action="registry-filter-change" aria-label="Filter by Lifebook">
+      <option value="">All Lifebooks</option>
+      ${lifebooks.map((lb) => `<option value="${escapeHtml(lb.domainName)}">${escapeHtml(lb.domainName)}</option>`).join('')}
+    </select>
+  `;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -490,25 +537,65 @@ function renderDormantCard(s) {
 // Registry search (partial re-render — no full page reload)
 // ─────────────────────────────────────────────────────────────────────────────
 
-async function renderRegistryResults(userId, q, category) {
+/**
+ * Render the registry results section, applying the three filter inputs:
+ * free-text search, category, and Lifebook. Search + category are
+ * forwarded to the server; Lifebook filtering is client-side because the
+ * server doesn't know about lifebooks (and adding it would require a
+ * registry-id JOIN on every request). The lifebook's
+ * `suggestedCapabilities: registryId[]` set is the source of truth — we
+ * intersect the server's results with that set after the round-trip.
+ *
+ * Back-compat: older callers passed positional `(userId, q, category)`.
+ * Those call sites have all been migrated to `(userId, state)`; this
+ * signature is the only form going forward.
+ */
+async function renderRegistryResults(userId, state) {
   const resultsEl = document.getElementById('registry-results');
   if (!resultsEl) return;
+  const { q = '', category = '', lifebookDomain = '' } = state ?? {};
   resultsEl.innerHTML = '<div style="color: var(--text-muted); font-size: 0.85rem;">Searching…</div>';
 
   try {
     const { entries } = await searchCapabilityRegistry(userId, q, category);
-    if (!entries || entries.length === 0) {
-      resultsEl.innerHTML = '<div style="color: var(--text-muted); font-size: 0.85rem;">No results found.</div>';
+    const filtered = applyLifebookFilter(entries ?? [], lifebookDomain);
+    if (filtered.length === 0) {
+      const lifebookMsg = lifebookDomain
+        ? ` for the "${escapeHtml(lifebookDomain)}" Lifebook`
+        : '';
+      resultsEl.innerHTML = `<div style="color: var(--text-muted); font-size: 0.85rem;">No results found${lifebookMsg}.</div>`;
       return;
     }
     resultsEl.innerHTML = `
       <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 0.6rem;">
-        ${entries.map(renderRegistryEntryCard).join('')}
+        ${filtered.map(renderRegistryEntryCard).join('')}
       </div>
     `;
   } catch (err) {
     resultsEl.innerHTML = `<div class="error-banner">${escapeHtml(err.friendlyMessage || err.message)}</div>`;
   }
+}
+
+/**
+ * Intersect a registry-entries list with the selected Lifebook's
+ * `suggestedCapabilities` set. Pure function so it's trivial to unit-test
+ * separately if a vitest harness for `apps/web` lands later.
+ *
+ * Returns the input unchanged when:
+ *   - No Lifebook is selected (empty string passed)
+ *   - The Lifebook isn't in our cached list (defensive — should never happen)
+ *   - The Lifebook has no suggested capabilities (empty registryId[] means
+ *     "the domain extractor didn't propose anything yet" — better to show
+ *     all than show nothing)
+ */
+function applyLifebookFilter(entries, lifebookDomain) {
+  if (!lifebookDomain) return entries;
+  const lb = _cachedLifebooks.find((x) => x.domainName === lifebookDomain);
+  if (!lb) return entries;
+  const allowed = lb.suggestedCapabilities ?? [];
+  if (allowed.length === 0) return entries;
+  const allowSet = new Set(allowed);
+  return entries.filter((e) => allowSet.has(e.id));
 }
 
 function renderRegistryEntryCard(entry) {

--- a/apps/web/public/js/pages/capabilities.js
+++ b/apps/web/public/js/pages/capabilities.js
@@ -116,12 +116,7 @@ function handleCapabilitiesAction(e) {
       if (slug) handleInstallRecipe(slug, userId, btn);
       break;
     }
-    case 'registry-search-submit':
-    case 'registry-filter-change': {
-      renderRegistryResults(userId, readRegistryFilterState());
-      break;
-    }
-    case 'registry-category-change': {
+    case 'registry-search-submit': {
       renderRegistryResults(userId, readRegistryFilterState());
       break;
     }
@@ -207,7 +202,12 @@ export async function renderCapabilities(container, userId) {
   _cachedDormant = capData.dormant ?? [];
   _cachedRecipes = recipesData.recipes ?? [];
   _cachedPendingOptIns = optInsData.optIns ?? [];
-  _cachedLifebooks = (lifebooksData?.lifebooks ?? []).filter((lb) => !lb.hiddenAt);
+  // `GET /api/lifebooks/:userId` already calls `listVisible()` server-side,
+  // so the response is hidden-filtered. Defensive client-side filter uses
+  // the actual API field (`hidden: boolean`) — Copilot caught that the
+  // prior `!lb.hiddenAt` was a no-op (wrong field name) and would have
+  // fail-opened if the endpoint ever changed to return hidden rows.
+  _cachedLifebooks = (lifebooksData?.lifebooks ?? []).filter((lb) => !lb.hidden);
 
   container.innerHTML = `
     <div style="display: flex; flex-direction: column; gap: 1.5rem;">
@@ -227,7 +227,12 @@ export async function renderCapabilities(container, userId) {
         </div>
         <div style="display: flex; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap;">
           <input class="form-input" id="registry-search" placeholder="Search capabilities…" style="flex: 2; min-width: 160px;">
-          <select class="form-input" id="registry-category" style="flex: 1; min-width: 120px;" data-action="registry-category-change">
+          <!-- The explicit change listener wired below is the sole
+               entry point for this select. Previously a data-action
+               attribute also forwarded clicks through the global
+               delegator, double-firing renderRegistryResults on every
+               dropdown-open. Copilot caught the duplicate on PR #256. -->
+          <select class="form-input" id="registry-category" style="flex: 1; min-width: 120px;">
             <option value="">All categories</option>
             <option value="developer">Developer</option>
             <option value="productivity">Productivity</option>
@@ -273,8 +278,11 @@ export async function renderCapabilities(container, userId) {
  */
 function renderLifebookFilterDropdown(lifebooks) {
   if (!Array.isArray(lifebooks) || lifebooks.length === 0) return '';
+  // No data-action — change events are wired explicitly below. Keeping
+  // the action would double-fire `renderRegistryResults` (once on the
+  // click that opens the dropdown, again on the change after selection).
   return `
-    <select class="form-input" id="registry-lifebook" style="flex: 1; min-width: 140px;" data-action="registry-filter-change" aria-label="Filter by Lifebook">
+    <select class="form-input" id="registry-lifebook" style="flex: 1; min-width: 140px;" aria-label="Filter by Lifebook">
       <option value="">All Lifebooks</option>
       ${lifebooks.map((lb) => `<option value="${escapeHtml(lb.domainName)}">${escapeHtml(lb.domainName)}</option>`).join('')}
     </select>
@@ -578,19 +586,23 @@ async function renderRegistryResults(userId, state) {
 
 /**
  * Intersect a registry-entries list with the selected Lifebook's
- * `suggestedCapabilities` set. Pure function so it's trivial to unit-test
- * separately if a vitest harness for `apps/web` lands later.
+ * `suggestedCapabilities` set. Pure function — all three inputs are
+ * arguments; no module-scope reads — so a future vitest harness for
+ * `apps/web` can drive it without monkeypatching `_cachedLifebooks`.
+ * The default parameter pulls from cache only at the call site inside
+ * `renderRegistryResults`, where module state is the right source.
  *
- * Returns the input unchanged when:
- *   - No Lifebook is selected (empty string passed)
- *   - The Lifebook isn't in our cached list (defensive — should never happen)
- *   - The Lifebook has no suggested capabilities (empty registryId[] means
- *     "the domain extractor didn't propose anything yet" — better to show
- *     all than show nothing)
+ * Returns `entries` unchanged when:
+ *   - No Lifebook is selected (empty string passed).
+ *   - The Lifebook isn't in `lifebooks` (defensive — should never happen).
+ *   - The Lifebook has an empty `suggestedCapabilities` list (the domain
+ *     extractor proposed nothing yet — better to show all than collapse,
+ *     so "extractor hasn't decided" doesn't look like "extractor found
+ *     no matches").
  */
-function applyLifebookFilter(entries, lifebookDomain) {
+function applyLifebookFilter(entries, lifebookDomain, lifebooks = _cachedLifebooks) {
   if (!lifebookDomain) return entries;
-  const lb = _cachedLifebooks.find((x) => x.domainName === lifebookDomain);
+  const lb = lifebooks.find((x) => x.domainName === lifebookDomain);
   if (!lb) return entries;
   const allowed = lb.suggestedCapabilities ?? [];
   if (allowed.length === 0) return entries;


### PR DESCRIPTION
## Summary

Closes the **"capability filter by domain on Capabilities page"** item that PR #242 (#193 Child 1) explicitly deferred. The Capabilities page now carries a Lifebook dropdown alongside the existing category filter; selecting a Lifebook intersects the registry results with that Lifebook's `suggestedCapabilities: registryId[]` set.

## What changed

**One file: `apps/web/public/js/pages/capabilities.js`**

- Fetch `/api/lifebooks/:userId` alongside the existing capabilities + recipes + opt-ins data on render. Best-effort — failure degrades to "no Lifebook filter offered" rather than blocking the page.
- New `renderLifebookFilterDropdown(lifebooks)` renders the `<select>` only when at least one visible Lifebook exists; hidden Lifebooks (`hiddenAt` set) are filtered out, matching the existing "hidden surfaces stay queryable in memory; surface visibility is the user's call" contract Lifebooks already follow.
- New `applyLifebookFilter(entries, lifebookDomain)` is the load-bearing piece. Pure function — intersects the registry results with the selected Lifebook's `suggestedCapabilities` set. Three short-circuit cases documented in the function docstring: no filter selected, Lifebook not in cached list, Lifebook has empty `suggestedCapabilities` (extractor proposed nothing yet — show everything rather than collapse to zero).
- Empty-state copy surfaces the active Lifebook name (`No results found for the "Health" Lifebook.`) so the user can immediately tell *why* nothing's showing.

**Internal cleanup**

The three `renderRegistryResults(userId, q, category)` call sites collapsed to a single `renderRegistryResults(userId, readRegistryFilterState())` form via a new `readRegistryFilterState()` helper. Adding the Lifebook filter without this would have meant editing five separate call sites; the next filter to land only has to touch two places now (the dropdown markup and the state reader).

## What this PR deliberately does NOT do

- **No DB migration.** The intersection set already lives on `lifebooks.suggested_capabilities`, populated by the domain-extraction worker that shipped in PR #242. Adding a `domain_name` column on `mcp_servers` would have been the heavier approach; this one stays purely on the read side.
- **No server-side filter.** The filter runs in JS after the API round-trip. The registry response is small (it's already pre-filtered by category) and lifebooks rarely have more than ~10 suggested capabilities each, so the client-side intersect is cheap.
- **No filter on the Installed section** (yet). Today the filter only narrows the *Browse Registry* results — that's where users discover new capabilities and most want to narrow by Lifebook. Filtering Installed is a follow-up if usage suggests it.

## Test plan

- [x] **Smoke-tested in Chrome** at `localhost:3202/#/capabilities` with mocked Lifebook + registry data:
  - **All Lifebooks** (initial): all 4 mocked entries shown.
  - **Health Lifebook**: filter narrows to `cap-fitbit` only (other Health-suggested entries aren't in the registry mock; the intersect handled it correctly).
  - **Money Lifebook**: filter narrows to `cap-mint` only.
  - **Back to All Lifebooks**: all 4 entries restored.
  - **Hidden Lifebook**: confirmed it doesn't appear in the dropdown options.
- [x] `node --check` clean on `capabilities.js`.

Smoke-test results captured live:

```json
{
  "dropdownPresent": true,
  "dropdownOptions": ["", "Health", "Money"],  // "Hidden" correctly absent
  "allEntriesCount": 4,
  "healthEntries": ["cap-fitbit"],
  "moneyEntries": ["cap-mint"],
  "allBackEntries": ["cap-fitbit", "cap-mint", "cap-github", "cap-spotify"]
}
```

## Notes for reviewers

- `applyLifebookFilter()` is intentionally pure (no DOM reads, no module-level state mutation) so it's portable to a vitest harness if `apps/web` ever gets one. The three short-circuit cases (no filter selected / Lifebook missing / empty suggested list) are documented inline.
- The "empty suggestedCapabilities means show everything, not collapse" call is the only judgment one here. The alternative ("extractor hasn't proposed anything yet, so this Lifebook filter should show zero") would have made the empty state harder to interpret — users would think the filter was broken. Worth flagging if you read it differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)