### PR TITLE
feat(#193 follow-up): per-Lifebook briefing prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@ All notable changes to SkyTwin will be documented in this file.
 
 ## [unreleased] — Per-Lifebook briefing prose (#193 follow-up)
 
+### Fixed (post-Copilot round 1)
+
+- **Tier-promotion rows now flow into per-Lifebook briefings.** The
+  prior filter checked `payload.registryId`, but `tier_promotion`
+  payloads carry `{ from, to, reason }` (no registry id) and
+  reference the server via `server_id`. `gatherBriefingData` now
+  computes a `server_id → registry_id` map and `filterDataByLifebook`
+  uses it to attribute promotions to the right lifebook.
+- **N+1 query pattern eliminated.** The orchestrator now calls
+  `gatherBriefingData` ONCE per user and passes the bundle through
+  both the global briefing and every per-Lifebook briefing. Per-
+  lifebook DB cost dropped from "2 repo calls + 1 query per
+  lifebook" to "filter the in-memory bundle."
+- **Empty-allowlist footgun fixed.** `filterDataByLifebook` now
+  returns an EMPTY bundle when the lifebook has no
+  `suggested_capabilities`, instead of returning the unfiltered
+  global bundle. Previously a scoped call with an empty allowlist
+  would have written a global briefing under the domain's label.
+- **`listForUser` scoped to global by default.** Adding the
+  `domain_name` column would otherwise have silently interleaved
+  per-Lifebook rows into the existing twin-briefings history. New
+  `opts.includeDomainScoped` lets callers opt in. New
+  `listForUserDomain()` mirror serves the per-domain history.
+- **6 new route-level tests** for `GET /lifebook/:domain/latest`
+  (returns briefing when present, returns `null` when absent,
+  forwards cadence, ignores bogus cadence, 403 on cross-user,
+  400 on missing userId).
+
+### Original change
+
 Closes the last of the three #193 Child 1 follow-ups deferred by
 PR #242 (capabilities Lifebook filter shipped in #256; provenance
 wing filter shipped in #257; this one). The weekly briefing worker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,74 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Per-Lifebook briefing prose (#193 follow-up)
+
+Closes the last of the three #193 Child 1 follow-ups deferred by
+PR #242 (capabilities Lifebook filter shipped in #256; provenance
+wing filter shipped in #257; this one). The weekly briefing worker
+now emits, in addition to the existing global briefing, one
+per-Lifebook briefing for each visible domain with activity in the
+window. The lifebook page renders the per-domain briefing when one
+exists.
+
+### Migration
+
+- `042-briefing-domain.sql` — adds nullable `domain_name STRING`
+  column to `twin_briefings`. NULL preserves the historical global-
+  briefing semantic untouched. A string value scopes the briefing
+  to that lifebook's domain (matching `lifebooks.domain_name`).
+  Partial index `(user_id, domain_name, generated_at DESC) WHERE
+  domain_name IS NOT NULL` keeps per-domain queries fast without
+  bloating storage for global rows.
+
+### Repository
+
+- `briefingRepository.create()` accepts an optional `domainName`.
+- `briefingRepository.getLatestForUser()` now explicitly scopes to
+  `domain_name IS NULL` — the historical method only ever served
+  global briefings, so the implicit semantic is now explicit.
+- New `briefingRepository.getLatestForUserDomain(userId, domain,
+  cadence?)` for the per-Lifebook surface.
+
+### Worker
+
+- `apps/worker/src/jobs/briefing-generator.ts` extends the job:
+  after writing the global briefing, fetch the user's visible
+  lifebooks and emit one per-domain briefing per lifebook with
+  events in the window. Events are filtered by
+  `registry_id ∈ lifebook.suggested_capabilities` — the same set
+  the domain extractor proposed. Empty filtered sets are skipped
+  (a "nothing happened in Health this week" briefing is noise).
+  Per-lifebook failures are caught and logged so one broken domain
+  doesn't kill the rest.
+- The prompt carries an optional `{{domain}}` input; the
+  template's `{{#if domain}}` block adds a one-sentence framing
+  for the scoped domain. Deterministic fallback unchanged.
+
+### API
+
+- New `GET /api/twin-briefings/lifebook/:domain/latest?cadence=`
+  returns `{ briefing: TwinBriefingRow | null }`. Null when no
+  per-domain briefing exists yet — the common case while the
+  worker hasn't run, the domain is too new, or it had zero events.
+
+### Frontend
+
+- `apps/web/public/js/pages/lifebook.js` fetches the per-domain
+  briefing best-effort and renders it as a card. When no briefing
+  exists yet, a friendly empty state explains when one will
+  appear. Best-effort fetch — the rest of the page renders even
+  if the briefing endpoint is unavailable.
+
+### Test plan
+
+3 new vitest cases in `briefing-generator.test.ts`:
+- Per-Lifebook briefing written per visible lifebook with matching events.
+- Lifebook with no matching events skipped (no empty rows).
+- Per-lifebook failure doesn't take out the other lifebooks (resilience).
+
+worker 86/86 (+3 new), api 547/547, db 189/189. Workspace: 70/70
+turbo tasks green; build clean.
+
 ## [unreleased] — Provenance graph: filter by Lifebook wing (#193 follow-up)
 
 Closes the **"provenance graph wing-filter consumer"** item that
@@ -266,7 +335,6 @@ What this doesn't ship (deliberate, deferred to follow-ups):
   on signals written after this lands. A backfill migration is cheap to
   write (re-read the Gmail label + From header for stored signal rows)
   but is a separate concern from the live ingest path.
-
 
 ## [unreleased] — Embedded LLM downloader: round-3 review fixes (#187 AC#2 follow-up)
 

--- a/apps/api/src/__tests__/briefing-routes.test.ts
+++ b/apps/api/src/__tests__/briefing-routes.test.ts
@@ -15,7 +15,9 @@ const { mockBriefingRepository } = vi.hoisted(() => ({
   mockBriefingRepository: {
     create: vi.fn(),
     getLatestForUser: vi.fn(),
+    getLatestForUserDomain: vi.fn(),
     listForUser: vi.fn(),
+    listForUserDomain: vi.fn(),
     markRead: vi.fn(),
   },
 }));
@@ -185,6 +187,104 @@ describe('POST /api/twin-briefings/:id/read', () => {
 
   it('returns 400 for a non-UUID id path param', async () => {
     const { status } = await req(buildApp(), 'POST', '/api/twin-briefings/not-a-uuid/read');
+    expect(status).toBe(400);
+  });
+});
+
+// ── #193 follow-up: GET /api/twin-briefings/lifebook/:domain/latest ─────
+
+describe('GET /api/twin-briefings/lifebook/:domain/latest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the per-Lifebook briefing when one exists', async () => {
+    const row = { ...BRIEFING_ROW, domain_name: 'Health' };
+    mockBriefingRepository.getLatestForUserDomain.mockResolvedValue(row);
+
+    const { status, body } = await req(
+      buildApp(),
+      'GET',
+      '/api/twin-briefings/lifebook/Health/latest',
+    );
+
+    expect(status).toBe(200);
+    expect((body as { briefing: { domain_name: string } }).briefing.domain_name).toBe('Health');
+    expect(mockBriefingRepository.getLatestForUserDomain).toHaveBeenCalledWith(
+      USER_ID,
+      'Health',
+      undefined,
+    );
+  });
+
+  it('returns { briefing: null } when no per-Lifebook briefing exists yet', async () => {
+    mockBriefingRepository.getLatestForUserDomain.mockResolvedValue(null);
+
+    const { status, body } = await req(
+      buildApp(),
+      'GET',
+      '/api/twin-briefings/lifebook/EmptyDomain/latest',
+    );
+
+    expect(status).toBe(200);
+    expect(body).toEqual({ briefing: null });
+  });
+
+  it('forwards the cadence query param to the repository', async () => {
+    mockBriefingRepository.getLatestForUserDomain.mockResolvedValue({
+      ...BRIEFING_ROW,
+      domain_name: 'Money',
+      cadence: 'weekly',
+    });
+
+    await req(
+      buildApp(),
+      'GET',
+      '/api/twin-briefings/lifebook/Money/latest?cadence=weekly',
+    );
+
+    expect(mockBriefingRepository.getLatestForUserDomain).toHaveBeenCalledWith(
+      USER_ID,
+      'Money',
+      'weekly',
+    );
+  });
+
+  it('ignores an unknown cadence value (passes undefined to the repo)', async () => {
+    mockBriefingRepository.getLatestForUserDomain.mockResolvedValue(null);
+
+    await req(
+      buildApp(),
+      'GET',
+      '/api/twin-briefings/lifebook/Money/latest?cadence=bogus',
+    );
+
+    expect(mockBriefingRepository.getLatestForUserDomain).toHaveBeenCalledWith(
+      USER_ID,
+      'Money',
+      undefined,
+    );
+  });
+
+  it('returns 403 when the briefing belongs to another user', async () => {
+    mockBriefingRepository.getLatestForUserDomain.mockResolvedValue({
+      ...BRIEFING_ROW,
+      domain_name: 'Health',
+      user_id: 'someone-else',
+    });
+
+    const { status } = await req(
+      buildApp(),
+      'GET',
+      '/api/twin-briefings/lifebook/Health/latest',
+    );
+
+    expect(status).toBe(403);
+  });
+
+  it('returns 400 when no userId is present (session missing + no query)', async () => {
+    const appNoUser = buildApp(null);
+    const { status } = await req(appNoUser, 'GET', '/api/twin-briefings/lifebook/Health/latest');
     expect(status).toBe(400);
   });
 });

--- a/apps/api/src/routes/twin-briefings.ts
+++ b/apps/api/src/routes/twin-briefings.ts
@@ -62,6 +62,51 @@ export function createTwinBriefingsRouter(): Router {
   });
 
   // ─────────────────────────────────────────────────────────────────────────
+  // GET /lifebook/:domain/latest?cadence=daily|weekly
+  // #193 follow-up: return the most recent briefing scoped to a Lifebook
+  // domain. NULL when none exists yet (the worker hasn't emitted one,
+  // the domain is too new, or the domain had zero events in the window).
+  // The lifebook page renders the prose when present and a friendly
+  // "no briefing yet" affordance when not.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.get('/lifebook/:domain/latest', async (req, res, next) => {
+    try {
+      const userId = getUserId(req);
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+      const { domain } = req.params;
+      if (!domain || domain.length === 0) {
+        res.status(400).json({ error: 'domain is required' });
+        return;
+      }
+
+      const rawCadence = req.query['cadence'];
+      const cadence = rawCadence === 'daily' || rawCadence === 'weekly'
+        ? rawCadence
+        : undefined;
+
+      const briefing = await briefingRepository.getLatestForUserDomain(
+        userId,
+        domain,
+        cadence,
+      );
+      if (!briefing) {
+        res.json({ briefing: null });
+        return;
+      }
+      if (briefing.user_id !== userId) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+      }
+      res.json({ briefing });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
   // GET /?cadence=&limit=
   // List briefings for the user, newest-first.
   // ─────────────────────────────────────────────────────────────────────────

--- a/apps/web/public/js/api-client.js
+++ b/apps/web/public/js/api-client.js
@@ -866,6 +866,20 @@ export function unhideLifebook(userId, domainName) {
   );
 }
 
+/**
+ * #193 follow-up: fetch the latest per-Lifebook briefing for one
+ * domain. Returns `{ briefing: TwinBriefingRow | null }` — null when
+ * no per-domain briefing exists yet (the worker hasn't emitted one,
+ * the domain is too new, or the domain had no events in the window).
+ */
+export function fetchLifebookBriefing(userId, domainName, cadence) {
+  const qs = new URLSearchParams({ userId });
+  if (cadence === 'daily' || cadence === 'weekly') qs.set('cadence', cadence);
+  return fetchJSON(
+    `${API}/twin-briefings/lifebook/${encodeURIComponent(domainName)}/latest?${qs}`,
+  );
+}
+
 // ── Federation (#194 Child 1) ─────────────────────────────────────────────────
 
 export function startFederationPairing(userId) {

--- a/apps/web/public/js/pages/lifebook.js
+++ b/apps/web/public/js/pages/lifebook.js
@@ -1,4 +1,4 @@
-import { fetchLifebook, hideLifebook, escapeHtml } from '../api-client.js';
+import { fetchLifebook, fetchLifebookBriefing, hideLifebook, escapeHtml } from '../api-client.js';
 import { showSavedToast, showErrorToast } from '../toast.js';
 import { KEY_USER_ID } from '../storage-keys.js';
 
@@ -73,6 +73,19 @@ export async function renderLifebook(container, _userIdFromArg) {
     return;
   }
 
+  // #193 follow-up: best-effort fetch of the per-Lifebook briefing.
+  // No briefing yet is the common case (the worker only emits one per
+  // domain that has events in the window); we render a friendly empty
+  // state rather than treating it as an error.
+  let briefing = null;
+  try {
+    const briefingData = await fetchLifebookBriefing(userId, domainName);
+    briefing = briefingData?.briefing ?? null;
+  } catch {
+    // Swallow — the rest of the page should render even when the
+    // briefing endpoint is unavailable.
+  }
+
   const signals = Array.isArray(lb.sampleSignals) ? lb.sampleSignals : [];
   const caps = Array.isArray(lb.suggestedCapabilities) ? lb.suggestedCapabilities : [];
 
@@ -89,6 +102,8 @@ export async function renderLifebook(container, _userIdFromArg) {
         Detected ${lb.detectedAt ? formatDate(lb.detectedAt) : 'recently'} · last seen ${lb.lastSeenAt ? formatDate(lb.lastSeenAt) : 'recently'}
       </div>
     </div>
+
+    ${renderLifebookBriefingCard(briefing, lb.domainName)}
 
     ${wing ? `
     <div class="card">
@@ -117,6 +132,45 @@ export async function renderLifebook(container, _userIdFromArg) {
       <a href="#/capabilities" class="btn btn-outline btn-sm" style="margin-top:0.75rem;">Browse capabilities</a>
     </div>
     ` : ''}
+  `;
+}
+
+/**
+ * #193 follow-up: render the per-Lifebook briefing card. Three states:
+ *   1. briefing exists: show the prose + the generation timestamp.
+ *   2. no briefing yet: friendly empty state explaining when one
+ *      shows up (weekly worker run after at least one event in the
+ *      domain's window).
+ *   3. briefing was returned but has empty prose: defensive — render
+ *      the empty state, same as case 2.
+ *
+ * The prose is server-side Markdown but the dashboard doesn't bundle
+ * a Markdown renderer; we render the raw text inside a <pre>-style
+ * block that preserves line breaks. A future enhancement could wire
+ * up a Markdown renderer for the whole twin-briefings surface.
+ */
+function renderLifebookBriefingCard(briefing, domainName) {
+  if (briefing && typeof briefing.prose_markdown === 'string' && briefing.prose_markdown.trim().length > 0) {
+    const when = briefing.generated_at ? formatDate(briefing.generated_at) : 'recently';
+    const cadenceLabel = briefing.cadence === 'weekly' ? 'Weekly' : 'Daily';
+    return `
+      <div class="card">
+        <div class="card-header" style="display:flex;align-items:center;justify-content:space-between;gap:0.75rem;">
+          <span class="card-title">${escapeHtml(cadenceLabel)} briefing — ${escapeHtml(domainName)}</span>
+          <span class="card-subtitle" style="margin:0;font-size:0.75rem;">Generated ${escapeHtml(when)}</span>
+        </div>
+        <div style="margin-top:0.75rem;white-space:pre-wrap;line-height:1.55;font-size:0.9rem;color:var(--text);">${escapeHtml(briefing.prose_markdown)}</div>
+      </div>
+    `;
+  }
+  return `
+    <div class="card">
+      <div class="card-header"><span class="card-title">${escapeHtml(domainName)} briefing</span></div>
+      <div class="card-subtitle">
+        Your twin will write a per-${escapeHtml(domainName)} briefing on the next briefing run if
+        there's been activity in this Lifebook. Until then you'll see the global briefing on the dashboard.
+      </div>
+    </div>
   `;
 }
 

--- a/apps/worker/src/__tests__/briefing-generator.test.ts
+++ b/apps/worker/src/__tests__/briefing-generator.test.ts
@@ -9,11 +9,13 @@ const {
   mockBriefingRepository,
   mockAppSuggestionRepository,
   mockMcpServerRepository,
+  mockLifebookRepository,
   mockQuery,
 } = vi.hoisted(() => ({
   mockBriefingRepository: {
     create: vi.fn(),
     getLatestForUser: vi.fn(),
+    getLatestForUserDomain: vi.fn(),
     listForUser: vi.fn(),
     markRead: vi.fn(),
   },
@@ -39,6 +41,13 @@ const {
     markAllResumedForUser: vi.fn(),
     updateLastActive: vi.fn(),
   },
+  mockLifebookRepository: {
+    listVisible: vi.fn(),
+    upsert: vi.fn(),
+    getByUserAndDomain: vi.fn(),
+    hide: vi.fn(),
+    unhide: vi.fn(),
+  },
   mockQuery: vi.fn(),
 }));
 
@@ -46,6 +55,7 @@ vi.mock('@skytwin/db', () => ({
   briefingRepository: mockBriefingRepository,
   appSuggestionRepository: mockAppSuggestionRepository,
   mcpServerRepository: mockMcpServerRepository,
+  lifebookRepository: mockLifebookRepository,
   query: mockQuery,
 }));
 
@@ -95,6 +105,9 @@ describe('runBriefingGeneratorJob', () => {
     vi.clearAllMocks();
     // Default: no provenance nodes for promotions
     mockQuery.mockResolvedValue({ rows: [] });
+    // Default: user has no lifebooks (no per-domain briefings written).
+    // Tests that exercise the per-domain path override this.
+    mockLifebookRepository.listVisible.mockResolvedValue([]);
   });
 
   it('generates a daily briefing for an active user with an installed server', async () => {
@@ -177,5 +190,188 @@ describe('runBriefingGeneratorJob', () => {
 
     expect(mockBriefingRepository.create).not.toHaveBeenCalled();
     expect(mockMcpServerRepository.listForUser).not.toHaveBeenCalled();
+  });
+
+  // ── #193 follow-up: per-Lifebook briefings ───────────────────────────────
+
+  it('emits a per-Lifebook briefing for each visible lifebook with matching events', async () => {
+    const healthServer = makeServer({
+      id: 'srv-health',
+      user_id: 'user-poly',
+      registry_id: 'fitbit-mcp',
+      display_name: 'Fitbit',
+    });
+    const moneyServer = makeServer({
+      id: 'srv-money',
+      user_id: 'user-poly',
+      registry_id: 'mint-mcp',
+      display_name: 'Mint',
+    });
+    mockMcpServerRepository.listForUser.mockResolvedValue([healthServer, moneyServer]);
+    mockAppSuggestionRepository.getPendingForUser.mockResolvedValue([]);
+    mockLifebookRepository.listVisible.mockResolvedValue([
+      {
+        id: 'lb-health',
+        user_id: 'user-poly',
+        domain_name: 'Health',
+        importance: 'core',
+        sample_signals: [],
+        suggested_capabilities: ['fitbit-mcp'],
+        wing_id: 'wing-h',
+        detected_at: new Date(),
+        last_seen_at: new Date(),
+        hidden_at: null,
+      },
+      {
+        id: 'lb-money',
+        user_id: 'user-poly',
+        domain_name: 'Money',
+        importance: 'core',
+        sample_signals: [],
+        suggested_capabilities: ['mint-mcp'],
+        wing_id: 'wing-m',
+        detected_at: new Date(),
+        last_seen_at: new Date(),
+        hidden_at: null,
+      },
+    ]);
+    mockBriefingRepository.create.mockImplementation(async (input) => ({
+      id: 'briefing-x',
+      user_id: input.userId,
+      cadence: input.cadence,
+      generated_at: new Date(),
+      prose_markdown: input.proseMarkdown,
+      source_event_count: input.sourceEventCount,
+      llm_provider: input.llmProvider ?? null,
+      llm_cost_cents: input.llmCostCents ?? null,
+      read_at: null,
+      domain_name: input.domainName ?? null,
+    }));
+
+    await runBriefingGeneratorJob({ cadence: 'daily', userIds: ['user-poly'] });
+
+    // 1 global + 2 per-Lifebook = 3 create calls.
+    expect(mockBriefingRepository.create).toHaveBeenCalledTimes(3);
+    const calls = mockBriefingRepository.create.mock.calls.map((c) => c[0]);
+    const globalCall = calls.find((c) => c.domainName === undefined);
+    const healthCall = calls.find((c) => c.domainName === 'Health');
+    const moneyCall = calls.find((c) => c.domainName === 'Money');
+    expect(globalCall).toBeDefined();
+    expect(healthCall).toBeDefined();
+    expect(moneyCall).toBeDefined();
+    // Each per-Lifebook briefing should mention the scoped capability name.
+    expect(healthCall!.proseMarkdown).toContain('Fitbit');
+    expect(moneyCall!.proseMarkdown).toContain('Mint');
+  });
+
+  it('skips per-Lifebook emission when the lifebook has no events in the window', async () => {
+    // User has one active server (Linear) but a Health lifebook whose
+    // suggested_capabilities don't include it. The filter should
+    // collapse to zero events → no per-domain briefing written.
+    const server = makeServer({ user_id: 'user-empty-lb' });
+    mockMcpServerRepository.listForUser.mockResolvedValue([server]);
+    mockAppSuggestionRepository.getPendingForUser.mockResolvedValue([]);
+    mockLifebookRepository.listVisible.mockResolvedValue([
+      {
+        id: 'lb-health',
+        user_id: 'user-empty-lb',
+        domain_name: 'Health',
+        importance: 'core',
+        sample_signals: [],
+        suggested_capabilities: ['unrelated-mcp'],
+        wing_id: 'wing-h',
+        detected_at: new Date(),
+        last_seen_at: new Date(),
+        hidden_at: null,
+      },
+    ]);
+    mockBriefingRepository.create.mockImplementation(async (input) => ({
+      id: 'briefing-y',
+      user_id: input.userId,
+      cadence: input.cadence,
+      generated_at: new Date(),
+      prose_markdown: input.proseMarkdown,
+      source_event_count: input.sourceEventCount,
+      llm_provider: null,
+      llm_cost_cents: null,
+      read_at: null,
+      domain_name: input.domainName ?? null,
+    }));
+
+    await runBriefingGeneratorJob({ cadence: 'daily', userIds: ['user-empty-lb'] });
+
+    // Only the global briefing is written — Health gets skipped.
+    expect(mockBriefingRepository.create).toHaveBeenCalledTimes(1);
+    const onlyCall = mockBriefingRepository.create.mock.calls[0]?.[0];
+    expect(onlyCall.domainName).toBeUndefined();
+  });
+
+  it('continues writing other per-Lifebook briefings when one lifebook throws', async () => {
+    const healthServer = makeServer({
+      id: 'srv-h',
+      user_id: 'user-resilient',
+      registry_id: 'fitbit-mcp',
+    });
+    const moneyServer = makeServer({
+      id: 'srv-m',
+      user_id: 'user-resilient',
+      registry_id: 'mint-mcp',
+    });
+    mockMcpServerRepository.listForUser.mockResolvedValue([healthServer, moneyServer]);
+    mockAppSuggestionRepository.getPendingForUser.mockResolvedValue([]);
+    mockLifebookRepository.listVisible.mockResolvedValue([
+      {
+        id: 'lb-health',
+        user_id: 'user-resilient',
+        domain_name: 'Health',
+        importance: 'core',
+        sample_signals: [],
+        suggested_capabilities: ['fitbit-mcp'],
+        wing_id: 'wing-h',
+        detected_at: new Date(),
+        last_seen_at: new Date(),
+        hidden_at: null,
+      },
+      {
+        id: 'lb-money',
+        user_id: 'user-resilient',
+        domain_name: 'Money',
+        importance: 'core',
+        sample_signals: [],
+        suggested_capabilities: ['mint-mcp'],
+        wing_id: 'wing-m',
+        detected_at: new Date(),
+        last_seen_at: new Date(),
+        hidden_at: null,
+      },
+    ]);
+    // First per-domain create (Health) throws; the rest must still go through.
+    let createCallIdx = 0;
+    mockBriefingRepository.create.mockImplementation(async (input) => {
+      createCallIdx++;
+      if (createCallIdx === 2) {
+        throw new Error('simulated Health write failure');
+      }
+      return {
+        id: `briefing-${createCallIdx}`,
+        user_id: input.userId,
+        cadence: input.cadence,
+        generated_at: new Date(),
+        prose_markdown: input.proseMarkdown,
+        source_event_count: input.sourceEventCount,
+        llm_provider: null,
+        llm_cost_cents: null,
+        read_at: null,
+        domain_name: input.domainName ?? null,
+      };
+    });
+
+    await runBriefingGeneratorJob({ cadence: 'daily', userIds: ['user-resilient'] });
+
+    // Global + Health (threw) + Money = 3 attempts; one threw but the
+    // job didn't abort, so Money still landed.
+    expect(mockBriefingRepository.create).toHaveBeenCalledTimes(3);
+    const written = mockBriefingRepository.create.mock.calls.map((c) => c[0].domainName);
+    expect(written).toContain('Money');
   });
 });

--- a/apps/worker/src/jobs/briefing-generator.ts
+++ b/apps/worker/src/jobs/briefing-generator.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@skytwin/core';
-import { briefingRepository, appSuggestionRepository, mcpServerRepository, query } from '@skytwin/db';
+import { briefingRepository, appSuggestionRepository, lifebookRepository, mcpServerRepository, query } from '@skytwin/db';
 import { runPrompt } from '@skytwin/policy-prompts';
 import type { LlmClient } from '@skytwin/llm-client';
 
@@ -193,16 +193,60 @@ function buildTemplatedProse(
 }
 
 /**
+ * #193 follow-up: filter a gathered-briefing-data bundle down to only
+ * the items relevant to one Lifebook's domain. Membership is decided
+ * by `mcpServer.registry_id ∈ lifebook.suggested_capabilities` — the
+ * same registry-id set the domain extractor proposed for the wing.
+ * Suggestions, active/dormant/recentlyInstalled, and tier-promotions
+ * (whose `payload.registryId` matches) all flow through the same set.
+ *
+ * Returns a structurally identical bundle so the downstream prose
+ * generator doesn't need to know whether it's looking at the global
+ * feed or a scoped one.
+ */
+function filterDataByLifebook(
+  data: Awaited<ReturnType<typeof gatherBriefingData>>,
+  registryIds: ReadonlySet<string>,
+): typeof data {
+  if (registryIds.size === 0) {
+    // Empty allow-list = "the domain extractor proposed nothing yet";
+    // pass through unchanged rather than emit an empty briefing.
+    return data;
+  }
+  const inSet = (registryId: string | null | undefined): boolean =>
+    typeof registryId === 'string' && registryIds.has(registryId);
+  const filteredPromotions = data.promotionResult.rows.filter((r) => {
+    const p = r.payload as Record<string, unknown> | null;
+    return inSet(typeof p?.['registryId'] === 'string' ? (p['registryId'] as string) : null);
+  });
+  return {
+    suggestions: data.suggestions.filter((s) => inSet(s.registry_id)),
+    active: data.active.filter((s) => inSet(s.registry_id)),
+    dormant: data.dormant.filter((s) => inSet(s.registry_id)),
+    recentlyInstalled: data.recentlyInstalled.filter((s) => inSet(s.registry_id)),
+    promotionResult: { ...data.promotionResult, rows: filteredPromotions },
+    since: data.since,
+  };
+}
+
+/**
  * Generate a briefing for a single user.
  * Tries the adaptive briefing-prose prompt first; falls back to the
  * deterministic Markdown template.
+ *
+ * When `scope` is provided, the gathered data is pre-filtered to that
+ * Lifebook's registry-id set and the prompt receives the domain name
+ * so the prose stays scoped. Otherwise this generates a global
+ * briefing (the historical semantic — untouched).
  */
 async function generateBriefingProse(
   userId: string,
   cadence: 'daily' | 'weekly',
   llmClient?: LlmClient,
+  scope?: { domainName: string; registryIds: ReadonlySet<string> },
 ): Promise<{ prose: string; sourceEventCount: number; llmProvider?: string }> {
-  const data = await gatherBriefingData(userId, cadence);
+  const rawData = await gatherBriefingData(userId, cadence);
+  const data = scope ? filterDataByLifebook(rawData, scope.registryIds) : rawData;
 
   const sourceEventCount =
     data.suggestions.length +
@@ -249,6 +293,8 @@ async function generateBriefingProse(
       }));
 
       // Output type matches the prompt's documented schema: { briefing: string }.
+      // `domain` is set only for per-Lifebook briefings — the template's
+      // `{{#if domain}}` block scopes the prose accordingly.
       const result = await runPrompt<{ briefing: string; highlight_count?: number }>({
         promptName: 'briefing-prose',
         inputs: {
@@ -257,6 +303,7 @@ async function generateBriefingProse(
           language: 'en',
           pending_tasks: pendingTasks,
           risk_profile: '',
+          domain: scope?.domainName ?? '',
         },
         user: { userId },
         llmClient,
@@ -302,6 +349,7 @@ export async function runBriefingGeneratorJob(
 
   log.info(`Briefing generator: generating for ${userIds.length} user(s)`);
   let generated = 0;
+  let perDomainGenerated = 0;
   let failed = 0;
 
   for (const userId of userIds) {
@@ -320,6 +368,13 @@ export async function runBriefingGeneratorJob(
         llmCostCents: undefined,
       });
       generated++;
+
+      // #193 follow-up: emit per-Lifebook briefings for each visible
+      // domain that has at least one event in the window. Skip empty
+      // domains so we don't fill the table with "nothing happened in
+      // Health" rows. Failures on one domain don't fail the whole
+      // user — each lifebook gets its own try/catch.
+      perDomainGenerated += await emitPerDomainBriefings(userId, cadence, llmClient);
     } catch (err) {
       failed++;
       log.warn('Failed to generate briefing for user', {
@@ -328,5 +383,79 @@ export async function runBriefingGeneratorJob(
     }
   }
 
-  log.info(`Briefing generator complete: ${generated} generated, ${failed} failed`);
+  log.info(
+    `Briefing generator complete: ${generated} global, ${perDomainGenerated} per-Lifebook, ${failed} failed`,
+  );
+}
+
+/**
+ * #193 follow-up: produce per-Lifebook briefings for every visible
+ * lifebook with at least one source event in the window. Returns the
+ * count of briefings actually written so the orchestrator can log it.
+ *
+ * Failures on individual lifebooks are logged and skipped — one
+ * domain's prompt blowing up should never take out another domain's
+ * briefing. The global briefing has already been written by the
+ * caller when this runs, so the worst case is "fewer per-Lifebook
+ * rows than expected," not "the user lost their daily summary."
+ */
+async function emitPerDomainBriefings(
+  userId: string,
+  cadence: 'daily' | 'weekly',
+  llmClient?: LlmClient,
+): Promise<number> {
+  let lifebooks: Awaited<ReturnType<typeof lifebookRepository.listVisible>>;
+  try {
+    lifebooks = await lifebookRepository.listVisible(userId);
+  } catch (err) {
+    log.warn('Could not load lifebooks for per-domain briefings; skipping', {
+      userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return 0;
+  }
+  if (lifebooks.length === 0) return 0;
+
+  let written = 0;
+  for (const lb of lifebooks) {
+    try {
+      const registryIds = new Set(
+        Array.isArray(lb.suggested_capabilities) ? lb.suggested_capabilities : [],
+      );
+      // Empty allow-list = the extractor hasn't proposed any
+      // capabilities for this domain yet. Skip rather than fall back
+      // to the global feed under a domain label.
+      if (registryIds.size === 0) continue;
+
+      const { prose, sourceEventCount, llmProvider } = await generateBriefingProse(
+        userId,
+        cadence,
+        llmClient,
+        { domainName: lb.domain_name, registryIds },
+      );
+
+      // Skip empty domains — "nothing happened in Health this week"
+      // is noise, not a useful briefing. The user will see the
+      // global briefing or no briefing.
+      if (sourceEventCount === 0) continue;
+
+      await briefingRepository.create({
+        userId,
+        cadence,
+        proseMarkdown: prose,
+        sourceEventCount,
+        llmProvider,
+        llmCostCents: undefined,
+        domainName: lb.domain_name,
+      });
+      written++;
+    } catch (err) {
+      log.warn('Per-domain briefing failed for one lifebook; continuing', {
+        userId,
+        domain: lb.domain_name,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return written;
 }

--- a/apps/worker/src/jobs/briefing-generator.ts
+++ b/apps/worker/src/jobs/briefing-generator.ts
@@ -96,15 +96,26 @@ async function gatherBriefingData(userId: string, cadence: 'daily' | 'weekly') {
   const since = new Date(Date.now() - lookbackMs);
   const recentlyInstalled = active.filter((s) => s.installed_at && s.installed_at > since);
 
-  const promotionResult = await query<{ payload: unknown; occurred_at: Date }>(
-    `SELECT payload, occurred_at
+  const promotionResult = await query<{ payload: unknown; occurred_at: Date; server_id: string | null }>(
+    `SELECT payload, occurred_at, server_id
      FROM capability_provenance_nodes
      WHERE user_id = $1 AND node_type = 'tier_promotion' AND occurred_at > $2
      ORDER BY occurred_at DESC`,
     [userId, since],
   );
 
-  return { suggestions, active, dormant, recentlyInstalled, promotionResult, since };
+  // Pre-compute server_id → registry_id so filterDataByLifebook can
+  // map tier-promotion rows (which carry server_id but not registry_id
+  // in the payload) to their owning lifebook. Copilot round-2 on #258
+  // flagged that the previous filter checked payload.registryId, which
+  // tier_promotion never sets — so promotions were always dropped from
+  // per-Lifebook briefings.
+  const serverIdToRegistry = new Map<string, string>();
+  for (const s of allServers) {
+    if (s.registry_id) serverIdToRegistry.set(s.id, s.registry_id);
+  }
+
+  return { suggestions, active, dormant, recentlyInstalled, promotionResult, serverIdToRegistry, since };
 }
 
 /**
@@ -209,15 +220,31 @@ function filterDataByLifebook(
   registryIds: ReadonlySet<string>,
 ): typeof data {
   if (registryIds.size === 0) {
-    // Empty allow-list = "the domain extractor proposed nothing yet";
-    // pass through unchanged rather than emit an empty briefing.
-    return data;
+    // Empty allow-list = "the domain extractor proposed nothing yet."
+    // Return an EMPTY bundle so sourceEventCount is 0 and the caller
+    // skips the write — previously this returned the unfiltered global
+    // bundle, which Copilot round-2 on #258 flagged as a footgun: a
+    // global briefing could end up labeled with the lifebook's domain.
+    return {
+      suggestions: [],
+      active: [],
+      dormant: [],
+      recentlyInstalled: [],
+      promotionResult: { ...data.promotionResult, rows: [] },
+      serverIdToRegistry: data.serverIdToRegistry,
+      since: data.since,
+    };
   }
   const inSet = (registryId: string | null | undefined): boolean =>
     typeof registryId === 'string' && registryIds.has(registryId);
+  // tier_promotion provenance rows don't carry registryId in their
+  // payload (they're { from, to, reason }); instead they reference an
+  // mcp_servers row via server_id. Map server_id → registry_id and
+  // check membership against the lifebook's allowlist that way.
   const filteredPromotions = data.promotionResult.rows.filter((r) => {
-    const p = r.payload as Record<string, unknown> | null;
-    return inSet(typeof p?.['registryId'] === 'string' ? (p['registryId'] as string) : null);
+    if (!r.server_id) return false;
+    const registryId = data.serverIdToRegistry.get(r.server_id);
+    return inSet(registryId);
   });
   return {
     suggestions: data.suggestions.filter((s) => inSet(s.registry_id)),
@@ -225,6 +252,7 @@ function filterDataByLifebook(
     dormant: data.dormant.filter((s) => inSet(s.registry_id)),
     recentlyInstalled: data.recentlyInstalled.filter((s) => inSet(s.registry_id)),
     promotionResult: { ...data.promotionResult, rows: filteredPromotions },
+    serverIdToRegistry: data.serverIdToRegistry,
     since: data.since,
   };
 }
@@ -238,14 +266,23 @@ function filterDataByLifebook(
  * Lifebook's registry-id set and the prompt receives the domain name
  * so the prose stays scoped. Otherwise this generates a global
  * briefing (the historical semantic — untouched).
+ *
+ * Callers that emit multiple briefings for the same user (global +
+ * per-Lifebook) should pre-gather the data ONCE via
+ * `gatherBriefingData()` and pass it in as `preGathered` — this
+ * avoids the N+1 query pattern Copilot round-2 on #258 flagged
+ * (suggestion-repo + server-repo + promotion-query call per
+ * lifebook). When `preGathered` is omitted the function does its own
+ * gather for the single-briefing case.
  */
 async function generateBriefingProse(
   userId: string,
   cadence: 'daily' | 'weekly',
   llmClient?: LlmClient,
   scope?: { domainName: string; registryIds: ReadonlySet<string> },
+  preGathered?: Awaited<ReturnType<typeof gatherBriefingData>>,
 ): Promise<{ prose: string; sourceEventCount: number; llmProvider?: string }> {
-  const rawData = await gatherBriefingData(userId, cadence);
+  const rawData = preGathered ?? await gatherBriefingData(userId, cadence);
   const data = scope ? filterDataByLifebook(rawData, scope.registryIds) : rawData;
 
   const sourceEventCount =
@@ -354,10 +391,19 @@ export async function runBriefingGeneratorJob(
 
   for (const userId of userIds) {
     try {
+      // Gather once per user; share the bundle across global +
+      // per-Lifebook briefings. Copilot round-2 on #258 flagged the
+      // prior N+1 pattern (every per-Lifebook call hit
+      // suggestion-repo, server-repo, and the promotion query
+      // independently).
+      const sharedData = await gatherBriefingData(userId, cadence);
+
       const { prose, sourceEventCount, llmProvider } = await generateBriefingProse(
         userId,
         cadence,
         llmClient,
+        undefined,
+        sharedData,
       );
       await briefingRepository.create({
         userId,
@@ -374,7 +420,12 @@ export async function runBriefingGeneratorJob(
       // domains so we don't fill the table with "nothing happened in
       // Health" rows. Failures on one domain don't fail the whole
       // user — each lifebook gets its own try/catch.
-      perDomainGenerated += await emitPerDomainBriefings(userId, cadence, llmClient);
+      perDomainGenerated += await emitPerDomainBriefings(
+        userId,
+        cadence,
+        llmClient,
+        sharedData,
+      );
     } catch (err) {
       failed++;
       log.warn('Failed to generate briefing for user', {
@@ -402,7 +453,8 @@ export async function runBriefingGeneratorJob(
 async function emitPerDomainBriefings(
   userId: string,
   cadence: 'daily' | 'weekly',
-  llmClient?: LlmClient,
+  llmClient: LlmClient | undefined,
+  sharedData: Awaited<ReturnType<typeof gatherBriefingData>>,
 ): Promise<number> {
   let lifebooks: Awaited<ReturnType<typeof lifebookRepository.listVisible>>;
   try {
@@ -432,6 +484,7 @@ async function emitPerDomainBriefings(
         cadence,
         llmClient,
         { domainName: lb.domain_name, registryIds },
+        sharedData,
       );
 
       // Skip empty domains — "nothing happened in Health this week"

--- a/packages/db/src/migrations/042-briefing-domain.sql
+++ b/packages/db/src/migrations/042-briefing-domain.sql
@@ -1,0 +1,36 @@
+-- 042-briefing-domain.sql
+-- #193 follow-up: per-Lifebook briefings.
+--
+-- Today every twin_briefings row is a *global* briefing summarizing
+-- the user's whole capability surface. The Emergent Lifebooks epic
+-- (#193 Child 1) wants a per-domain variant: a briefing scoped to one
+-- detected life domain, rendered on the Lifebook page so the user can
+-- see what their twin has been up to within Health, Money, etc.
+--
+-- Schema-wise: a nullable `domain_name` column on the existing table.
+-- NULL means "global briefing" (the existing semantic, untouched). A
+-- string value means "per-Lifebook briefing scoped to that domain
+-- name" — matching the canonical name used elsewhere
+-- (lifebooks.domain_name).
+--
+-- We deliberately don't FK to lifebooks(domain_name) because:
+--   1. (user_id, domain_name) on lifebooks is UNIQUE, but the
+--      lifebooks row may be soft-hidden (hidden_at NOT NULL) — the
+--      briefing should survive the hide so the user's history is
+--      preserved.
+--   2. If the domain extractor renames a domain in a future run, the
+--      briefing's domain_name becomes orphaned but still readable as
+--      a historical artifact.
+-- Both behaviors are intentional. Use the index below to fetch
+-- per-domain briefings efficiently.
+
+ALTER TABLE twin_briefings
+  ADD COLUMN IF NOT EXISTS domain_name STRING;
+
+-- Partial index keyed on (user_id, domain_name, generated_at DESC).
+-- Only domain-scoped rows participate; global briefings (domain_name
+-- IS NULL) stay served by the existing (user_id, generated_at)
+-- ordering. Partial index keeps storage and write overhead minimal.
+CREATE INDEX IF NOT EXISTS twin_briefings_user_domain_idx
+  ON twin_briefings (user_id, domain_name, generated_at DESC)
+  WHERE domain_name IS NOT NULL;

--- a/packages/db/src/repositories/briefing-repository.ts
+++ b/packages/db/src/repositories/briefing-repository.ts
@@ -10,6 +10,12 @@ export interface TwinBriefingRow {
   llm_provider: string | null;
   llm_cost_cents: number | null;
   read_at: Date | null;
+  /**
+   * #193 follow-up: when set, this is a per-Lifebook briefing scoped to
+   * that domain (matching `lifebooks.domain_name`). NULL means the
+   * historical global-briefing semantic, untouched.
+   */
+  domain_name: string | null;
 }
 
 export interface CreateTwinBriefingInput {
@@ -19,6 +25,8 @@ export interface CreateTwinBriefingInput {
   sourceEventCount: number;
   llmProvider?: string;
   llmCostCents?: number;
+  /** #193 follow-up: omit for global briefings; set for per-Lifebook ones. */
+  domainName?: string;
 }
 
 /**
@@ -34,8 +42,8 @@ export const briefingRepository = {
   async create(input: CreateTwinBriefingInput): Promise<TwinBriefingRow> {
     const result = await query<TwinBriefingRow>(
       `INSERT INTO twin_briefings
-         (user_id, cadence, prose_markdown, source_event_count, llm_provider, llm_cost_cents)
-       VALUES ($1, $2, $3, $4, $5, $6)
+         (user_id, cadence, prose_markdown, source_event_count, llm_provider, llm_cost_cents, domain_name)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
        RETURNING *`,
       [
         input.userId,
@@ -44,6 +52,7 @@ export const briefingRepository = {
         input.sourceEventCount,
         input.llmProvider ?? null,
         input.llmCostCents ?? null,
+        input.domainName ?? null,
       ],
     );
     const row = result.rows[0];
@@ -53,13 +62,16 @@ export const briefingRepository = {
 
   /**
    * Return the most recently generated briefing for a user, optionally
-   * filtered by cadence.
+   * filtered by cadence. Only returns *global* briefings (domain_name
+   * IS NULL) — the per-Lifebook query lives in
+   * `getLatestForUserDomain()` so the existing surface stays bounded
+   * to the historical semantic.
    */
   async getLatestForUser(userId: string, cadence?: 'daily' | 'weekly'): Promise<TwinBriefingRow | null> {
     if (cadence) {
       const result = await query<TwinBriefingRow>(
         `SELECT * FROM twin_briefings
-         WHERE user_id = $1 AND cadence = $2
+         WHERE user_id = $1 AND cadence = $2 AND domain_name IS NULL
          ORDER BY generated_at DESC
          LIMIT 1`,
         [userId, cadence],
@@ -68,10 +80,42 @@ export const briefingRepository = {
     }
     const result = await query<TwinBriefingRow>(
       `SELECT * FROM twin_briefings
-       WHERE user_id = $1
+       WHERE user_id = $1 AND domain_name IS NULL
        ORDER BY generated_at DESC
        LIMIT 1`,
       [userId],
+    );
+    return result.rows[0] ?? null;
+  },
+
+  /**
+   * #193 follow-up: return the most recently generated briefing scoped
+   * to a Lifebook domain. Returns null when no domain-scoped briefing
+   * exists for that user + domain (e.g. the worker hasn't emitted one
+   * yet, or the domain is too new). Per-domain briefings of either
+   * cadence are valid; pass `cadence` to scope further.
+   */
+  async getLatestForUserDomain(
+    userId: string,
+    domainName: string,
+    cadence?: 'daily' | 'weekly',
+  ): Promise<TwinBriefingRow | null> {
+    if (cadence) {
+      const result = await query<TwinBriefingRow>(
+        `SELECT * FROM twin_briefings
+         WHERE user_id = $1 AND domain_name = $2 AND cadence = $3
+         ORDER BY generated_at DESC
+         LIMIT 1`,
+        [userId, domainName, cadence],
+      );
+      return result.rows[0] ?? null;
+    }
+    const result = await query<TwinBriefingRow>(
+      `SELECT * FROM twin_briefings
+       WHERE user_id = $1 AND domain_name = $2
+       ORDER BY generated_at DESC
+       LIMIT 1`,
+      [userId, domainName],
     );
     return result.rows[0] ?? null;
   },

--- a/packages/db/src/repositories/briefing-repository.ts
+++ b/packages/db/src/repositories/briefing-repository.ts
@@ -121,14 +121,28 @@ export const briefingRepository = {
   },
 
   /**
-   * List briefings for a user, ordered newest-first.
+   * List briefings for a user, ordered newest-first. Scoped to GLOBAL
+   * briefings (domain_name IS NULL) by default — the historical
+   * surface this method has always served. Set
+   * `opts.includeDomainScoped: true` to include per-Lifebook rows in
+   * the same list (used by the audit / history surfaces that want
+   * the complete timeline).
+   *
+   * Copilot round-2 on PR #258 flagged that the unscoped query would
+   * silently change `/api/twin-briefings/` history results by
+   * interleaving per-domain rows once migration 042 lands. Default-
+   * to-global preserves the existing contract.
    */
-  async listForUser(userId: string, opts: { cadence?: 'daily' | 'weekly'; limit?: number } = {}): Promise<TwinBriefingRow[]> {
+  async listForUser(
+    userId: string,
+    opts: { cadence?: 'daily' | 'weekly'; limit?: number; includeDomainScoped?: boolean } = {},
+  ): Promise<TwinBriefingRow[]> {
     const limit = opts.limit ?? 20;
+    const scopeClause = opts.includeDomainScoped ? '' : ' AND domain_name IS NULL';
     if (opts.cadence) {
       const result = await query<TwinBriefingRow>(
         `SELECT * FROM twin_briefings
-         WHERE user_id = $1 AND cadence = $2
+         WHERE user_id = $1 AND cadence = $2${scopeClause}
          ORDER BY generated_at DESC
          LIMIT $3`,
         [userId, opts.cadence, limit],
@@ -137,10 +151,42 @@ export const briefingRepository = {
     }
     const result = await query<TwinBriefingRow>(
       `SELECT * FROM twin_briefings
-       WHERE user_id = $1
+       WHERE user_id = $1${scopeClause}
        ORDER BY generated_at DESC
        LIMIT $2`,
       [userId, limit],
+    );
+    return result.rows;
+  },
+
+  /**
+   * #193 follow-up: list per-Lifebook briefings for a domain, newest
+   * first. Mirror of `listForUser` but scoped to one `domain_name`.
+   * Used by the lifebook history surface (future) and any caller that
+   * needs the per-domain timeline.
+   */
+  async listForUserDomain(
+    userId: string,
+    domainName: string,
+    opts: { cadence?: 'daily' | 'weekly'; limit?: number } = {},
+  ): Promise<TwinBriefingRow[]> {
+    const limit = opts.limit ?? 20;
+    if (opts.cadence) {
+      const result = await query<TwinBriefingRow>(
+        `SELECT * FROM twin_briefings
+         WHERE user_id = $1 AND domain_name = $2 AND cadence = $3
+         ORDER BY generated_at DESC
+         LIMIT $4`,
+        [userId, domainName, opts.cadence, limit],
+      );
+      return result.rows;
+    }
+    const result = await query<TwinBriefingRow>(
+      `SELECT * FROM twin_briefings
+       WHERE user_id = $1 AND domain_name = $2
+       ORDER BY generated_at DESC
+       LIMIT $3`,
+      [userId, domainName, limit],
     );
     return result.rows;
   },

--- a/packages/policy-prompts/prompts/briefing-prose/v1.md
+++ b/packages/policy-prompts/prompts/briefing-prose/v1.md
@@ -11,11 +11,20 @@ daily_token_budget_per_user: 40000
 deterministic_fallback: pass-through
 description: |
   Compose a concise daily briefing in Markdown from today's structured
-  events, tasks, and signals.
+  events, tasks, and signals. When `domain` is set, the briefing is
+  scoped to that Lifebook domain rather than the user's global feed.
 ---
 
 # System
 You are a daily briefing writer for a digital twin. Transform the structured event data into a clean, scannable Markdown briefing the user will read at the start of their day. Be concise. Lead with what matters most.
+
+{{#if domain}}
+This is a per-Lifebook briefing scoped to **{{domain}}**. Open with one
+sentence framing the activity in that life domain. Only include events,
+tasks, and signals relevant to {{domain}} — the caller has already
+pre-filtered the inputs, so summarize them faithfully rather than
+broadening the scope.
+{{/if}}
 
 User risk profile: {{risk_profile}}
 User language: {{language}}


### PR DESCRIPTION
## Summary

Closes the **last** of the three #193 Child 1 follow-ups that PR #242 explicitly deferred (capabilities Lifebook filter shipped in #256, provenance wing filter shipped in #257, this one). The weekly briefing worker now emits, in addition to the existing global briefing, one per-Lifebook briefing for each visible domain with activity in the window. The lifebook page renders the per-domain briefing when one exists.

All three #193 deferred items are now closed end-to-end.

## What changed

### Migration

**`packages/db/src/migrations/042-briefing-domain.sql`** — adds nullable `domain_name STRING` column to `twin_briefings`. NULL preserves the historical global-briefing semantic untouched. A string value scopes the briefing to that lifebook's domain (matching `lifebooks.domain_name`). Partial index `(user_id, domain_name, generated_at DESC) WHERE domain_name IS NOT NULL` keeps per-domain queries fast without bloating storage for global rows.

### Repository

- `briefingRepository.create()` accepts an optional `domainName`.
- `briefingRepository.getLatestForUser()` now explicitly scopes to `domain_name IS NULL` (the historical method always returned global briefings; the semantic is now explicit instead of implicit).
- New `briefingRepository.getLatestForUserDomain(userId, domain, cadence?)` for the per-Lifebook surface.

### Worker

**`apps/worker/src/jobs/briefing-generator.ts`**:

- After writing the global briefing, fetch the user's visible lifebooks and emit one per-domain briefing per lifebook with events in the window. Events are filtered by `registry_id ∈ lifebook.suggested_capabilities` — the same set the domain extractor proposed for that wing.
- **Empty filtered sets are skipped** — a "nothing happened in Health this week" briefing is noise. Only domains with at least one event in the window get a per-Lifebook row.
- **Per-lifebook failures are caught and logged** so one broken domain (LLM error, empty payload, etc.) doesn't take out the other lifebooks or the global briefing.
- The prompt now carries an optional `{{domain}}` input; the template's `{{#if domain}}` block adds a one-sentence framing for the scoped domain. Deterministic fallback unchanged.

### API

- New `GET /api/twin-briefings/lifebook/:domain/latest?cadence=` returns `{ briefing: TwinBriefingRow | null }`. NULL when no per-domain briefing exists yet — the common case while the worker hasn't run, the domain is too new, or it had zero events in the window.

### Frontend

- **`apps/web/public/js/pages/lifebook.js`** fetches the per-domain briefing best-effort and renders it as a card on the Lifebook page. When no briefing exists yet, a friendly empty state explains when one will appear. The fetch is best-effort: the rest of the page renders even if the briefing endpoint is unavailable.

## What this PR deliberately does NOT do

- **Bundle a Markdown renderer.** The dashboard doesn't have one today; the prose is rendered as text with line breaks preserved. Wiring up a renderer for the full twin-briefings surface is a separate concern that touches the dashboard briefing too.
- **Backfill per-domain briefings for past periods.** Per-domain briefings only get written starting from the next worker run after migration 042 lands. There's no historical "what would my Health briefing have said last week?" path.
- **Mark per-domain briefings as read.** The existing read tracking lives on `twin_briefings.read_at` and applies to any briefing — but the lifebook page doesn't currently surface a "mark as read" affordance. That's a follow-up UX consideration.

## Test plan

- [x] **3 new vitest cases** in `briefing-generator.test.ts`:
  - Per-Lifebook briefing is written per visible lifebook with matching events.
  - Lifebook with no matching events is skipped (no "nothing happened" rows).
  - Per-lifebook failure doesn't take out the other lifebooks (resilience).
- [x] **Full worker suite**: 86/86 passing (+3 new tests).
- [x] **Full api suite**: 547/547 (db trip-wire after schema change checks the migration loads cleanly).
- [x] **Full db suite**: 189/189.
- [x] **Full workspace**: 70/70 turbo tasks green.
- [x] `pnpm build --concurrency=1` clean.
- [x] `node --check` clean on the JS files.

## Notes for reviewers

- The repository change to `getLatestForUser()` adds `AND domain_name IS NULL` to the historical query. This makes the historical contract ("global briefings only") explicit. Existing callers were already getting global briefings by default; this just makes that semantic load-bearing rather than incidental.
- The worker's per-domain filter is a strict subset operation. If a server's `registry_id` matches multiple lifebooks (unusual but legal), it shows up in every matching domain's briefing. That's intentional — the user wants to see Fitbit data in both Health and (e.g.) Productivity if both have it as a suggested capability.
- The `{{#if domain}}` template syntax is the existing handlebars dialect; the runPrompt layer already handles conditional blocks. Empty-string `domain` falls through to the global path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)