### PR TITLE
feat(#193 follow-up): provenance graph filter by Lifebook wing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,65 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Provenance graph: filter by Lifebook wing (#193 follow-up)
+
+Closes the **"provenance graph wing-filter consumer"** item that
+PR #242 (#193 Child 1) explicitly deferred. The lifebook page has
+been linking to `#/provenance?wing=<wingId>` since #242 shipped, but
+the provenance page couldn't honor that filter because nodes had no
+wing linkage. This PR adds the wing-id column + write-time
+population + API filter + frontend consumer end-to-end.
+
+### Migration
+
+- `041-provenance-wing-id.sql` — adds nullable `wing_id UUID`
+  column to `capability_provenance_nodes` plus a partial index
+  `(user_id, wing_id, occurred_at DESC) WHERE wing_id IS NOT NULL`
+  so per-wing graph queries are indexed without bloating the index
+  with the long tail of NULL rows. No FK to lifebooks (would block
+  lifebook hard-delete); the frontend filter naturally excludes
+  NULL rows.
+
+### Write-time population
+
+- `provenanceRepository.writeNode()` auto-derives `wing_id` when
+  the caller doesn't pass one explicitly: if the payload carries
+  a `registryId`, look up the lifebook whose
+  `suggested_capabilities` contains that id and stamp its
+  `wing_id` on the node. Best-effort — a registryId not in any
+  lifebook stays NULL. Explicit `wingId` argument always wins
+  over auto-derivation, so future call sites with their own wing
+  context can bypass the lookup.
+- Older rows written before migration 041 stay NULL forever
+  unless a future backfill utility runs.
+
+### API
+
+- `GET /api/capabilities/provenance-graph` now accepts an optional
+  `wing=<uuid>` query param. UUID-validated (returns 400 on bad
+  shape, same pattern as `serverId`). Each node in the response
+  includes `wingId: string | null`.
+
+### Frontend
+
+- `provenance-graph.js` reads the `wing` param off the hash query
+  string (the lifebook page's `#/provenance?wing=<uuid>` link),
+  passes it through `fetchProvenanceGraph`, and renders a
+  scoped-state indicator above the graph with a "Show all wings"
+  button to clear the filter. UUID-validated client-side too so a
+  malformed hash doesn't reach the API.
+
+### Test plan
+
+3 new vitest cases for the API surface (wing filter active,
+invalid wing → 400, response includes `wingId` per node). Full
+api suite: 547/547. Workspace: 70/70 turbo tasks green.
+
+What this does NOT do: per-domain briefing prose (the other #193
+deferred follow-up — separate PR), and backfill of `wing_id` for
+existing provenance rows. The wing filter shows post-migration
+nodes; older ones can be filled in by a follow-up utility if
+usage demands it.
+
 ## [unreleased] — Capabilities: filter the registry by Lifebook (#193 follow-up)
 
 ### Fixed (post-Copilot review)

--- a/apps/api/src/__tests__/provenance-graph-routes.test.ts
+++ b/apps/api/src/__tests__/provenance-graph-routes.test.ts
@@ -338,6 +338,57 @@ describe('GET /api/capabilities/provenance-graph', () => {
     );
     expect(status).toBe(400);
   });
+
+  // #193 follow-up: provenance graph filtered to a Lifebook wing.
+  it('filters by wing when provided', async () => {
+    const node = makeNode({ node_type: 'install' });
+    mockQuery
+      .mockResolvedValueOnce({ rows: [node], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const wingId = 'cccccccc-1111-2222-3333-444444444444';
+    const { status } = await req(
+      buildApp(),
+      'GET',
+      `/api/capabilities/provenance-graph?userId=${USER_ID}&wing=${wingId}`,
+    );
+
+    expect(status).toBe(200);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('wing_id'),
+      expect.arrayContaining([wingId]),
+    );
+  });
+
+  it('returns 400 when wing is not a valid UUID', async () => {
+    const { status, body } = await req(
+      buildApp(),
+      'GET',
+      `/api/capabilities/provenance-graph?userId=${USER_ID}&wing=not-a-uuid`,
+    );
+    expect(status).toBe(400);
+    expect((body as { error?: string }).error).toMatch(/wing/);
+  });
+
+  it('includes wingId on each node in the response', async () => {
+    const wingId = 'dddddddd-1111-2222-3333-555555555555';
+    const node = {
+      ...makeNode({ id: 'aaaaaaaa-9999-0000-0000-000000000001' }),
+      wing_id: wingId,
+    };
+    mockQuery
+      .mockResolvedValueOnce({ rows: [node], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const { status, body } = await req(
+      buildApp(),
+      'GET',
+      `/api/capabilities/provenance-graph?userId=${USER_ID}`,
+    );
+    expect(status).toBe(200);
+    const typedBody = body as { nodes: Array<{ wingId: string | null }> };
+    expect(typedBody.nodes[0]?.wingId).toBe(wingId);
+  });
 });
 
 // ── Tests: buildEvidencePreview helper ────────────────────────────────────

--- a/apps/api/src/routes/capabilities.ts
+++ b/apps/api/src/routes/capabilities.ts
@@ -1601,6 +1601,11 @@ export function createCapabilitiesRouter(): Router {
       const nodeType = typeof req.query['nodeType'] === 'string' ? req.query['nodeType'] : null;
       const since = typeof req.query['since'] === 'string' ? req.query['since'] : null;
       const serverId = typeof req.query['serverId'] === 'string' ? req.query['serverId'] : null;
+      // #193 follow-up: scope the graph to a single Lifebook wing.
+      // Lifebook page links here with `?wing=<lb.wingId>`; nodes that
+      // don't have a matching `wing_id` (older rows, node types without
+      // a lifebook linkage) are filtered out.
+      const wingId = typeof req.query['wing'] === 'string' ? req.query['wing'] : null;
       const limitRaw = typeof req.query['limit'] === 'string' ? parseInt(req.query['limit'], 10) : 200;
       const limit = Number.isFinite(limitRaw) && limitRaw > 0
         ? Math.min(limitRaw, 500)
@@ -1609,6 +1614,12 @@ export function createCapabilitiesRouter(): Router {
       // Validate serverId if provided
       if (serverId && !UUID_REGEX.test(serverId)) {
         res.status(400).json({ error: 'serverId must be a valid UUID' });
+        return;
+      }
+
+      // Validate wingId if provided
+      if (wingId && !UUID_REGEX.test(wingId)) {
+        res.status(400).json({ error: 'wing must be a valid UUID' });
         return;
       }
 
@@ -1636,6 +1647,10 @@ export function createCapabilitiesRouter(): Router {
         params.push(serverId);
         whereClause += ` AND server_id = $${params.length}`;
       }
+      if (wingId) {
+        params.push(wingId);
+        whereClause += ` AND wing_id = $${params.length}`;
+      }
 
       const nodeResult = await query<{
         id: string;
@@ -1643,10 +1658,11 @@ export function createCapabilitiesRouter(): Router {
         ref_table: string;
         ref_id: string;
         server_id: string | null;
+        wing_id: string | null;
         occurred_at: Date;
         payload: unknown;
       }>(
-        `SELECT id, node_type, ref_table, ref_id, server_id, occurred_at, payload
+        `SELECT id, node_type, ref_table, ref_id, server_id, wing_id, occurred_at, payload
          FROM capability_provenance_nodes
          ${whereClause}
          ORDER BY occurred_at DESC
@@ -1676,6 +1692,7 @@ export function createCapabilitiesRouter(): Router {
           id: n.id,
           type: n.node_type,
           label,
+          wingId: n.wing_id,
           occurredAt: n.occurred_at,
           payload: rawPayload,
         };

--- a/apps/web/public/js/pages/provenance-graph.js
+++ b/apps/web/public/js/pages/provenance-graph.js
@@ -68,6 +68,18 @@ function handleProvenanceGraphAction(e) {
       renderProvenanceGraph(document.getElementById('page-content'), userId, { limit: 1000 });
       break;
     }
+    case 'pg-clear-wing-filter': {
+      // Strip the `?wing=` query from the hash so subsequent renders
+      // load the un-scoped graph. Re-render explicitly so we don't
+      // depend on the hashchange listener firing.
+      const newHash = '#/provenance';
+      if (window.location.hash !== newHash) {
+        window.location.hash = newHash;
+      } else {
+        renderProvenanceGraph(document.getElementById('page-content'), getCurrentUserId(), { wing: '' });
+      }
+      break;
+    }
     default:
       break;
   }
@@ -77,10 +89,11 @@ function handleProvenanceGraphAction(e) {
 // API fetch helper
 // ─────────────────────────────────────────────────────────────────────────────
 
-async function fetchProvenanceGraph(userId, { nodeType = '', since = '', limit = 200 } = {}) {
+async function fetchProvenanceGraph(userId, { nodeType = '', since = '', limit = 200, wing = '' } = {}) {
   const params = new URLSearchParams({ userId });
   if (nodeType) params.set('nodeType', nodeType);
   if (since) params.set('since', since);
+  if (wing) params.set('wing', wing);
   if (limit !== 200) params.set('limit', String(limit));
 
   const res = await fetch(`/api/capabilities/provenance-graph?${params}`, {
@@ -96,6 +109,25 @@ async function fetchProvenanceGraph(userId, { nodeType = '', since = '', limit =
   return res.json();
 }
 
+/**
+ * Read the `wing` query param off the hash. Hash routes are like
+ * `#/provenance?wing=<uuid>`; the lifebook page links here with that
+ * shape. Returns '' when no wing param is set. Validates against the
+ * UUID shape so a malformed value can't get forwarded to the API.
+ */
+function readWingFromHash() {
+  const hash = window.location.hash || '';
+  const qIdx = hash.indexOf('?');
+  if (qIdx === -1) return '';
+  const search = new URLSearchParams(hash.slice(qIdx + 1));
+  const wing = search.get('wing') || '';
+  // RFC 4122 UUID shape — same regex the API uses to validate.
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(wing)) {
+    return '';
+  }
+  return wing;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Main render entry point
 // ─────────────────────────────────────────────────────────────────────────────
@@ -104,9 +136,15 @@ export async function renderProvenanceGraph(container, userId, opts = {}) {
   ensureProvenanceGraphListener();
   container.innerHTML = '<div class="loading">Loading provenance graph…</div>';
 
+  // Read `wing` from the hash query string unless the caller explicitly
+  // overrode it. The lifebook page links here with `?wing=<uuid>`; the
+  // graph filters to nodes scoped to that Lifebook wing.
+  const wing = opts.wing !== undefined ? opts.wing : readWingFromHash();
+  const fetchOpts = { ...opts, wing };
+
   let data;
   try {
-    data = await fetchProvenanceGraph(userId, opts);
+    data = await fetchProvenanceGraph(userId, fetchOpts);
   } catch (err) {
     container.innerHTML = renderApiError(err, {
       context: "Couldn't load provenance graph.",
@@ -133,6 +171,12 @@ export async function renderProvenanceGraph(container, userId, opts = {}) {
           Capability lifecycle events — signals, installs, promotions, actions.
           Click a node to see its full payload.
         </div>
+        ${wing ? `
+          <div style="display: flex; align-items: center; gap: 0.5rem; padding: 0.4rem 0.6rem; margin-bottom: 0.5rem; background: var(--bg-accent, var(--bg-card)); border-left: 3px solid var(--primary); border-radius: var(--radius-sm); font-size: 0.8rem;">
+            <span>Scoped to one Lifebook wing.</span>
+            <button class="btn btn-outline btn-sm" style="font-size: 0.7rem; padding: 0.1rem 0.4rem;" data-action="pg-clear-wing-filter">Show all wings</button>
+          </div>
+        ` : ''}
         <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: flex-end;">
           <label style="font-size: 0.8rem; color: var(--text-muted);">
             Filter by type

--- a/apps/web/public/js/pages/provenance-graph.js
+++ b/apps/web/public/js/pages/provenance-graph.js
@@ -70,8 +70,16 @@ function handleProvenanceGraphAction(e) {
     }
     case 'pg-clear-wing-filter': {
       // Strip the `?wing=` query from the hash so subsequent renders
-      // load the un-scoped graph. Re-render explicitly so we don't
-      // depend on the hashchange listener firing.
+      // load the un-scoped graph. Two branches:
+      //   - Hash currently has `?wing=…` → setting `window.location.hash`
+      //     to `#/provenance` triggers a hashchange event; the SPA
+      //     router responds by re-routing into this page, which calls
+      //     renderProvenanceGraph again. We rely on the router here.
+      //   - Hash is already `#/provenance` (unlikely path — clear was
+      //     somehow clicked twice or the URL was edited) → call
+      //     renderProvenanceGraph explicitly with wing='' so the
+      //     scope clears without depending on a hashchange that
+      //     won't fire.
       const newHash = '#/provenance';
       if (window.location.hash !== newHash) {
         window.location.hash = newHash;

--- a/packages/db/src/migrations/041-provenance-wing-id.sql
+++ b/packages/db/src/migrations/041-provenance-wing-id.sql
@@ -1,0 +1,31 @@
+-- 041-provenance-wing-id.sql
+-- #193 follow-up: tie provenance nodes to a Lifebook wing.
+--
+-- The lifebook page (apps/web/public/js/pages/lifebook.js) already links to
+-- `#/provenance?wing=<wingId>`, but the provenance page couldn't honor that
+-- filter because nodes had no wing linkage. This migration adds a nullable
+-- `wing_id` column so the API can return only the nodes belonging to a
+-- specific Lifebook's wing.
+--
+-- Population strategy: best-effort at write time. The
+-- provenanceRepository.writeNode() call site that has lifebook context
+-- (install/action/feedback events that carry a registryId in the payload)
+-- looks up the lifebook for that registryId and stamps its wing_id on the
+-- node. Older rows and rows for node types without an obvious lifebook
+-- linkage (tier_promotion, external_agent, etc.) stay NULL. A future
+-- backfill utility can fill those in if needed.
+--
+-- Schema-wise: nullable column, no default, no FK constraint to lifebooks
+-- (which would block lifebook hard-deletes). The frontend filter only
+-- shows nodes with a matching wing_id, so NULL rows are naturally
+-- excluded from the per-wing view.
+
+ALTER TABLE capability_provenance_nodes
+  ADD COLUMN IF NOT EXISTS wing_id UUID;
+
+-- Partial index keyed on wing-scoped queries. CockroachDB supports
+-- partial indexes via the WHERE clause; this keeps the index small
+-- (only populated rows) while still serving the per-wing-graph hot path.
+CREATE INDEX IF NOT EXISTS capability_provenance_nodes_wing_idx
+  ON capability_provenance_nodes (user_id, wing_id, occurred_at DESC)
+  WHERE wing_id IS NOT NULL;

--- a/packages/db/src/repositories/provenance-repository.ts
+++ b/packages/db/src/repositories/provenance-repository.ts
@@ -7,6 +7,15 @@ export interface ProvenanceNodeRow {
   ref_table: string;
   ref_id: string;
   server_id: string | null;
+  /**
+   * #193 follow-up: optional Lifebook wing this node belongs to.
+   * Populated at write time when the caller has lifebook context
+   * (typically: the payload contains a `registryId` that matches a
+   * lifebook's `suggested_capabilities` entry). NULL for rows
+   * written before migration 041 and for node types with no
+   * obvious lifebook linkage (tier_promotion, external_agent, etc.).
+   */
+  wing_id: string | null;
   occurred_at: Date;
   payload: Record<string, unknown> | null;
   created_at: Date;
@@ -24,6 +33,8 @@ export interface WriteNodeInput {
   refTable: string;
   refId: string;
   serverId?: string | null;
+  /** #193 follow-up: Lifebook wing to tie this node to. Optional. */
+  wingId?: string | null;
   occurredAt?: Date;
   payload?: Record<string, unknown>;
 }
@@ -42,7 +53,7 @@ export const provenanceRepository = {
    */
   async getForServer(userId: string, serverId: string): Promise<ProvenanceNodeRow[]> {
     const result = await query<ProvenanceNodeRow>(
-      `SELECT id, user_id, node_type, ref_table, ref_id, server_id,
+      `SELECT id, user_id, node_type, ref_table, ref_id, server_id, wing_id,
               occurred_at, payload, created_at
        FROM capability_provenance_nodes
        WHERE user_id = $1 AND server_id = $2
@@ -54,14 +65,25 @@ export const provenanceRepository = {
 
   /**
    * Write a single provenance node and return the persisted row.
+   *
+   * #193 follow-up: when `input.wingId` is omitted but the payload
+   * carries a `registryId`, we look up the matching lifebook (the one
+   * whose `suggested_capabilities` contains that registry id) and stamp
+   * its wing_id on the node. This is best-effort — if the registry id
+   * isn't in any lifebook (e.g. capability installed before the domain
+   * extractor ran), wing_id stays NULL. Explicit `wingId` always wins
+   * over the auto-derivation.
    */
   async writeNode(input: WriteNodeInput): Promise<ProvenanceNodeRow> {
     const occurredAt = input.occurredAt ?? new Date();
+    const wingId = input.wingId !== undefined
+      ? input.wingId
+      : await resolveWingIdFromPayload(input.userId, input.payload);
     const result = await query<ProvenanceNodeRow>(
       `INSERT INTO capability_provenance_nodes
-         (user_id, node_type, ref_table, ref_id, server_id, occurred_at, payload)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
-       RETURNING id, user_id, node_type, ref_table, ref_id, server_id,
+         (user_id, node_type, ref_table, ref_id, server_id, wing_id, occurred_at, payload)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING id, user_id, node_type, ref_table, ref_id, server_id, wing_id,
                  occurred_at, payload, created_at`,
       [
         input.userId,
@@ -69,6 +91,7 @@ export const provenanceRepository = {
         input.refTable,
         input.refId,
         input.serverId ?? null,
+        wingId,
         occurredAt,
         input.payload != null ? JSON.stringify(input.payload) : null,
       ],
@@ -90,3 +113,42 @@ export const provenanceRepository = {
     );
   },
 };
+
+/**
+ * Resolve a Lifebook wing_id for a provenance-node payload, when the
+ * payload carries a `registryId` matching a lifebook's
+ * `suggested_capabilities` entry. Returns null when:
+ *
+ *   - The payload is null / not an object / has no `registryId`.
+ *   - No lifebook claims that registryId.
+ *   - The matching lifebook hasn't been bound to a wing yet.
+ *
+ * Used by `writeNode()` to auto-derive wing_id when the caller doesn't
+ * pass one explicitly. Kept as a module-local helper rather than a
+ * public repo method because the auto-derivation logic shouldn't be
+ * called from anywhere else — explicit `wingId` is the long-term path.
+ */
+async function resolveWingIdFromPayload(
+  userId: string,
+  payload: Record<string, unknown> | undefined,
+): Promise<string | null> {
+  if (!payload) return null;
+  const registryId = payload['registryId'];
+  if (typeof registryId !== 'string' || registryId.length === 0) return null;
+
+  // `@>` is the JSONB containment operator. `jsonb_build_array($2)`
+  // builds the single-element array `[<registryId>]`, and the @> check
+  // returns true when `suggested_capabilities` contains that element.
+  // Portable form across CockroachDB and PG; no `?` operator quirks.
+  const result = await query<{ wing_id: string | null }>(
+    `SELECT wing_id
+     FROM lifebooks
+     WHERE user_id = $1
+       AND wing_id IS NOT NULL
+       AND suggested_capabilities @> jsonb_build_array($2::text)
+     ORDER BY last_seen_at DESC
+     LIMIT 1`,
+    [userId, registryId],
+  );
+  return result.rows[0]?.wing_id ?? null;
+}

--- a/packages/db/src/repositories/provenance-repository.ts
+++ b/packages/db/src/repositories/provenance-repository.ts
@@ -119,9 +119,16 @@ export const provenanceRepository = {
  * payload carries a `registryId` matching a lifebook's
  * `suggested_capabilities` entry. Returns null when:
  *
- *   - The payload is null / not an object / has no `registryId`.
+ *   - The payload is undefined.
+ *   - The payload has no `registryId` string (missing key or non-string
+ *     value — registryId is the only key we look at, so any other
+ *     payload shape is treated the same as "no registryId").
  *   - No lifebook claims that registryId.
  *   - The matching lifebook hasn't been bound to a wing yet.
+ *
+ * The argument type is `Record<string, unknown> | undefined` so the
+ * non-object case is already excluded at compile time — that's why the
+ * runtime check only looks at falsy payload + the `registryId` shape.
  *
  * Used by `writeNode()` to auto-derive wing_id when the caller doesn't
  * pass one explicitly. Kept as a module-local helper rather than a


### PR DESCRIPTION
## Summary

Closes the **"provenance graph wing-filter consumer"** item that PR #242 (#193 Child 1) explicitly deferred. The lifebook page has been linking to `#/provenance?wing=<wingId>` since #242 shipped, but the provenance page couldn't honor that filter because nodes had no wing linkage. This PR adds the wing-id column + write-time population + API filter + frontend consumer end-to-end.

Two of three #193 follow-ups now closed (capabilities filter via PR #256; this one). One remaining: per-Lifebook briefing prose.

## What changed

### Migration

**`packages/db/src/migrations/041-provenance-wing-id.sql`** — adds nullable `wing_id UUID` to `capability_provenance_nodes` plus a partial index `(user_id, wing_id, occurred_at DESC) WHERE wing_id IS NOT NULL`. Partial keeps the index small — only populated rows — while still serving per-wing hot-path queries. No FK to `lifebooks` (would block lifebook hard-delete); the frontend filter naturally excludes NULL rows.

### Write-time population

**`provenanceRepository.writeNode()`** auto-derives `wing_id` when the caller doesn't pass one explicitly. Logic: if the payload carries a `registryId`, look up the lifebook whose `suggested_capabilities` contains that id and stamp its `wing_id` on the node. Best-effort — a registryId not in any lifebook stays NULL. Explicit `wingId` argument always wins over the auto-derivation, so future call sites with their own wing context (e.g. an action invoked from inside a Lifebook page) can bypass the lookup.

### API

**`GET /api/capabilities/provenance-graph`** accepts a new optional `wing=<uuid>` query param. UUID-validated (returns 400 on bad shape, mirroring the existing `serverId` validation). Each node returned to the client includes `wingId: string | null`.

### Frontend

**`apps/web/public/js/pages/provenance-graph.js`** reads the `wing` param off the hash query string (the lifebook page's `#/provenance?wing=<uuid>` link), passes it through `fetchProvenanceGraph`, and renders a clearly-visible scoped-state indicator above the graph with a "Show all wings" button to clear the filter. UUID-validated client-side too so a malformed hash doesn't reach the API.

## What this PR deliberately does NOT do

- **Backfill of `wing_id` for pre-migration provenance rows.** Older nodes stay NULL forever unless a future utility runs. The wing filter shows post-migration nodes; that's the right MVP for "Lifebook scoping" since the lifebook itself is a recent concept and the most relevant nodes are recent.
- **Per-domain briefing prose** — the third #193 deferred follow-up. Separate PR.

## Test plan

- [x] 3 new vitest cases in `provenance-graph-routes.test.ts`:
  - `wing` filter is forwarded as `wing_id` in the SQL params + WHERE clause.
  - Malformed `wing` UUID returns 400 with a `wing`-mentioning error.
  - Response nodes include `wingId` per node.
- [x] **Full api suite**: 547/547 passing (+3 new tests).
- [x] **Full workspace**: 70/70 turbo tasks green.
- [x] `pnpm build --concurrency=1` clean.
- [x] `node --check` clean on the JS file.

## Notes for reviewers

- The `resolveWingIdFromPayload` helper runs one extra SELECT per provenance-node write. On install/action node creation that's negligible (these aren't hot paths). For high-volume node writers (signal/entity), the payload typically doesn't have a `registryId`, so the helper short-circuits and never hits the DB.
- The partial index strategy means the per-wing query cost stays bounded even as the `capability_provenance_nodes` table grows with NULL-wing rows. CockroachDB supports partial indexes natively.
- Auto-derivation could disagree with explicit `wingId` if a caller passed one and a different lifebook later claimed the same registryId. The current contract — explicit wins — means the explicit value is authoritative. Worth flagging if you read it differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)