### PR TITLE
feat(#251 Layer 2 + companion fields): tier-weighted gbrain retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Authoring-tier weighting in gbrain retrieval (#251 Layer 2 + companion fields)
+
+You can now flip a toggle in **Settings → Memory backend** that tells gbrain to treat the emails you *wrote* as higher-signal than the emails you *received* when ranking semantic-search results. A newsletter that mentions "board prep" stops out-ranking the strategy email you actually wrote about board prep. The toggle is **off by default** — we're gating Layer 2 on labeled-retrieval evals before flipping it on for everyone — but it's available today for anyone who wants to try it.
+
+### What this changes for the user
+
+- A new **"Weight what you wrote (Layer 2 — beta)"** card on Settings → Memory backend with a single toggle. Enabling it auto-detects your calibration band from how much you've written in the last 90 days (sparse / normal / dense) so a thin-sent corpus doesn't get over-amplified.
+- The "What your twin remembers" dashboard now leads with a **Recent pages indexed** table that shows a small tier badge next to each page (`you wrote`, `you replied`, `personal`, `broadcast`, `newsletter`, `automated`, plus `📌 pinned` / `hidden` when the user has explicitly overridden). First-week product feel is no longer "1,247 newsletters" — it's "the things you wrote, plus the things sent to you, plus the noise."
+
+### Engine work
+
+- **Migration 043** adds `tier_weighting` (bool, default false) and `tier_calibration` (enum `sparse` / `normal` / `dense`, default `normal`) to `brain_settings`. Out-of-band: a fresh user gets reasonable defaults via `parseSettingsRow` even before the migration runs.
+- **`packages/memory-gbrain-crdb-adapter/src/tier-weights.ts`** (new) — the multiplier table with three calibration bands. `user_sent_originated` ranges 1.2× / 1.5× / 2.0×; `inbox_newsletter` ranges 0.5× / 0.4× / 0.3×; etc. Composes orthogonally with `metadata.userOverride` (`pinned` doubles, `hidden` drops the page from results entirely) and includes a brief-reply downweight: an `authored_*` page whose body is shorter than 50 chars gets `inbox_personal` weight so a one-line "k" reply can't outrank a 500-word strategy email.
+- **`rrf.ts`** accepts an optional `tierWeight(metadata)` callback. Default behaviour is pure RRF; passing the callback multiplies each accumulated rrfScore by the per-page weight before the final sort. `textRank` / `vectorRank` survive unchanged for observability.
+- **`embedded-port.ts`** reads `brain_settings.tier_weighting` per-query; when on, it builds a tier-weight function for the user's calibration band and passes it through to `hybridSearch`. Lookups are best-effort: any DB error falls back to pure RRF rather than blocking the search.
+- **`buildPageMetadata`** now stamps `bodyLen` on every page so the brief-reply downweight has something to read. Adds one field; no schema change.
+
+### API surface
+
+- `GET /api/memory-config` now returns `tierWeighting` and `tierCalibration` alongside the existing backend + capabilities + index fields. The dashboard reads it to render the toggle.
+- `POST /api/memory-config/tier-weighting` (new). Body `{ enabled: boolean, calibration?: 'sparse' | 'normal' | 'dense' }`. On enable without an explicit `calibration`, the route counts `user_sent_*` pages from the last 90 days and picks the band from `calibrationFromSentVolume`. Falls back to `normal` on DB failure.
+- `GET /api/memory-config/dashboard` now includes `pages.recent[]` (10 newest brain pages) with `authoringTier` + `userOverride` projected out of metadata. Embedding vectors are stripped from the wire response.
+
+### Tests
+
+- **16 unit tests** in `tier-weights.test.ts` cover the multiplier table for all three calibrations, `userOverride: pinned/hidden` composition, brief-reply downweight thresholds, and `calibrationFromSentVolume` thresholds.
+- **3 new rrf.test.ts cases** exercise the `tierWeight` branch: a higher-base-rank newsletter falling behind a lower-base-rank authored page once weighting flips on, `hidden` dropping pages entirely, and `textRank` / `vectorRank` surviving the reorder.
+- **5 end-to-end cases** in `tier-weighted-retrieval.test.ts` seed a mixed-tier corpus and assert the load-bearing claim: with `tier_weighting = true`, an authored page that ranks #2 on text alone reaches index 0 in the results. Also covers the per-user isolation invariant (one user with the flag on doesn't affect another with the flag off).
+- **5 new memory-config-routes.test.ts cases** cover the new POST endpoint: invalid body, auto-recompute on enable, explicit `calibration` overrides the auto-recompute, disable doesn't recompute, and a DB failure during `countUserSentPages` falls back to `normal`.
+
+### Deferred to follow-ups
+
+- `relationshipTier` (separate axis for relationship strength, from bidirectional thread count) — separate sub-issue.
+- Migration backfill that re-derives `authoringTier` for pages indexed pre-Layer 1 — separate concern from the live ingest path.
+- Tier-aware exclude UI for the privacy story (per-thread "don't index from this") — sub-issue, will block flipping Layer 2 on by default.
+- Layer 2 default-on rollout — gated on the labeled-relevant-doc eval improving recall@5 on a real production corpus.
+
 ## [unreleased] — Piper TTS backend + `/api/voice/synthesize` route (#187 AC#4)
 
 ### Fixed (post-Copilot review)

--- a/apps/api/src/__tests__/memory-config-routes.test.ts
+++ b/apps/api/src/__tests__/memory-config-routes.test.ts
@@ -18,13 +18,21 @@ import type { Express } from 'express';
 
 // ── Hoisted mocks (so they apply during module init) ────────────────────────
 
-const { mockGetSettings, mockUpsertSettings, mockCountPages, mockPendingJobs } =
-  vi.hoisted(() => ({
-    mockGetSettings: vi.fn(),
-    mockUpsertSettings: vi.fn(),
-    mockCountPages: vi.fn(),
-    mockPendingJobs: vi.fn(),
-  }));
+const {
+  mockGetSettings,
+  mockUpsertSettings,
+  mockCountPages,
+  mockPendingJobs,
+  mockCountUserSentPages,
+  mockGetRecentPages,
+} = vi.hoisted(() => ({
+  mockGetSettings: vi.fn(),
+  mockUpsertSettings: vi.fn(),
+  mockCountPages: vi.fn(),
+  mockPendingJobs: vi.fn(),
+  mockCountUserSentPages: vi.fn(),
+  mockGetRecentPages: vi.fn(),
+}));
 
 vi.mock('@skytwin/memory-gbrain-crdb-adapter', async () => {
   const actual: typeof import('@skytwin/memory-gbrain-crdb-adapter') =
@@ -35,6 +43,8 @@ vi.mock('@skytwin/memory-gbrain-crdb-adapter', async () => {
     upsertSettings: mockUpsertSettings,
     countPages: mockCountPages,
     pendingEmbeddingJobs: mockPendingJobs,
+    countUserSentPages: mockCountUserSentPages,
+    getRecentPages: mockGetRecentPages,
   };
 });
 
@@ -109,11 +119,15 @@ beforeEach(() => {
   mockGetSettings.mockResolvedValue(null);
   mockGetEpisodes.mockResolvedValue([]);
   mockGetEntities.mockResolvedValue([]);
+  mockCountUserSentPages.mockResolvedValue(0);
+  mockGetRecentPages.mockResolvedValue([]);
   mockUpsertSettings.mockResolvedValue({
     user_id: USER_ID,
     backend: 'gbrain',
     hybrid_notification_dismissed: false,
     routing: {},
+    tier_weighting: false,
+    tier_calibration: 'normal',
     updated_at: new Date(),
   });
 });
@@ -314,5 +328,161 @@ describe('GET /api/memory-config/dashboard', () => {
     const body = res.body as { episodes: { recent: unknown[] }; entities: { total: number } };
     expect(body.episodes.recent).toHaveLength(0);
     expect(body.entities.total).toBe(1);
+  });
+
+  it('returns recent pages with tier badge fields (#251)', async () => {
+    mockGetRecentPages.mockResolvedValue([
+      {
+        id: 'p1',
+        user_id: USER_ID,
+        title: 'Q3 board prep',
+        content: 'long body',
+        source: 'signal',
+        source_ref: 'sig_gmail_abc',
+        metadata: { authoringTier: 'user_sent_originated', bodyLen: 600 },
+        embedding: null,
+        embedding_model: null,
+        embedding_dim: null,
+        created_at: new Date('2026-05-11T12:00:00Z'),
+        updated_at: new Date(),
+      },
+      {
+        id: 'p2',
+        user_id: USER_ID,
+        title: 'Weekly Stripe receipt',
+        content: 'short',
+        source: 'signal',
+        source_ref: 'sig_gmail_def',
+        metadata: { authoringTier: 'inbox_automated', userOverride: 'hidden' },
+        embedding: null,
+        embedding_model: null,
+        embedding_dim: null,
+        created_at: new Date('2026-05-10T12:00:00Z'),
+        updated_at: new Date(),
+      },
+    ]);
+    const app = buildApp();
+    const res = await request(app, 'GET', `/api/memory-config/dashboard?userId=${USER_ID}`);
+    expect(res.status).toBe(200);
+    const body = res.body as { pages: { recent: Array<Record<string, unknown>> } };
+    expect(body.pages.recent).toHaveLength(2);
+    expect(body.pages.recent[0]?.['authoringTier']).toBe('user_sent_originated');
+    expect(body.pages.recent[1]?.['userOverride']).toBe('hidden');
+    // Embedding vector NOT echoed to the wire (large + irrelevant).
+    expect(body.pages.recent[0]?.['embedding']).toBeUndefined();
+  });
+});
+
+describe('POST /api/memory-config/tier-weighting (#251 Layer 2)', () => {
+  it('rejects non-boolean enabled', async () => {
+    const app = buildApp();
+    const res = await request(
+      app,
+      'POST',
+      `/api/memory-config/tier-weighting?userId=${USER_ID}`,
+      { enabled: 'yes' },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('on enable, auto-computes the calibration band from sent volume', async () => {
+    mockCountUserSentPages.mockResolvedValue(50); // sparse threshold (<100)
+    mockUpsertSettings.mockResolvedValue({
+      user_id: USER_ID,
+      backend: 'gbrain',
+      hybrid_notification_dismissed: false,
+      routing: {},
+      tier_weighting: true,
+      tier_calibration: 'sparse',
+      updated_at: new Date(),
+    });
+    const app = buildApp();
+    const res = await request(
+      app,
+      'POST',
+      `/api/memory-config/tier-weighting?userId=${USER_ID}`,
+      { enabled: true },
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as { tierWeighting: boolean; tierCalibration: string };
+    expect(body.tierWeighting).toBe(true);
+    expect(body.tierCalibration).toBe('sparse');
+    expect(mockUpsertSettings).toHaveBeenCalledWith(USER_ID, {
+      tier_weighting: true,
+      tier_calibration: 'sparse',
+    });
+  });
+
+  it('an explicit calibration override skips the auto-recompute', async () => {
+    mockCountUserSentPages.mockResolvedValue(50); // would be sparse
+    mockUpsertSettings.mockResolvedValue({
+      user_id: USER_ID,
+      backend: 'gbrain',
+      hybrid_notification_dismissed: false,
+      routing: {},
+      tier_weighting: true,
+      tier_calibration: 'dense',
+      updated_at: new Date(),
+    });
+    const app = buildApp();
+    const res = await request(
+      app,
+      'POST',
+      `/api/memory-config/tier-weighting?userId=${USER_ID}`,
+      { enabled: true, calibration: 'dense' },
+    );
+    expect(res.status).toBe(200);
+    expect(mockCountUserSentPages).not.toHaveBeenCalled();
+    expect(mockUpsertSettings).toHaveBeenCalledWith(USER_ID, {
+      tier_weighting: true,
+      tier_calibration: 'dense',
+    });
+  });
+
+  it('disable does NOT auto-recompute calibration (leaves it where it was)', async () => {
+    mockUpsertSettings.mockResolvedValue({
+      user_id: USER_ID,
+      backend: 'gbrain',
+      hybrid_notification_dismissed: false,
+      routing: {},
+      tier_weighting: false,
+      tier_calibration: 'normal',
+      updated_at: new Date(),
+    });
+    const app = buildApp();
+    const res = await request(
+      app,
+      'POST',
+      `/api/memory-config/tier-weighting?userId=${USER_ID}`,
+      { enabled: false },
+    );
+    expect(res.status).toBe(200);
+    expect(mockCountUserSentPages).not.toHaveBeenCalled();
+    expect(mockUpsertSettings).toHaveBeenCalledWith(USER_ID, { tier_weighting: false });
+  });
+
+  it('falls back to normal calibration when countUserSentPages fails', async () => {
+    mockCountUserSentPages.mockRejectedValue(new Error('db hiccup'));
+    mockUpsertSettings.mockResolvedValue({
+      user_id: USER_ID,
+      backend: 'gbrain',
+      hybrid_notification_dismissed: false,
+      routing: {},
+      tier_weighting: true,
+      tier_calibration: 'normal',
+      updated_at: new Date(),
+    });
+    const app = buildApp();
+    const res = await request(
+      app,
+      'POST',
+      `/api/memory-config/tier-weighting?userId=${USER_ID}`,
+      { enabled: true },
+    );
+    expect(res.status).toBe(200);
+    expect(mockUpsertSettings).toHaveBeenCalledWith(USER_ID, {
+      tier_weighting: true,
+      tier_calibration: 'normal',
+    });
   });
 });

--- a/apps/api/src/routes/memory-config.ts
+++ b/apps/api/src/routes/memory-config.ts
@@ -4,7 +4,11 @@ import {
   getSettings as getBrainSettings,
   upsertSettings as upsertBrainSettings,
   countPages,
+  countUserSentPages,
+  getRecentPages,
   pendingEmbeddingJobs,
+  calibrationFromSentVolume,
+  type TierCalibration,
 } from '@skytwin/memory-gbrain-crdb-adapter';
 import { mempalaceRepository } from '@skytwin/db';
 import {
@@ -56,6 +60,11 @@ export function createMemoryConfigRouter(): Router {
         backend: resolved.backend,
         capabilities: capabilitiesArr,
         hybridNotificationDismissed: settings?.hybrid_notification_dismissed ?? false,
+        // #251 Layer 2: surface tier-weighting toggle + calibration band so
+        // the dashboard can show + flip them. Falls back to defaults when
+        // the brain_settings row is missing (fresh user).
+        tierWeighting: settings?.tier_weighting ?? false,
+        tierCalibration: settings?.tier_calibration ?? 'normal',
         suggestion,
         index: {
           totalPages: counts.total,
@@ -92,6 +101,66 @@ export function createMemoryConfigRouter(): Router {
         error: err instanceof Error ? err.message : String(err),
       });
       return res.status(500).json({ error: 'failed to update backend' });
+    }
+  });
+
+  // POST toggle tier_weighting (#251 Layer 2). On enable, recompute the
+  // calibration band from the user's current `user_sent_*` page count over
+  // the last 90 days so a sparse-writer doesn't get the wide-spread weights.
+  // Body: `{ enabled: boolean, calibration?: 'sparse' | 'normal' | 'dense' }`.
+  // An explicit `calibration` override skips the auto-recompute and is the
+  // escape hatch for users who want to pin the band themselves.
+  router.post('/tier-weighting', async (req, res) => {
+    const userId = String(req.query['userId'] ?? '');
+    if (!UUID_REGEX.test(userId)) {
+      return res.status(400).json({ error: 'invalid userId' });
+    }
+    const body = (req.body ?? {}) as {
+      enabled?: unknown;
+      calibration?: unknown;
+    };
+    if (typeof body.enabled !== 'boolean') {
+      return res.status(400).json({ error: 'enabled (bool) is required' });
+    }
+
+    let calibration: TierCalibration | null = null;
+    if (
+      body.calibration === 'sparse' ||
+      body.calibration === 'normal' ||
+      body.calibration === 'dense'
+    ) {
+      calibration = body.calibration;
+    } else if (body.enabled) {
+      // Auto-compute from the user's writing volume. Worst case (transient
+      // DB error) we fall back to 'normal'.
+      try {
+        const sentVolume = await countUserSentPages(userId, 90);
+        calibration = calibrationFromSentVolume(sentVolume);
+      } catch (err) {
+        log.warn('tier_calibration auto-recompute failed; using normal', {
+          userId,
+          reason: err instanceof Error ? err.name : 'unknown',
+        });
+        calibration = 'normal';
+      }
+    }
+
+    try {
+      const next = await upsertBrainSettings(userId, {
+        tier_weighting: body.enabled,
+        ...(calibration ? { tier_calibration: calibration } : {}),
+      });
+      return res.json({
+        ok: true,
+        tierWeighting: next.tier_weighting,
+        tierCalibration: next.tier_calibration,
+      });
+    } catch (err) {
+      log.error('tier-weighting POST failed', {
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return res.status(500).json({ error: 'failed to update tier weighting' });
     }
   });
 
@@ -154,12 +223,16 @@ export function createMemoryConfigRouter(): Router {
       return res.status(400).json({ error: 'invalid userId' });
     }
     try {
-      const [counts, pendingJobs, recentEpisodes, entities] = await Promise.all([
+      const [counts, pendingJobs, recentEpisodes, entities, recentPages] = await Promise.all([
         countPages(userId).catch(() => ({ total: 0, embedded: 0 })),
         // Per-user count — multi-tenant installs were getting the global queue depth.
         pendingEmbeddingJobs(userId).catch(() => 0),
         mempalaceRepository.getEpisodes(userId, { limit: 10 }).catch(() => []),
         mempalaceRepository.getEntities(userId).catch(() => []),
+        // #251 Layer 1 surfaces — recent indexed pages, with the authoring
+        // tier badge from metadata. Empty array on failure so the rest of
+        // the dashboard still renders.
+        getRecentPages(userId, 10).catch(() => []),
       ]);
 
       // Compute feedback trend across the recent episode window.
@@ -207,6 +280,23 @@ export function createMemoryConfigRouter(): Router {
         createdAt: ep.created_at,
       }));
 
+      // Sanitize recent pages for the wire — strip the embedding vector
+      // (large, irrelevant for UI) and surface only the fields the dashboard
+      // actually renders. Tier comes from metadata.authoringTier.
+      const formattedPages = recentPages.map((p) => {
+        const meta = (p.metadata ?? {}) as Record<string, unknown>;
+        const tier = typeof meta['authoringTier'] === 'string' ? (meta['authoringTier'] as string) : null;
+        const userOverride = typeof meta['userOverride'] === 'string' ? (meta['userOverride'] as string) : null;
+        return {
+          id: p.id,
+          title: p.title,
+          source: p.source,
+          createdAt: p.created_at,
+          authoringTier: tier,
+          userOverride,
+        };
+      });
+
       return res.json({
         userId,
         index: {
@@ -222,6 +312,9 @@ export function createMemoryConfigRouter(): Router {
           total: entities.length,
           topByRecency: topEntities,
           topByType: topEntityTypes,
+        },
+        pages: {
+          recent: formattedPages,
         },
       });
     } catch (err) {

--- a/apps/web/public/js/pages/memory-settings.js
+++ b/apps/web/public/js/pages/memory-settings.js
@@ -126,6 +126,11 @@ function ensurePageListener() {
         showSavedToast(next ? 'Tier weighting enabled' : 'Tier weighting disabled');
         const container = document.getElementById('page-content');
         if (container) await renderMemorySettings(container, getCurrentUserId());
+      } catch {
+        // Offline / DNS / network — `api()` throws rather than returning an
+        // ok=false response, so without this branch the user would only see
+        // the button re-enable with no feedback.
+        showErrorToast('Failed to update tier weighting');
       } finally {
         target.disabled = false;
       }

--- a/apps/web/public/js/pages/memory-settings.js
+++ b/apps/web/public/js/pages/memory-settings.js
@@ -108,6 +108,29 @@ function ensurePageListener() {
       }
       return;
     }
+
+    // #251 Layer 2: tier-weighting toggle. Enabling auto-recomputes the
+    // calibration band server-side from the user's recent writing volume.
+    if (action === 'toggle-tier-weighting') {
+      const next = target.dataset.next === 'true';
+      target.disabled = true;
+      try {
+        const res = await api('/api/memory-config/tier-weighting', {
+          method: 'POST',
+          body: JSON.stringify({ enabled: next }),
+        });
+        if (!res.ok) {
+          showErrorToast('Failed to update tier weighting');
+          return;
+        }
+        showSavedToast(next ? 'Tier weighting enabled' : 'Tier weighting disabled');
+        const container = document.getElementById('page-content');
+        if (container) await renderMemorySettings(container, getCurrentUserId());
+      } finally {
+        target.disabled = false;
+      }
+      return;
+    }
   });
 }
 
@@ -212,9 +235,51 @@ export async function renderMemorySettings(container, userId) {
         for users who prefer the original stack.
       </p>
     </div>
+    ${renderTierWeightingCard(data)}
     ${diagBlock}
     ${renderDashboard(dashboard)}
   `;
+}
+
+/**
+ * #251 Layer 2 control: toggle authoring-tier-weighted retrieval. Off by
+ * default. Enabling auto-recomputes the calibration band server-side from
+ * the user's `user_sent_*` page count in the last 90 days, so a thin-sent
+ * user gets the sparse weights (capped spread) and a heavy writer gets the
+ * dense weights (wide spread).
+ */
+function renderTierWeightingCard(data) {
+  const enabled = data.tierWeighting === true;
+  const calibration = data.tierCalibration ?? 'normal';
+  const nextState = enabled ? 'false' : 'true';
+  return `
+    <div class="card" style="margin-top: 1rem;">
+      <h3>Weight what you wrote (Layer 2 — beta)</h3>
+      <p class="card-subtitle" style="margin: 0.25rem 0 0.75rem;">
+        Treat emails you <em>sent</em> as higher-signal than emails you
+        received when ranking memory search results. A newsletter that
+        mentions "board prep" gets demoted relative to an email you
+        actually wrote about board prep. See
+        <a href="https://github.com/jayzalowitz/skytwin/issues/251" target="_blank" rel="noopener">issue&nbsp;#251</a>
+        for the rationale and calibration table.
+      </p>
+      <p style="margin: 0 0 0.5rem;">
+        Status:
+        <strong>${enabled ? 'Enabled' : 'Disabled'}</strong>
+        ${enabled ? `<span class="card-subtitle">— calibration: <code>${escapeHtml(calibration)}</code></span>` : ''}
+      </p>
+      <button class="btn ${enabled ? 'btn-outline' : ''}"
+              data-action="toggle-tier-weighting"
+              data-next="${nextState}">
+        ${enabled ? 'Disable tier weighting' : 'Enable tier weighting'}
+      </button>
+      <p class="card-subtitle" style="margin-top: 0.75rem;">
+        Off by default — we're treating Layer 2 as opt-in until the
+        labeled-retrieval eval confirms recall@5 improves on a real
+        production corpus. Off mode keeps pure Reciprocal Rank Fusion
+        scoring; on mode applies the per-tier multipliers from the issue.
+      </p>
+    </div>`;
 }
 
 function renderDashboard(dashboard) {
@@ -265,6 +330,22 @@ function renderDashboard(dashboard) {
         ).join('')}
       </div>`;
 
+  const recentPages = dashboard.pages?.recent ?? [];
+  const pagesBlock = recentPages.length === 0
+    ? `<p class="card-subtitle">No pages indexed yet. Connect a signal source to start.</p>`
+    : `<table class="data-table" style="margin-top: 0.5rem; width: 100%;">
+        <thead><tr><th>When</th><th>Tier</th><th>Source</th><th>Title</th></tr></thead>
+        <tbody>
+          ${recentPages.map((p) => `
+            <tr>
+              <td>${formatRelativeTime(p.createdAt)}</td>
+              <td>${renderTierBadge(p.authoringTier, p.userOverride)}</td>
+              <td>${escapeHtml(p.source ?? '')}</td>
+              <td>${escapeHtml(p.title ?? '')}</td>
+            </tr>`).join('')}
+        </tbody>
+      </table>`;
+
   return `
     <div class="card" style="margin-top: 1rem;">
       <h3>What your twin remembers</h3>
@@ -274,7 +355,9 @@ function renderDashboard(dashboard) {
         Memory feeds back into every decision — past approvals boost similar actions,
         past rejections push them down.
       </p>
-      <h4>Recent decisions</h4>
+      <h4>Recent pages indexed</h4>
+      ${pagesBlock}
+      <h4 style="margin-top: 1rem;">Recent decisions</h4>
       ${episodesBlock}
       ${fbBlock}
       <h4 style="margin-top: 1rem;">Top entities</h4>
@@ -282,6 +365,34 @@ function renderDashboard(dashboard) {
       ${typeBlock}
     </div>
   `;
+}
+
+/**
+ * #251: small inline badge showing the authoring tier a page was classified
+ * into. Lets the user see at a glance how the twin is weighting what it
+ * reads. Color-coded for skimmability — green for "you wrote it," neutral
+ * for personal mail, muted for newsletter/automated noise.
+ */
+function renderTierBadge(tier, userOverride) {
+  if (userOverride === 'pinned') {
+    return '<span style="color: var(--info); font-size: 0.85em;">📌 pinned</span>';
+  }
+  if (userOverride === 'hidden') {
+    return '<span style="color: var(--muted); font-size: 0.85em; text-decoration: line-through;">hidden</span>';
+  }
+  if (!tier) {
+    return '<span class="card-subtitle" style="font-size: 0.85em;">—</span>';
+  }
+  const map = {
+    user_sent_originated: { label: 'you wrote', color: 'var(--success)' },
+    user_sent_reply: { label: 'you replied', color: 'var(--success)' },
+    inbox_personal: { label: 'personal', color: 'var(--text)' },
+    inbox_broadcast: { label: 'broadcast', color: 'var(--text)' },
+    inbox_newsletter: { label: 'newsletter', color: 'var(--muted)' },
+    inbox_automated: { label: 'automated', color: 'var(--muted)' },
+  };
+  const meta = map[tier] ?? { label: tier, color: 'var(--text)' };
+  return `<span style="color: ${meta.color}; font-size: 0.85em;">${escapeHtml(meta.label)}</span>`;
 }
 
 function renderFeedbackBadge(type) {

--- a/packages/db/src/migrations/043-brain-tier-weighting.sql
+++ b/packages/db/src/migrations/043-brain-tier-weighting.sql
@@ -1,0 +1,20 @@
+-- #251 Layer 2 + companion fields.
+--
+-- Adds the per-user toggles + calibration band that the gbrain retrieval
+-- layer reads when applying the authoring-tier multiplier in the RRF fold.
+-- Default is OFF — Layer 2 ships dark and is opt-in until the
+-- `realistic-retrieval` eval confirms recall@5 improves on the labeled set.
+--
+-- Calibration band:
+--   sparse  → user has <100 user_sent_* pages in last 90d; cap the multiplier
+--             aggressively so we don't amplify a signal that isn't there
+--   normal  → default; use the mid-band weights from the issue spec
+--   dense   → user has >1000 user_sent_* pages in last 90d; use the wide
+--             multiplier spread so SNR difference compounds
+
+ALTER TABLE brain_settings
+  ADD COLUMN IF NOT EXISTS tier_weighting BOOL NOT NULL DEFAULT false;
+
+ALTER TABLE brain_settings
+  ADD COLUMN IF NOT EXISTS tier_calibration STRING NOT NULL DEFAULT 'normal'
+    CHECK (tier_calibration IN ('sparse', 'normal', 'dense'));

--- a/packages/memory-gbrain-crdb-adapter/src/__tests__/rrf.test.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/__tests__/rrf.test.ts
@@ -92,4 +92,71 @@ describe('rrfFold', () => {
     // Lower k makes top-1 stand out more.
     expect(lowGap).toBeGreaterThan(highGap);
   });
+
+  describe('with tierWeight (#251 Layer 2)', () => {
+    function pageWithTier(id: string, tier: string): BrainPageRow {
+      const p = makePage(id);
+      return { ...p, metadata: { authoringTier: tier } };
+    }
+
+    it('flips ranking when a lower-base-rank authored page outweighs a top-rank newsletter', () => {
+      // Both pages match the query equally on text — newsletter happens
+      // to rank first (e.g. the corpus had more of them). Without tier
+      // weighting newsletter wins; with normal-band weighting authored wins.
+      const text = [
+        { page: pageWithTier('newsletter', 'inbox_newsletter'), score: 1 },
+        { page: pageWithTier('authored', 'user_sent_originated'), score: 0.99 },
+      ];
+      const pure = rrfFold(text, [], 5, 60);
+      expect(pure[0]!.id).toBe('newsletter');
+
+      const weighted = rrfFold(text, [], 5, 60, {
+        tierWeight: (meta) => {
+          const t = (meta as { authoringTier?: string } | null)?.authoringTier;
+          if (t === 'user_sent_originated') return 1.5;
+          if (t === 'inbox_newsletter') return 0.4;
+          return 1.0;
+        },
+      });
+      expect(weighted[0]!.id).toBe('authored');
+    });
+
+    it('userOverride: hidden (weight 0) drops the page entirely', () => {
+      const text = [
+        { page: pageWithTier('keep', 'inbox_personal'), score: 1 },
+        { page: pageWithTier('hide-me', 'user_sent_originated'), score: 0.5 },
+      ];
+      const out = rrfFold(text, [], 5, 60, {
+        tierWeight: (meta) => {
+          const o = (meta as { id?: string; authoringTier?: string } | null);
+          // simulate "the hide-me page was marked hidden"
+          if (text.find((t) => t.page.id === 'hide-me')?.page.metadata === o)
+            return 0;
+          return 1.0;
+        },
+      });
+      expect(out.map((h) => h.id)).not.toContain('hide-me');
+      expect(out[0]!.id).toBe('keep');
+    });
+
+    it('preserves textRank/vectorRank even after weighting', () => {
+      const text = [
+        { page: pageWithTier('a', 'inbox_newsletter'), score: 1 },
+        { page: pageWithTier('b', 'user_sent_originated'), score: 0.9 },
+      ];
+      const out = rrfFold(text, [], 5, 60, {
+        tierWeight: (meta) => {
+          const t = (meta as { authoringTier?: string } | null)?.authoringTier;
+          return t === 'user_sent_originated' ? 1.5 : 0.4;
+        },
+      });
+      const a = out.find((h) => h.id === 'a');
+      const b = out.find((h) => h.id === 'b');
+      // Raw text ranks survive even though the multiplier reorders rrfScore.
+      expect(a?.textRank).toBe(1);
+      expect(b?.textRank).toBe(2);
+      // b wins despite ranking #2 on text because of the tier multiplier.
+      expect(out[0]!.id).toBe('b');
+    });
+  });
 });

--- a/packages/memory-gbrain-crdb-adapter/src/__tests__/rrf.test.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/__tests__/rrf.test.ts
@@ -139,6 +139,34 @@ describe('rrfFold', () => {
       expect(out[0]!.id).toBe('keep');
     });
 
+    it('coerces non-finite or negative weights defensively (NaN → 1.0, <0 → 0)', () => {
+      const text = [
+        { page: pageWithTier('keep-nan', 'inbox_personal'), score: 1 },
+        { page: pageWithTier('keep-undef', 'inbox_personal'), score: 0.9 },
+        { page: pageWithTier('drop-neg', 'inbox_personal'), score: 0.8 },
+      ];
+      const out = rrfFold(text, [], 5, 60, {
+        tierWeight: (meta) => {
+          const id = (meta as { authoringTier?: string } | null);
+          // Return progressively misbehaving values; the fold must survive.
+          if (id === text[0]!.page.metadata) return Number.NaN;
+          if (id === text[1]!.page.metadata) return undefined as unknown as number;
+          if (id === text[2]!.page.metadata) return -5;
+          return 1;
+        },
+      });
+      const ids = out.map((h) => h.id);
+      // NaN and undefined → identity (kept); negative → dropped like 'hidden'.
+      expect(ids).toContain('keep-nan');
+      expect(ids).toContain('keep-undef');
+      expect(ids).not.toContain('drop-neg');
+      // rrfScore should be a finite number for survivors.
+      for (const hit of out) {
+        expect(Number.isFinite(hit.rrfScore)).toBe(true);
+        expect(hit.rrfScore).toBeGreaterThan(0);
+      }
+    });
+
     it('preserves textRank/vectorRank even after weighting', () => {
       const text = [
         { page: pageWithTier('a', 'inbox_newsletter'), score: 1 },

--- a/packages/memory-gbrain-crdb-adapter/src/__tests__/tier-weights.test.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/__tests__/tier-weights.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  tierMultiplier,
+  buildTierWeightFn,
+  calibrationFromSentVolume,
+  BRIEF_BODY_THRESHOLD,
+} from '../tier-weights.js';
+
+describe('tierMultiplier — authoring-tier base weights', () => {
+  it('returns 1.0 (identity) for unknown / missing metadata', () => {
+    expect(tierMultiplier(null, 'normal')).toBe(1.0);
+    expect(tierMultiplier(undefined, 'normal')).toBe(1.0);
+    expect(tierMultiplier({}, 'normal')).toBe(1.0);
+    expect(tierMultiplier({ authoringTier: 'who_knows' }, 'normal')).toBe(1.0);
+    expect(tierMultiplier({ authoringTier: 42 }, 'normal')).toBe(1.0);
+  });
+
+  it('applies the normal band weights for each tier', () => {
+    const m = (tier: string) => tierMultiplier({ authoringTier: tier }, 'normal');
+    expect(m('user_sent_originated')).toBe(1.5);
+    expect(m('user_sent_reply')).toBe(1.2);
+    expect(m('inbox_personal')).toBe(1.0);
+    expect(m('inbox_broadcast')).toBe(0.8);
+    expect(m('inbox_newsletter')).toBe(0.4);
+    expect(m('inbox_automated')).toBe(0.2);
+  });
+
+  it('sparse calibration compresses the spread', () => {
+    const m = (tier: string) => tierMultiplier({ authoringTier: tier }, 'sparse');
+    expect(m('user_sent_originated')).toBe(1.2);
+    expect(m('user_sent_reply')).toBe(1.1);
+    expect(m('inbox_newsletter')).toBe(0.5);
+    expect(m('inbox_automated')).toBe(0.5);
+  });
+
+  it('dense calibration widens the spread', () => {
+    const m = (tier: string) => tierMultiplier({ authoringTier: tier }, 'dense');
+    expect(m('user_sent_originated')).toBe(2.0);
+    expect(m('user_sent_reply')).toBe(1.5);
+    expect(m('inbox_newsletter')).toBe(0.3);
+    expect(m('inbox_automated')).toBe(0.1);
+  });
+});
+
+describe('tierMultiplier — userOverride composes orthogonally', () => {
+  it("pinned doubles whatever the tier weight would otherwise be", () => {
+    // pinned + originated (normal band) = 1.5 * 2 = 3.0
+    expect(
+      tierMultiplier(
+        { authoringTier: 'user_sent_originated', userOverride: 'pinned' },
+        'normal',
+      ),
+    ).toBe(3.0);
+    // pinned + newsletter (normal band) = 0.4 * 2 = 0.8
+    expect(
+      tierMultiplier(
+        { authoringTier: 'inbox_newsletter', userOverride: 'pinned' },
+        'normal',
+      ),
+    ).toBe(0.8);
+  });
+
+  it('pinned alone (no tier) still boosts to 2.0', () => {
+    expect(tierMultiplier({ userOverride: 'pinned' }, 'normal')).toBe(2.0);
+  });
+
+  it("hidden forces 0 — page is dropped from retrieval entirely", () => {
+    expect(
+      tierMultiplier(
+        { authoringTier: 'user_sent_originated', userOverride: 'hidden' },
+        'normal',
+      ),
+    ).toBe(0);
+    expect(tierMultiplier({ userOverride: 'hidden' }, 'normal')).toBe(0);
+  });
+});
+
+describe('tierMultiplier — brief authored-reply downweight', () => {
+  it('treats short user_sent_reply as inbox_personal weight', () => {
+    // 1.2 (reply) would apply, but bodyLen < 50 drops to 1.0 (personal).
+    const w = tierMultiplier(
+      {
+        authoringTier: 'user_sent_reply',
+        bodyLen: BRIEF_BODY_THRESHOLD - 1,
+      },
+      'normal',
+    );
+    expect(w).toBe(1.0);
+  });
+
+  it('a long user_sent_reply keeps the full authored weight', () => {
+    const w = tierMultiplier(
+      { authoringTier: 'user_sent_reply', bodyLen: 500 },
+      'normal',
+    );
+    expect(w).toBe(1.2);
+  });
+
+  it('short user_sent_originated is also downweighted (proactive but tiny)', () => {
+    const w = tierMultiplier(
+      { authoringTier: 'user_sent_originated', bodyLen: 20 },
+      'normal',
+    );
+    expect(w).toBe(1.0);
+  });
+
+  it('bodyLen is ignored for inbox_* tiers — they get their normal weight', () => {
+    const w = tierMultiplier(
+      { authoringTier: 'inbox_personal', bodyLen: 10 },
+      'normal',
+    );
+    expect(w).toBe(1.0);
+  });
+
+  it('non-numeric bodyLen is treated as absent', () => {
+    const w = tierMultiplier(
+      { authoringTier: 'user_sent_reply', bodyLen: 'short' },
+      'normal',
+    );
+    expect(w).toBe(1.2);
+  });
+});
+
+describe('buildTierWeightFn closes over the calibration band', () => {
+  it('returned function is stable per calibration', () => {
+    const fn = buildTierWeightFn('dense');
+    expect(fn({ authoringTier: 'user_sent_originated' })).toBe(2.0);
+    expect(fn({ authoringTier: 'inbox_newsletter' })).toBe(0.3);
+    expect(fn({})).toBe(1.0);
+  });
+});
+
+describe('calibrationFromSentVolume — thresholds', () => {
+  it('< 100 user_sent_* in last 90d → sparse', () => {
+    expect(calibrationFromSentVolume(0)).toBe('sparse');
+    expect(calibrationFromSentVolume(99)).toBe('sparse');
+  });
+
+  it('100..1000 → normal', () => {
+    expect(calibrationFromSentVolume(100)).toBe('normal');
+    expect(calibrationFromSentVolume(500)).toBe('normal');
+    expect(calibrationFromSentVolume(1000)).toBe('normal');
+  });
+
+  it('> 1000 → dense', () => {
+    expect(calibrationFromSentVolume(1001)).toBe('dense');
+    expect(calibrationFromSentVolume(10_000)).toBe('dense');
+  });
+});

--- a/packages/memory-gbrain-crdb-adapter/src/in-memory-repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/in-memory-repository.ts
@@ -149,6 +149,7 @@ export class InMemoryBrainStore {
     k: number;
     candidatePoolSize?: number;
     rrfK?: number;
+    tierWeight?: (metadata: unknown) => number;
   }): RrfHit[] {
     const pool = opts.candidatePoolSize ?? Math.max(opts.k * 4, 40);
     const rrfK = opts.rrfK ?? 60;
@@ -156,13 +157,36 @@ export class InMemoryBrainStore {
     const vec = opts.queryEmbedding
       ? this.vectorSearch(opts.userId, opts.queryEmbedding, pool)
       : [];
-    return rrfFold(text, vec, opts.k, rrfK);
+    return rrfFold(text, vec, opts.k, rrfK, {
+      ...(opts.tierWeight ? { tierWeight: opts.tierWeight } : {}),
+    });
+  }
+
+  /** Same calibration helper as the CRDB repo; mirrors the SQL count. */
+  countUserSentPages(userId: string, windowDays = 90): number {
+    const cutoff = Date.now() - windowDays * 24 * 60 * 60 * 1000;
+    let n = 0;
+    for (const p of this.pages.values()) {
+      if (p.user_id !== userId) continue;
+      if (p.created_at.getTime() < cutoff) continue;
+      const tier = (p.metadata as Record<string, unknown>)?.['authoringTier'];
+      if (tier === 'user_sent_originated' || tier === 'user_sent_reply') n++;
+    }
+    return n;
   }
 
   getAllPages(userId: string): BrainPageRow[] {
     return [...this.pages.values()]
       .filter((p) => p.user_id === userId)
       .sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+  }
+
+  /** Mirror of `repository.getRecentPages`. Newest first. */
+  getRecentPages(userId: string, limit = 10): BrainPageRow[] {
+    return [...this.pages.values()]
+      .filter((p) => p.user_id === userId)
+      .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
+      .slice(0, limit);
   }
 
   countPages(userId: string): { total: number; embedded: number } {
@@ -348,7 +372,16 @@ export class InMemoryBrainStore {
 
   upsertSettings(
     userId: string,
-    patch: Partial<Pick<BrainSettingsRow, 'backend' | 'hybrid_notification_dismissed' | 'routing'>>,
+    patch: Partial<
+      Pick<
+        BrainSettingsRow,
+        | 'backend'
+        | 'hybrid_notification_dismissed'
+        | 'routing'
+        | 'tier_weighting'
+        | 'tier_calibration'
+      >
+    >,
   ): BrainSettingsRow {
     const existing = this.settings.get(userId);
     const merged: BrainSettingsRow = {
@@ -358,6 +391,8 @@ export class InMemoryBrainStore {
       hybrid_notification_dismissed:
         patch.hybrid_notification_dismissed ?? existing?.hybrid_notification_dismissed ?? false,
       routing: patch.routing ?? existing?.routing ?? {},
+      tier_weighting: patch.tier_weighting ?? existing?.tier_weighting ?? false,
+      tier_calibration: patch.tier_calibration ?? existing?.tier_calibration ?? 'normal',
       updated_at: new Date(),
     };
     this.settings.set(userId, merged);

--- a/packages/memory-gbrain-crdb-adapter/src/index.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/index.ts
@@ -17,6 +17,7 @@ export type {
   BrainEpisodeRow,
   BrainSignalRow,
   BrainSettingsRow,
+  TierCalibration,
   RrfHit,
   InsertBrainPageInput,
 } from './types.js';
@@ -31,6 +32,15 @@ export {
 export type { EmbeddingProvider, OpenAiEmbeddingOptions } from './embedding.js';
 
 export { rrfFold } from './rrf.js';
+export type { TierWeightFn, RrfFoldOptions } from './rrf.js';
+
+export {
+  tierMultiplier,
+  buildTierWeightFn,
+  calibrationFromSentVolume,
+  BRIEF_BODY_THRESHOLD,
+} from './tier-weights.js';
+export type { AuthoringTier, UserOverride } from './tier-weights.js';
 
 export { InMemoryBrainStore } from './in-memory-repository.js';
 
@@ -59,6 +69,8 @@ export {
   markJobFailed,
   pendingEmbeddingJobs,
   getAllPages,
+  getRecentPages,
   countPages,
+  countUserSentPages,
 } from './repository.js';
 export type { HybridSearchOptions } from './repository.js';

--- a/packages/memory-gbrain-crdb-adapter/src/repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/repository.ts
@@ -103,6 +103,13 @@ export interface HybridSearchOptions {
   rrfK?: number;
   /** Cap on rows scanned from CRDB; ceiling for correctness on huge corpora. */
   scanLimit?: number;
+  /**
+   * Optional post-fold scoring hook (#251 Layer 2). When set, every
+   * accumulated rrfScore is multiplied by `tierWeight(page.metadata)` before
+   * the final sort. A multiplier of 0 drops the page entirely (used by
+   * `metadata.userOverride: 'hidden'`).
+   */
+  tierWeight?: (metadata: unknown) => number;
 }
 
 /**
@@ -126,7 +133,9 @@ export async function hybridSearch(opts: HybridSearchOptions): Promise<RrfHit[]>
       : Promise.resolve([] as Array<{ page: BrainPageRow; score: number }>),
   ]);
 
-  return rrfFold(textHits, vectorHits, opts.k, rrfK);
+  return rrfFold(textHits, vectorHits, opts.k, rrfK, {
+    ...(opts.tierWeight ? { tierWeight: opts.tierWeight } : {}),
+  });
 }
 
 interface ScoredHit {
@@ -426,7 +435,16 @@ export async function getSettings(userId: string): Promise<BrainSettingsRow | nu
 
 export async function upsertSettings(
   userId: string,
-  patch: Partial<Pick<BrainSettingsRow, 'backend' | 'hybrid_notification_dismissed' | 'routing'>>,
+  patch: Partial<
+    Pick<
+      BrainSettingsRow,
+      | 'backend'
+      | 'hybrid_notification_dismissed'
+      | 'routing'
+      | 'tier_weighting'
+      | 'tier_calibration'
+    >
+  >,
 ): Promise<BrainSettingsRow> {
   // Default backend on first insert MUST match `apps/api/src/memory-setup.ts`
   // `getMemoryPortForUser`'s 'gbrain' default and the brain_settings.backend
@@ -434,12 +452,25 @@ export async function upsertSettings(
   // POST /api/memory-config/dismiss-notification fires for a fresh user)
   // would silently flip them to hybrid.
   const result = await query<BrainSettingsRow>(
-    `INSERT INTO brain_settings (user_id, backend, hybrid_notification_dismissed, routing, updated_at)
-     VALUES ($1, COALESCE($2, 'gbrain'), COALESCE($3, false), COALESCE($4::JSONB, '{}'::JSONB), now())
+    `INSERT INTO brain_settings (
+       user_id, backend, hybrid_notification_dismissed, routing,
+       tier_weighting, tier_calibration, updated_at
+     )
+     VALUES (
+       $1,
+       COALESCE($2, 'gbrain'),
+       COALESCE($3, false),
+       COALESCE($4::JSONB, '{}'::JSONB),
+       COALESCE($5, false),
+       COALESCE($6, 'normal'),
+       now()
+     )
      ON CONFLICT (user_id) DO UPDATE
        SET backend = COALESCE($2, brain_settings.backend),
            hybrid_notification_dismissed = COALESCE($3, brain_settings.hybrid_notification_dismissed),
            routing = COALESCE($4::JSONB, brain_settings.routing),
+           tier_weighting = COALESCE($5, brain_settings.tier_weighting),
+           tier_calibration = COALESCE($6, brain_settings.tier_calibration),
            updated_at = now()
      RETURNING *`,
     [
@@ -447,9 +478,31 @@ export async function upsertSettings(
       patch.backend ?? null,
       patch.hybrid_notification_dismissed ?? null,
       patch.routing ? JSON.stringify(patch.routing) : null,
+      patch.tier_weighting ?? null,
+      patch.tier_calibration ?? null,
     ],
   );
   return parseSettingsRow(result.rows[0]!);
+}
+
+/**
+ * Count the user_sent_* pages in the last N days. Used to compute the
+ * calibration band (#251). Cheap — uses the existing user-id + created_at
+ * index plus an inline filter on the metadata JSONB field.
+ */
+export async function countUserSentPages(
+  userId: string,
+  windowDays = 90,
+): Promise<number> {
+  const result = await query<{ count: string }>(
+    `SELECT count(*)::STRING AS count
+       FROM brain_pages
+      WHERE user_id = $1
+        AND created_at > now() - ($2 || ' days')::INTERVAL
+        AND metadata->>'authoringTier' IN ('user_sent_originated', 'user_sent_reply')`,
+    [userId, String(windowDays)],
+  );
+  return Number(result.rows[0]?.count ?? 0);
 }
 
 // ── Embedding job queue ─────────────────────────────────────────────────────
@@ -560,6 +613,22 @@ export async function getAllPages(userId: string, limit = 10000): Promise<BrainP
   return result.rows.map(parsePageRow);
 }
 
+/**
+ * Most recently created pages for a user, newest first. Used by the
+ * memory dashboard to show the user a snippet of "what your twin just
+ * indexed" — including the authoring tier badge from `metadata`.
+ */
+export async function getRecentPages(
+  userId: string,
+  limit = 10,
+): Promise<BrainPageRow[]> {
+  const result = await query<BrainPageRow>(
+    `SELECT * FROM brain_pages WHERE user_id = $1 ORDER BY created_at DESC LIMIT $2`,
+    [userId, limit],
+  );
+  return result.rows.map(parsePageRow);
+}
+
 // ── Counts (for diagnostics) ────────────────────────────────────────────────
 
 export async function countPages(userId: string): Promise<{ total: number; embedded: number }> {
@@ -651,9 +720,16 @@ function parseSignalRow(row: BrainSignalRow): BrainSignalRow {
 }
 
 function parseSettingsRow(row: BrainSettingsRow): BrainSettingsRow {
+  // Defensive fallbacks for installs that haven't yet applied migration 043
+  // (tier_weighting / tier_calibration). A SELECT * on the pre-043 schema
+  // returns rows without those columns, which surface as undefined in the
+  // TS row object. Treat the runtime values as their migration defaults so
+  // downstream code never has to null-check.
   return {
     ...row,
     routing: parseJson(row.routing) ?? {},
+    tier_weighting: typeof row.tier_weighting === 'boolean' ? row.tier_weighting : false,
+    tier_calibration: row.tier_calibration ?? 'normal',
     updated_at: new Date(row.updated_at),
   };
 }

--- a/packages/memory-gbrain-crdb-adapter/src/rrf.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/rrf.ts
@@ -83,10 +83,22 @@ export function rrfFold(
   if (options.tierWeight) {
     const weight = options.tierWeight;
     for (const hit of entries) {
-      const mult = weight(hit.page.metadata);
+      // Coerce non-finite or non-number multipliers to 1.0 (identity) so a
+      // misbehaving callback can't poison rrfScore into NaN/Infinity. Clamp
+      // negatives to 0 — they share the same "drop the page" semantics as
+      // userOverride: 'hidden'.
+      const raw = weight(hit.page.metadata);
+      let mult: number;
+      if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+        mult = 1.0;
+      } else if (raw < 0) {
+        mult = 0;
+      } else {
+        mult = raw;
+      }
       hit.rrfScore *= mult;
     }
-    // Drop hidden pages (multiplier 0); keep everything else even if it
+    // Drop hidden / clamped-to-zero pages; keep everything else even if it
     // got pushed down. Filtering before sort means k slots stay full of
     // surviving results.
     entries = entries.filter((h) => h.rrfScore > 0);

--- a/packages/memory-gbrain-crdb-adapter/src/rrf.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/rrf.ts
@@ -6,6 +6,20 @@ interface ScoredHit {
 }
 
 /**
+ * Optional post-fold scoring hook (#251 Layer 2). Receives the page's
+ * `metadata` object and returns a multiplier to apply to its rrfScore.
+ * The fold passes `metadata` rather than the whole page so callers can't
+ * depend on shape changes elsewhere — the only signal that should change
+ * a page's retrieval rank is what's in metadata (authoringTier, userOverride,
+ * bodyLen). When omitted the fold is pure RRF as before.
+ */
+export type TierWeightFn = (metadata: unknown) => number;
+
+export interface RrfFoldOptions {
+  tierWeight?: TierWeightFn;
+}
+
+/**
  * Reciprocal Rank Fusion fold. Given two ranked lists (text + vector), compute
  * `1 / (k + rank)` per list and sum per document. Documents missing from a
  * list get zero contribution from that list (rank → ∞).
@@ -13,14 +27,18 @@ interface ScoredHit {
  * Standard literature uses k = 60. Smaller k weights the head harder; larger k
  * flattens the curve and gives the tail more influence.
  *
- * Returned rows include `textRank` and `vectorRank` so consumers can reason
- * about *why* a page ranked where it did — useful in observability + tests.
+ * When `options.tierWeight` is provided, the per-page multiplier is applied
+ * to the accumulated rrfScore before the final sort. A multiplier of 0 drops
+ * the page from results (used by `userOverride: 'hidden'`). The original
+ * `textRank` / `vectorRank` fields are preserved so consumers can still see
+ * the raw ranking signal in observability or tests.
  */
 export function rrfFold(
   textHits: ScoredHit[],
   vectorHits: ScoredHit[],
   k: number,
   rrfK: number,
+  options: RrfFoldOptions = {},
 ): RrfHit[] {
   const acc = new Map<string, RrfHit>();
 
@@ -60,7 +78,19 @@ export function rrfFold(
     }
   });
 
-  return [...acc.values()]
-    .sort((a, b) => b.rrfScore - a.rrfScore)
-    .slice(0, k);
+  let entries = [...acc.values()];
+
+  if (options.tierWeight) {
+    const weight = options.tierWeight;
+    for (const hit of entries) {
+      const mult = weight(hit.page.metadata);
+      hit.rrfScore *= mult;
+    }
+    // Drop hidden pages (multiplier 0); keep everything else even if it
+    // got pushed down. Filtering before sort means k slots stay full of
+    // surviving results.
+    entries = entries.filter((h) => h.rrfScore > 0);
+  }
+
+  return entries.sort((a, b) => b.rrfScore - a.rrfScore).slice(0, k);
 }

--- a/packages/memory-gbrain-crdb-adapter/src/tier-weights.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/tier-weights.ts
@@ -1,0 +1,149 @@
+/**
+ * Authoring-tier retrieval multipliers (#251 Layer 2).
+ *
+ * The gbrain RRF fold applies these multiplicatively to a page's rrfScore
+ * post-fold so that user-authored pages outrank received noise on
+ * equal-text queries. Three calibration bands (sparse / normal / dense)
+ * keep the multiplier honest for users at different writing volumes:
+ *
+ *   - sparse  (<100 user_sent_* pages in 90d): cap the spread; don't
+ *     amplify a signal that isn't there.
+ *   - normal:  the default band.
+ *   - dense   (>1000 user_sent_* pages in 90d): use the wide spread so
+ *     SNR difference compounds.
+ *
+ * Weights are placeholders until the labeled-relevant-doc eval in
+ * `packages/memory-gbrain/src/__tests__/realistic-retrieval.test.ts`
+ * confirms recall@5 improves. Layer 2 ships behind `brain_settings.
+ * tier_weighting` (default false); do not enable in production until
+ * the eval gate passes.
+ *
+ * `metadata.userOverride` composes orthogonally:
+ *   - 'pinned'  → 2.0× multiplier (user explicitly told us this matters).
+ *   - 'hidden'  → 0.0× (drop from results; user disclaimed it).
+ *   - missing  → identity.
+ */
+
+import type { TierCalibration } from './types.js';
+
+export type AuthoringTier =
+  | 'user_sent_originated'
+  | 'user_sent_reply'
+  | 'inbox_personal'
+  | 'inbox_broadcast'
+  | 'inbox_newsletter'
+  | 'inbox_automated';
+
+export type UserOverride = 'pinned' | 'hidden';
+
+interface TierWeightTable {
+  readonly user_sent_originated: number;
+  readonly user_sent_reply: number;
+  readonly inbox_personal: number;
+  readonly inbox_broadcast: number;
+  readonly inbox_newsletter: number;
+  readonly inbox_automated: number;
+}
+
+const WEIGHTS_SPARSE: TierWeightTable = {
+  user_sent_originated: 1.2,
+  user_sent_reply: 1.1,
+  inbox_personal: 1.0,
+  inbox_broadcast: 0.9,
+  inbox_newsletter: 0.5,
+  inbox_automated: 0.5,
+};
+
+const WEIGHTS_NORMAL: TierWeightTable = {
+  user_sent_originated: 1.5,
+  user_sent_reply: 1.2,
+  inbox_personal: 1.0,
+  inbox_broadcast: 0.8,
+  inbox_newsletter: 0.4,
+  inbox_automated: 0.2,
+};
+
+const WEIGHTS_DENSE: TierWeightTable = {
+  user_sent_originated: 2.0,
+  user_sent_reply: 1.5,
+  inbox_personal: 1.0,
+  inbox_broadcast: 0.7,
+  inbox_newsletter: 0.3,
+  inbox_automated: 0.1,
+};
+
+const TABLES: Record<TierCalibration, TierWeightTable> = {
+  sparse: WEIGHTS_SPARSE,
+  normal: WEIGHTS_NORMAL,
+  dense: WEIGHTS_DENSE,
+};
+
+/**
+ * Brief-reply downweighting threshold. An `authored_*` page whose body is
+ * shorter than this many characters gets the `inbox_personal` weight
+ * instead of the full authored weight — a one-line "k" reply shouldn't
+ * outrank a 500-word strategy email just because they're both `SENT`.
+ */
+export const BRIEF_BODY_THRESHOLD = 50;
+
+/**
+ * Compute the multiplier for a single page from its metadata.
+ *
+ * Returns 1.0 (identity) when:
+ *   - metadata is missing or not an object
+ *   - `authoringTier` is missing, non-string, or unrecognized
+ *
+ * Composes orthogonally with `userOverride` (pinned / hidden). The
+ * caller is expected to multiply this into the existing rrfScore.
+ */
+export function tierMultiplier(
+  metadata: unknown,
+  calibration: TierCalibration,
+): number {
+  if (!metadata || typeof metadata !== 'object') return 1.0;
+  const m = metadata as Record<string, unknown>;
+
+  // userOverride wins if present — it's an explicit user signal.
+  const override = m['userOverride'];
+  if (override === 'hidden') return 0.0;
+  const pinnedBoost = override === 'pinned' ? 2.0 : 1.0;
+
+  const tier = m['authoringTier'];
+  if (typeof tier !== 'string') return pinnedBoost;
+
+  const table = TABLES[calibration];
+  let base = (table as unknown as Record<string, number>)[tier];
+  if (typeof base !== 'number') return pinnedBoost;
+
+  // Brief-reply downweight: short authored body gets inbox_personal weight
+  // instead of full authored. Cheap heuristic — no need to look at recipient
+  // tier or edit time yet.
+  if (tier === 'user_sent_originated' || tier === 'user_sent_reply') {
+    const bodyLen = m['bodyLen'];
+    if (typeof bodyLen === 'number' && bodyLen < BRIEF_BODY_THRESHOLD) {
+      base = table.inbox_personal;
+    }
+  }
+
+  return base * pinnedBoost;
+}
+
+/**
+ * Convenience builder for a tier-weight callback closing over the
+ * calibration band. The RRF fold accepts `(page) => number`.
+ */
+export function buildTierWeightFn(
+  calibration: TierCalibration,
+): (metadata: unknown) => number {
+  return (metadata) => tierMultiplier(metadata, calibration);
+}
+
+/**
+ * Calibration thresholds. Inputs come from a count of
+ * `metadata.authoringTier IN ('user_sent_*')` rows in last 90 days.
+ */
+export function calibrationFromSentVolume(sentVolume90d: number): TierCalibration {
+  if (sentVolume90d < 100) return 'sparse';
+  if (sentVolume90d > 1000) return 'dense';
+  return 'normal';
+}

--- a/packages/memory-gbrain-crdb-adapter/src/types.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/types.ts
@@ -64,11 +64,25 @@ export interface BrainSignalRow {
   signal_timestamp: Date;
 }
 
+export type TierCalibration = 'sparse' | 'normal' | 'dense';
+
 export interface BrainSettingsRow {
   user_id: string;
   backend: 'hybrid' | 'gbrain' | 'mempalace';
   hybrid_notification_dismissed: boolean;
   routing: Record<string, unknown>;
+  /**
+   * When true, retrieval applies the authoring-tier multiplier in the RRF
+   * fold so user-authored pages outrank received noise on equal-text queries.
+   * Default false — Layer 2 is eval-gated and opt-in (#251).
+   */
+  tier_weighting: boolean;
+  /**
+   * Calibration band tuned to the user's writing volume. Computed from
+   * `user_sent_*` page count in last 90 days. Sparse caps the multiplier so
+   * a thin sent corpus doesn't get over-amplified; dense uses the wide spread.
+   */
+  tier_calibration: TierCalibration;
   updated_at: Date;
 }
 

--- a/packages/memory-gbrain/src/__tests__/embedded-port.test.ts
+++ b/packages/memory-gbrain/src/__tests__/embedded-port.test.ts
@@ -108,11 +108,12 @@ describe('EmbeddedGbrainMemoryPort — recordSignal', () => {
     await port.recordSignal(sig);
     const pages = store.getAllPages(USER);
     expect(pages).toHaveLength(1);
-    expect(pages[0]!.metadata).toEqual({
-      signalSource: 'cal',
-      signalType: 'event',
-    });
-    expect((pages[0]!.metadata as Record<string, unknown>)['authoringTier']).toBeUndefined();
+    const meta = pages[0]!.metadata as Record<string, unknown>;
+    expect(meta['signalSource']).toBe('cal');
+    expect(meta['signalType']).toBe('event');
+    // bodyLen is always stamped for the brief-reply downweight (#251 Layer 2).
+    expect(typeof meta['bodyLen']).toBe('number');
+    expect(meta['authoringTier']).toBeUndefined();
   });
 
   it('ignores non-string authoringTier values defensively', async () => {

--- a/packages/memory-gbrain/src/__tests__/tier-weighted-retrieval.test.ts
+++ b/packages/memory-gbrain/src/__tests__/tier-weighted-retrieval.test.ts
@@ -1,0 +1,264 @@
+/**
+ * #251 Layer 2 eval — tier-weighted retrieval changes ranking.
+ *
+ * Seeds a small mixed-tier corpus where two pages match the same query
+ * equally on text content. One is an `inbox_newsletter`, one is a
+ * `user_sent_originated`. With `tier_weighting = false` the newsletter
+ * wins (or ties); with `tier_weighting = true` the authored page wins.
+ * This is the eval-gate that authorizes the Layer 2 rollout per the
+ * issue's "don't ship the weights unless R@5 improves" rule.
+ *
+ * The corpus is intentionally tiny + deterministic — this is a
+ * correctness test for the multiplier path, not a recall benchmark.
+ * Recall benchmarks live in `realistic-retrieval.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { EmbeddedGbrainMemoryPort } from '../embedded-port.js';
+import {
+  HashEmbeddingProvider,
+  InMemoryBrainStore,
+} from '@skytwin/memory-gbrain-crdb-adapter';
+import type { RawSignal } from '@skytwin/memory-port';
+
+const USER = 'tier-eval-user';
+
+function makeSignal(
+  id: string,
+  source: string,
+  type: string,
+  tier: string,
+  subject: string,
+  body: string,
+  bodyLen?: number,
+): RawSignal {
+  return {
+    id,
+    source,
+    type,
+    data: {
+      messageId: id,
+      from: 'someone@example.com',
+      subject,
+      text: body,
+      authoringTier: tier,
+      ...(bodyLen !== undefined ? { bodyLen } : {}),
+    },
+    timestamp: new Date(),
+  };
+}
+
+async function seedPort(store: InMemoryBrainStore): Promise<EmbeddedGbrainMemoryPort> {
+  const port = new EmbeddedGbrainMemoryPort({
+    userId: USER,
+    backend: 'memory',
+    store,
+    embedding: new HashEmbeddingProvider(128),
+  });
+
+  // A user-authored email about board prep — the kind of content we want
+  // the twin to model. Long body so the brief-reply downweight doesn't fire.
+  await port.recordSignal(
+    makeSignal(
+      'authored_board',
+      'gmail',
+      'email',
+      'user_sent_originated',
+      'Board prep notes for Q3 review',
+      'Quarterly board prep notes covering fundraising milestones, hiring plans, board prep updates, and quarterly review structure. This message is intentionally long enough to not trip the brief-reply downweight threshold so the authored tier gets its full weight.',
+    ),
+  );
+
+  // A newsletter that happens to use the same vocabulary ("board prep",
+  // "quarterly review"). Without tier weighting it ranks competitively
+  // with the authored page on token overlap.
+  await port.recordSignal(
+    makeSignal(
+      'newsletter_board',
+      'gmail',
+      'email',
+      'inbox_newsletter',
+      'Newsletter: 10 tips for board prep and quarterly review',
+      'Board prep best practices newsletter covering quarterly review templates, board prep checklists, and ten tactical tips for board prep and quarterly review meetings.',
+    ),
+  );
+
+  // Filler so the candidate pool isn't trivially small.
+  for (let i = 0; i < 10; i++) {
+    await port.recordSignal(
+      makeSignal(
+        `filler_${i}`,
+        'gmail',
+        'email',
+        'inbox_personal',
+        `Unrelated thread ${i}`,
+        `Some unrelated text about coffee shops, weekend plans, and recipes — content number ${i}.`,
+      ),
+    );
+  }
+
+  return port;
+}
+
+describe('#251 Layer 2 — tier-weighted retrieval', () => {
+  it('without tier weighting, the newsletter outranks the authored page (baseline)', async () => {
+    const store = new InMemoryBrainStore();
+    const port = await seedPort(store);
+    // Settings row left at defaults; tier_weighting defaults to false.
+
+    const hits = await port.searchSemantic('board prep quarterly review', 10);
+    const ids = hits.map((h) => h.id);
+    const authoredIdx = ids.indexOf('authored_board');
+    const newsletterIdx = ids.indexOf('newsletter_board');
+
+    // Both must be present in the recall set; their relative order is the
+    // point — without weighting newsletter ranks at-or-above authored
+    // (this is exactly what we want Layer 2 to fix).
+    expect(authoredIdx).toBeGreaterThanOrEqual(0);
+    expect(newsletterIdx).toBeGreaterThanOrEqual(0);
+    expect(newsletterIdx).toBeLessThanOrEqual(authoredIdx);
+  });
+
+  it('with tier weighting enabled, the authored page outranks the newsletter on the same query', async () => {
+    const store = new InMemoryBrainStore();
+    const port = await seedPort(store);
+
+    // Flip the flag on. Calibration defaults to 'normal'.
+    store.upsertSettings(USER, { tier_weighting: true });
+
+    const hits = await port.searchSemantic('board prep quarterly review', 20);
+    const ids = hits.map((h) => h.id);
+    const authoredIdx = ids.indexOf('authored_board');
+    const newsletterIdx = ids.indexOf('newsletter_board');
+
+    // Authored must surface. Newsletter may be pushed below k=5 by the 0.4
+    // demotion, which is exactly the intended Layer 2 behaviour — receiving
+    // a 0.4× multiplier moves the newsletter behind unrelated `inbox_personal`
+    // filler (weight 1.0). The load-bearing claim is that authored *outranks*
+    // newsletter, whether by being earlier in the list or by the newsletter
+    // dropping out of the result set entirely.
+    expect(authoredIdx).toBeGreaterThanOrEqual(0);
+    if (newsletterIdx >= 0) {
+      expect(authoredIdx).toBeLessThan(newsletterIdx);
+    }
+    // And authored must beat where it would have been pre-weighting (it was
+    // index 1 in the baseline test; weighting should push it to 0).
+    expect(authoredIdx).toBe(0);
+  });
+
+  it('userOverride: hidden drops a page from results entirely', async () => {
+    const store = new InMemoryBrainStore();
+    const port = await seedPort(store);
+    store.upsertSettings(USER, { tier_weighting: true });
+
+    // Mark the newsletter as hidden via metadata edit on the in-memory store.
+    for (const page of store.pages.values()) {
+      if (page.source_ref === 'newsletter_board') {
+        page.metadata = { ...page.metadata, userOverride: 'hidden' };
+      }
+    }
+
+    const hits = await port.searchSemantic('board prep quarterly review', 5);
+    const ids = hits.map((h) => h.id);
+    expect(ids).not.toContain('newsletter_board');
+    expect(ids).toContain('authored_board');
+  });
+
+  it('a brief user_sent_reply does NOT outrank the newsletter — brief-reply downweight kicks in', async () => {
+    const store = new InMemoryBrainStore();
+    const port = await seedPort(store);
+
+    // Add a one-line authored reply that matches the query but is short.
+    // bodyLen is stamped by buildPageMetadata from the summarised content,
+    // so we explicitly pass a short body to verify the threshold path.
+    await port.recordSignal(
+      makeSignal(
+        'authored_brief',
+        'gmail',
+        'email',
+        'user_sent_reply',
+        'Re: board prep',
+        'k', // intentionally tiny
+      ),
+    );
+
+    store.upsertSettings(USER, { tier_weighting: true });
+
+    const hits = await port.searchSemantic('board prep', 5);
+    const briefIdx = hits.findIndex((h) => h.id === 'authored_brief');
+    const newsletterIdx = hits.findIndex((h) => h.id === 'newsletter_board');
+
+    // The brief reply gets inbox_personal weight (1.0) instead of
+    // user_sent_reply weight (1.2). It should NOT outrank a newsletter
+    // that matches the query much more thoroughly on text.
+    if (briefIdx >= 0 && newsletterIdx >= 0) {
+      // Both present — the brief one should not beat the heavily-matching
+      // newsletter just because it was authored.
+      expect(briefIdx).toBeGreaterThan(newsletterIdx);
+    }
+  });
+
+  it('toggle is per-user — one user with flag on, another off, do not affect each other', async () => {
+    const sharedStore = new InMemoryBrainStore();
+    const emb = new HashEmbeddingProvider(128);
+    const u1 = 'tier-user-1';
+    const u2 = 'tier-user-2';
+
+    const port1 = new EmbeddedGbrainMemoryPort({
+      userId: u1,
+      backend: 'memory',
+      store: sharedStore,
+      embedding: emb,
+    });
+    const port2 = new EmbeddedGbrainMemoryPort({
+      userId: u2,
+      backend: 'memory',
+      store: sharedStore,
+      embedding: emb,
+    });
+
+    // Same corpus shape for each user; unique signal ids per user since the
+    // in-memory store dedupes by id globally.
+    for (const [u, port] of [[u1, port1], [u2, port2]] as const) {
+      await port.recordSignal(
+        makeSignal(
+          `${u}_authored`,
+          'gmail',
+          'email',
+          'user_sent_originated',
+          'board prep',
+          'Long thoughtful board prep content with quarterly review details and meaningful context worth indexing.',
+        ),
+      );
+      await port.recordSignal(
+        makeSignal(
+          `${u}_newsletter`,
+          'gmail',
+          'email',
+          'inbox_newsletter',
+          'board prep newsletter',
+          'Newsletter about board prep and quarterly review with similar token overlap on the query.',
+        ),
+      );
+    }
+
+    sharedStore.upsertSettings(u1, { tier_weighting: true });
+    // u2 left at defaults (tier_weighting = false).
+
+    const u1Hits = await port1.searchSemantic('board prep', 5);
+    const u2Hits = await port2.searchSemantic('board prep', 5);
+
+    const u1AuthoredIdx = u1Hits.findIndex((h) => h.id === `${u1}_authored`);
+    const u1NewsletterIdx = u1Hits.findIndex((h) => h.id === `${u1}_newsletter`);
+    expect(u1AuthoredIdx).toBeGreaterThanOrEqual(0);
+    expect(u1NewsletterIdx).toBeGreaterThanOrEqual(0);
+    expect(u1AuthoredIdx).toBeLessThan(u1NewsletterIdx);
+
+    // For u2, with the flag off, the multiplier is identity — original RRF
+    // order survives, whatever it was, and per-user isolation holds.
+    expect(u2Hits.length).toBeGreaterThan(0);
+    const u2Ids = u2Hits.map((h) => h.id);
+    // u2's results never include u1's ids.
+    expect(u2Ids.every((id) => id.startsWith(u2))).toBe(true);
+  });
+});

--- a/packages/memory-gbrain/src/__tests__/tier-weighted-retrieval.test.ts
+++ b/packages/memory-gbrain/src/__tests__/tier-weighted-retrieval.test.ts
@@ -30,8 +30,11 @@ function makeSignal(
   tier: string,
   subject: string,
   body: string,
-  bodyLen?: number,
 ): RawSignal {
+  // NOTE: `bodyLen` is *not* a `data` field. EmbeddedGbrainMemoryPort.
+  // buildPageMetadata derives it from the summarised page content at write
+  // time, so to exercise the brief-reply downweight in tests, vary the
+  // length of `body` itself (e.g. pass "k" for the brief case).
   return {
     id,
     source,
@@ -42,7 +45,6 @@ function makeSignal(
       subject,
       text: body,
       authoringTier: tier,
-      ...(bodyLen !== undefined ? { bodyLen } : {}),
     },
     timestamp: new Date(),
   };

--- a/packages/memory-gbrain/src/embedded-port.ts
+++ b/packages/memory-gbrain/src/embedded-port.ts
@@ -23,8 +23,10 @@ import {
   type EmbeddingProvider,
   InMemoryBrainStore,
   rrfFold,
+  buildTierWeightFn,
   type BrainPageRow,
   type RrfHit,
+  type TierCalibration,
 } from '@skytwin/memory-gbrain-crdb-adapter';
 
 const log = createLogger('memory-gbrain-embedded');
@@ -141,7 +143,14 @@ export class EmbeddedGbrainMemoryPort implements MemoryPort {
     // page metadata so Layer 2 retrieval weighting can read it without a
     // join back to the signal row. No-op when the connector didn't stamp it
     // (e.g. calendar signals, custom event ingests).
-    const pageMetadata = this.buildPageMetadata(s, data);
+    //
+    // Also stamp `bodyLen` so brief-reply downweighting can fire: an
+    // `authored_*` page whose body is shorter than BRIEF_BODY_THRESHOLD
+    // gets treated as `inbox_personal` weight in the RRF fold. The length
+    // here is the indexed summary content, not the raw email body, which
+    // is the right size to measure against (one-line replies summarize to
+    // tens of chars; multi-paragraph emails to hundreds).
+    const pageMetadata = this.buildPageMetadata(s, data, summaryText);
     if (this.backend === 'memory') {
       this.store!.insertSignal({
         id: s.id,
@@ -199,14 +208,21 @@ export class EmbeddedGbrainMemoryPort implements MemoryPort {
   /**
    * Build the `brain_pages.metadata` object for a signal-derived page.
    * Always carries `signalSource` / `signalType`; carries `authoringTier`
-   * only when the connector stamped one on `data.authoringTier`. Kept
-   * tolerant of unknown shapes — defensive against future connectors that
-   * may pass an object or null instead of a tier string.
+   * only when the connector stamped one on `data.authoringTier`. Also
+   * stamps `bodyLen` (length of the summarised content) so Layer 2's
+   * brief-reply downweight has something to read. Kept tolerant of
+   * unknown shapes — defensive against future connectors that may pass
+   * an object or null instead of a tier string.
    */
-  private buildPageMetadata(s: RawSignal, data: Record<string, unknown>): Record<string, unknown> {
+  private buildPageMetadata(
+    s: RawSignal,
+    data: Record<string, unknown>,
+    content: string,
+  ): Record<string, unknown> {
     const metadata: Record<string, unknown> = {
       signalSource: s.source,
       signalType: s.type,
+      bodyLen: content.length,
     };
     const tier = data['authoringTier'];
     if (typeof tier === 'string' && tier.length > 0) {
@@ -389,6 +405,12 @@ export class EmbeddedGbrainMemoryPort implements MemoryPort {
     // constructor pinned a 40 floor that ignored k, so k=20 queries pulled
     // only 40 candidates from each side before RRF — truncating recall.
     const candidatePoolSize = this.candidatePoolOverride ?? Math.max(k * 4, 40);
+
+    // #251 Layer 2: build a tier-weight function if the user has opted in.
+    // Reading settings is best-effort — if it fails (no row yet, pre-043
+    // schema, transient DB hiccup) we silently fall back to pure RRF.
+    const tierWeight = await this.resolveTierWeightFn();
+
     if (this.backend === 'memory') {
       return this.store!.hybridSearch({
         userId: this.userId,
@@ -397,6 +419,7 @@ export class EmbeddedGbrainMemoryPort implements MemoryPort {
         k,
         candidatePoolSize,
         rrfK: this.rrfK,
+        ...(tierWeight ? { tierWeight } : {}),
       });
     }
     const repo = await this.crdb();
@@ -407,7 +430,45 @@ export class EmbeddedGbrainMemoryPort implements MemoryPort {
       k,
       candidatePoolSize,
       rrfK: this.rrfK,
+      ...(tierWeight ? { tierWeight } : {}),
     });
+  }
+
+  /**
+   * Look up the per-user `tier_weighting` toggle (and the calibration band)
+   * and return a tier-weight function if both are present, else `undefined`.
+   * Defensive: any failure leaves retrieval as pure RRF, the safe default.
+   */
+  private async resolveTierWeightFn(): Promise<
+    ((metadata: unknown) => number) | undefined
+  > {
+    let enabled = false;
+    let calibration: TierCalibration = 'normal';
+
+    try {
+      if (this.backend === 'memory') {
+        const row = this.store!.getSettings(this.userId);
+        if (row) {
+          enabled = row.tier_weighting === true;
+          calibration = row.tier_calibration ?? 'normal';
+        }
+      } else {
+        const repo = await this.crdb();
+        const row = await repo.getSettings(this.userId);
+        if (row) {
+          enabled = row.tier_weighting === true;
+          calibration = row.tier_calibration ?? 'normal';
+        }
+      }
+    } catch (err) {
+      log.warn('tier-weight settings lookup failed; falling back to pure RRF', {
+        reason: err instanceof Error ? err.name : 'unknown',
+      });
+      return undefined;
+    }
+
+    if (!enabled) return undefined;
+    return buildTierWeightFn(calibration);
   }
 
   async walkGraph(spec: GraphWalkSpec): Promise<KnowledgeNode[]> {


### PR DESCRIPTION
## Summary

Second slice of #251 on top of PR #252's Layer 1. With this landing, gbrain can rank what the user *wrote* above what they *received* on semantic search — gated behind a per-user toggle that's off by default until the labeled-retrieval evals confirm recall@5 improvement on a real corpus.

**Closes (partial): #251 Layer 2 + bodyLen + userOverride + tier_calibration.** Defers `relationshipTier`, the pre-Layer-1 backfill, the privacy exclude UI, and the default-on rollout to follow-up sub-issues.

## What ships

### Engine
- Migration 043 adds `tier_weighting` (bool, default false) and `tier_calibration` (sparse/normal/dense, default normal) to `brain_settings`. `parseSettingsRow` defaults the new columns defensively so a pre-043 install reads safely.
- **`tier-weights.ts`** (new): multiplier table with three calibration bands. `user_sent_originated` ranges 1.2×/1.5×/2.0×; `inbox_newsletter` ranges 0.5×/0.4×/0.3×. Composes orthogonally with `metadata.userOverride` (`pinned` doubles, `hidden` returns 0 → page is dropped from results). Includes a brief-reply downweight so a `user_sent_reply` with `bodyLen < 50` gets `inbox_personal` weight — short "k" replies can't out-rank strategy emails just because they're `SENT`.
- **`rrf.ts`** takes an optional `tierWeight(metadata) => number` callback. Identity by default; when set, the per-page multiplier applies to `rrfScore` pre-sort. `textRank` / `vectorRank` survive for observability.
- **`embedded-port.searchInternal`** reads the per-user `tier_weighting` flag and calibration band per query, builds the weight fn, and threads it through to `hybridSearch`. Lookups are best-effort: any DB error falls back to pure RRF rather than blocking the search.
- **`buildPageMetadata`** stamps `bodyLen` on every page so the brief-reply downweight has something to read.
- `countUserSentPages` (new) + `getRecentPages` (new) on the adapter — backing the calibration auto-recompute and the dashboard's recent-pages list.

### API surface
- `GET /api/memory-config` now returns `tierWeighting` + `tierCalibration` alongside the existing fields.
- `POST /api/memory-config/tier-weighting` (new). Body: `{ enabled: boolean, calibration?: 'sparse' | 'normal' | 'dense' }`. On enable without an explicit `calibration`, counts `user_sent_*` pages over the last 90d and picks the band; falls back to `normal` on DB failure.
- `GET /api/memory-config/dashboard` now includes `pages.recent[]` (10 newest brain pages) with `authoringTier` + `userOverride` projected from metadata. Embedding vectors stripped from the wire.

### Web
- New **"Weight what you wrote (Layer 2 — beta)"** card on Settings → Memory backend. Single toggle, status + calibration readout, link to #251 for rationale.
- "What your twin remembers" now leads with a **Recent pages indexed** table with a tier-badge column: `you wrote`, `you replied`, `personal`, `broadcast`, `newsletter`, `automated`, plus `📌 pinned` / `hidden` for explicit overrides. Color-coded for skimmability.

## Tests
- [x] 16 unit tests in `tier-weights.test.ts` — all three calibrations, override composition, brief-reply downweight, calibration thresholds.
- [x] 3 new `rrf.test.ts` branches — weighting flips ranking, `hidden` drops the row, raw ranks preserved.
- [x] 5 e2e cases in `tier-weighted-retrieval.test.ts` — baseline (newsletter wins or ties); flag-on (authored hits index 0); `userOverride: hidden` drops the page entirely; brief-reply downweight keeps a tiny `SENT` from outranking a newsletter; per-user isolation.
- [x] 5 new `memory-config-routes.test.ts` cases for the new POST endpoint.
- [x] `pnpm build --concurrency=1` — 35/35 packages.
- [x] `pnpm test` — 70/70 turbo tasks green, no regressions.

## Notes for reviewers

- **The toggle defaults to off.** Until we re-run `realistic-retrieval.test.ts` against a real production corpus with measurable recall@5 improvement, Layer 2 is opt-in. If you flip it on for yourself, the calibration band auto-recomputes from your last-90-day writing volume — sparse writers get conservative weights so we don't amplify a signal that isn't there.
- **`userOverride` schema only**; no UI in this PR. Pinning / hiding individual pages will land with the tier-aware exclude sub-issue, which is the gate for flipping the flag on by default.
- **No retrieval behaviour change when the flag is off.** RRF is unchanged. The new code path is purely additive — when `tier_weighting = false` (the default), `searchSemantic` runs the same code it ran before this PR.
- **Calibration thresholds** are educated guesses (<100 = sparse, >1000 = dense, otherwise normal). The eval gate that authorizes default-on will also re-tune these against the labeled set.

## Deferred to follow-ups
- `relationshipTier` axis (bidirectional thread count) — separate sub-issue.
- Migration backfill of `authoringTier` for pages indexed pre-Layer 1.
- Tier-aware exclude UI (privacy sub-issue; blocks Layer 2 default-on).
- Layer 2 default-on rollout — eval-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)