### PR TITLE
feat(#251 follow-up): tier-aware privacy controls — pin / hide / hide-sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Tier-aware privacy controls: pin / hide / hide-sender (#251 follow-up)
+
+The memory dashboard's "Recent pages indexed" table now shows three action buttons per row: **Pin**, **Hide**, and **Hide sender**. The first two flip `metadata.userOverride` between `'pinned'`, `'hidden'`, and unset (the gbrain RRF fold already reads this — pinned doubles the rrfScore, hidden drops the page from search entirely). The third one bulk-hides every indexed page from the same sender — useful for tidying out a newsletter or transactional sender you don't want the twin learning from.
+
+This is the privacy guardrail that gates Layer 2's default-on rollout. With it in place, users can keep tier-weighting enabled while still curating what the twin treats as signal.
+
+### Engine work
+
+- **`buildPageMetadata`** in `EmbeddedGbrainMemoryPort` now stamps `fromAddress` (lower-cased bare address from `data.from`) on every page that carries one. The bulk-hide action queries against this field, so it's a precondition for the sender action being useful. No schema change — `metadata` is JSONB.
+- **`updatePageMetadata(userId, pageId, patch)`** (new repository helper): merges a JSONB patch into the page's metadata column, scoped by `user_id` so a caller can't mutate someone else's pages even if they hold a guessable id. Returns affected row count; 0 maps to 404 at the route layer.
+- **`hideAllPagesFromSender(userId, fromAddress)`** (new): bulk `UPDATE` that sets `metadata.userOverride='hidden'` on every page where `metadata->>'fromAddress'` matches the supplied address (lower-cased). Returns affected row count for "hid N pages from X" toast feedback.
+- Both helpers have matching in-memory mirrors for tests.
+
+### API surface
+
+- **`POST /api/memory-config/pages/:pageId/override`**. Body `{ override: 'pinned' | 'hidden' | null }`. 404 when the page doesn't exist or belongs to another user (deliberately doesn't distinguish, so a caller can't probe for foreign page-id existence).
+- **`POST /api/memory-config/senders/hide`**. Body `{ fromAddress: string }`. Returns `{ ok: true, fromAddress, hidden: <count> }`.
+- `GET /api/memory-config/dashboard` now includes `pages.recent[].fromAddress` so the UI knows what to send to the sender endpoint.
+
+### Web
+
+- New per-row actions on the Recent pages indexed table: Pin / Unpin, Hide / Unhide, Hide sender. Buttons swap their action depending on current state. The sender button only appears for pages with a `fromAddress` (i.e. email-derived). The bulk action surfaces a confirmation prompt before firing (since one click can hide hundreds of rows).
+
+### Tests
+
+- 5 new unit tests on the in-memory repository: `updatePageMetadata` merges + respects user ownership + 404s on missing pages; `hideAllPagesFromSender` matches case-insensitively, scopes by user, and reports 0 when nothing matches.
+- 3 new embedded-port tests: `fromAddress` stamping lower-cases display-name addresses, handles bare addresses, omits when `data.from` is missing.
+- 6 new memory-config-routes tests: per-page override rejects bogus values, accepts pinned/hidden/null, 404s on missing pages; sender bulk-hide rejects missing `fromAddress`, lower-cases on the wire, surfaces affected count; dashboard payload includes `userOverride` + `fromAddress`.
+
 ## [unreleased] — Layer 2 ablation eval + tuned multipliers + floor-ratio gate (#251 follow-up)
 
 Stood up a labeled-retrieval ablation eval at

--- a/apps/api/src/__tests__/memory-config-routes.test.ts
+++ b/apps/api/src/__tests__/memory-config-routes.test.ts
@@ -25,6 +25,8 @@ const {
   mockPendingJobs,
   mockCountUserSentPages,
   mockGetRecentPages,
+  mockUpdatePageMetadata,
+  mockHideAllPagesFromSender,
 } = vi.hoisted(() => ({
   mockGetSettings: vi.fn(),
   mockUpsertSettings: vi.fn(),
@@ -32,6 +34,8 @@ const {
   mockPendingJobs: vi.fn(),
   mockCountUserSentPages: vi.fn(),
   mockGetRecentPages: vi.fn(),
+  mockUpdatePageMetadata: vi.fn(),
+  mockHideAllPagesFromSender: vi.fn(),
 }));
 
 vi.mock('@skytwin/memory-gbrain-crdb-adapter', async () => {
@@ -45,6 +49,8 @@ vi.mock('@skytwin/memory-gbrain-crdb-adapter', async () => {
     pendingEmbeddingJobs: mockPendingJobs,
     countUserSentPages: mockCountUserSentPages,
     getRecentPages: mockGetRecentPages,
+    updatePageMetadata: mockUpdatePageMetadata,
+    hideAllPagesFromSender: mockHideAllPagesFromSender,
   };
 });
 
@@ -121,6 +127,8 @@ beforeEach(() => {
   mockGetEntities.mockResolvedValue([]);
   mockCountUserSentPages.mockResolvedValue(0);
   mockGetRecentPages.mockResolvedValue([]);
+  mockUpdatePageMetadata.mockResolvedValue(1);
+  mockHideAllPagesFromSender.mockResolvedValue(0);
   mockUpsertSettings.mockResolvedValue({
     user_id: USER_ID,
     backend: 'gbrain',
@@ -484,5 +492,105 @@ describe('POST /api/memory-config/tier-weighting (#251 Layer 2)', () => {
       tier_weighting: true,
       tier_calibration: 'normal',
     });
+  });
+});
+
+describe('POST /api/memory-config/pages/:pageId/override (#251 privacy)', () => {
+  it('rejects an invalid override value', async () => {
+    const app = buildApp();
+    const res = await request(
+      app,
+      'POST',
+      `/api/memory-config/pages/page-1/override?userId=${USER_ID}`,
+      { override: 'bogus' },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts pinned + hidden + null and writes a metadata patch', async () => {
+    const app = buildApp();
+    for (const value of ['pinned', 'hidden', null]) {
+      mockUpdatePageMetadata.mockResolvedValueOnce(1);
+      const res = await request(
+        app,
+        'POST',
+        `/api/memory-config/pages/page-1/override?userId=${USER_ID}`,
+        { override: value },
+      );
+      expect(res.status).toBe(200);
+      expect(mockUpdatePageMetadata).toHaveBeenCalledWith(USER_ID, 'page-1', {
+        userOverride: value,
+      });
+    }
+  });
+
+  it('returns 404 when the adapter reports zero affected rows', async () => {
+    mockUpdatePageMetadata.mockResolvedValueOnce(0);
+    const app = buildApp();
+    const res = await request(
+      app,
+      'POST',
+      `/api/memory-config/pages/page-foreign/override?userId=${USER_ID}`,
+      { override: 'pinned' },
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/memory-config/senders/hide (#251 privacy)', () => {
+  it('rejects a missing or non-string fromAddress', async () => {
+    const app = buildApp();
+    const res = await request(
+      app,
+      'POST',
+      `/api/memory-config/senders/hide?userId=${USER_ID}`,
+      {},
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('passes the lower-cased fromAddress and reports the affected count', async () => {
+    mockHideAllPagesFromSender.mockResolvedValueOnce(7);
+    const app = buildApp();
+    const res = await request(
+      app,
+      'POST',
+      `/api/memory-config/senders/hide?userId=${USER_ID}`,
+      { fromAddress: 'Spam@Vendor.Example.com' },
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      fromAddress: 'spam@vendor.example.com',
+      hidden: 7,
+    });
+    expect(mockHideAllPagesFromSender).toHaveBeenCalledWith(
+      USER_ID,
+      'Spam@Vendor.Example.com',
+    );
+  });
+
+  it('returns the new dashboard payload with fromAddress + userOverride', async () => {
+    mockGetRecentPages.mockResolvedValueOnce([
+      {
+        id: 'p-pinned',
+        user_id: USER_ID,
+        title: 'Pinned',
+        content: '',
+        source: 'signal',
+        source_ref: 'sig-1',
+        metadata: { authoringTier: 'user_sent_originated', userOverride: 'pinned', fromAddress: 'me@example.com' },
+        embedding: null,
+        embedding_model: null,
+        embedding_dim: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
+    ]);
+    const app = buildApp();
+    const res = await request(app, 'GET', `/api/memory-config/dashboard?userId=${USER_ID}`);
+    const body = res.body as { pages: { recent: Array<Record<string, unknown>> } };
+    expect(body.pages.recent[0]?.['userOverride']).toBe('pinned');
+    expect(body.pages.recent[0]?.['fromAddress']).toBe('me@example.com');
   });
 });

--- a/apps/api/src/__tests__/memory-config-routes.test.ts
+++ b/apps/api/src/__tests__/memory-config-routes.test.ts
@@ -549,14 +549,17 @@ describe('POST /api/memory-config/senders/hide (#251 privacy)', () => {
     expect(res.status).toBe(400);
   });
 
-  it('passes the lower-cased fromAddress and reports the affected count', async () => {
+  it('trims + lower-cases fromAddress at the boundary before passing to the adapter', async () => {
     mockHideAllPagesFromSender.mockResolvedValueOnce(7);
     const app = buildApp();
+    // Whitespace + mixed case — both should be normalized away before
+    // the adapter sees the value (otherwise the stored fromAddress, which
+    // is trimmed + lower-cased at write time, would never match).
     const res = await request(
       app,
       'POST',
       `/api/memory-config/senders/hide?userId=${USER_ID}`,
-      { fromAddress: 'Spam@Vendor.Example.com' },
+      { fromAddress: '  Spam@Vendor.Example.com  ' },
     );
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
@@ -566,7 +569,7 @@ describe('POST /api/memory-config/senders/hide (#251 privacy)', () => {
     });
     expect(mockHideAllPagesFromSender).toHaveBeenCalledWith(
       USER_ID,
-      'Spam@Vendor.Example.com',
+      'spam@vendor.example.com',
     );
   });
 

--- a/apps/api/src/routes/memory-config.ts
+++ b/apps/api/src/routes/memory-config.ts
@@ -197,8 +197,10 @@ export function createMemoryConfigRouter(): Router {
       });
     }
     try {
-      // JSONB || merges; passing `userOverride: null` removes the key on
-      // PostgreSQL's strip-nulls behavior. CRDB matches PG here.
+      // `updatePageMetadata` treats null-valued patch keys as delete
+      // requests (uses `jsonb - 'key'` in SQL, `delete` in the in-memory
+      // mirror) so a `clear` action leaves the column clean rather than
+      // storing `{"userOverride": null}` indefinitely.
       const patch =
         body.override === null
           ? { userOverride: null }
@@ -232,13 +234,19 @@ export function createMemoryConfigRouter(): Router {
     if (typeof body.fromAddress !== 'string' || body.fromAddress.trim().length === 0) {
       return res.status(400).json({ error: 'fromAddress (string) is required' });
     }
+    // Normalize once at the boundary — trim AND lower-case — so the
+    // adapter query, the response, and any logged context all see the
+    // same canonical form. Without the trim, "  spam@x.com  " would
+    // pass validation but never match the stored fromAddress field
+    // (which is trimmed + lower-cased at write time).
+    const normalizedFrom = body.fromAddress.trim().toLowerCase();
     try {
-      const hidden = await hideAllPagesFromSender(userId, body.fromAddress);
-      return res.json({ ok: true, fromAddress: body.fromAddress.toLowerCase(), hidden });
+      const hidden = await hideAllPagesFromSender(userId, normalizedFrom);
+      return res.json({ ok: true, fromAddress: normalizedFrom, hidden });
     } catch (err) {
       log.error('senders hide POST failed', {
         userId,
-        fromAddress: body.fromAddress,
+        fromAddress: normalizedFrom,
         error: err instanceof Error ? err.message : String(err),
       });
       return res.status(500).json({ error: 'failed to hide sender' });

--- a/apps/api/src/routes/memory-config.ts
+++ b/apps/api/src/routes/memory-config.ts
@@ -8,6 +8,8 @@ import {
   getRecentPages,
   pendingEmbeddingJobs,
   calibrationFromSentVolume,
+  updatePageMetadata,
+  hideAllPagesFromSender,
   type TierCalibration,
 } from '@skytwin/memory-gbrain-crdb-adapter';
 import { mempalaceRepository } from '@skytwin/db';
@@ -164,6 +166,85 @@ export function createMemoryConfigRouter(): Router {
     }
   });
 
+  // POST per-page userOverride (#251 privacy follow-up).
+  //
+  // Body: `{ override: 'pinned' | 'hidden' | null }`. `null` clears the
+  // override (no-op if there wasn't one). The :pageId param is matched
+  // against `brain_pages.id`; the row's `user_id` column is checked
+  // against the query-string userId so a guessable page id can't be
+  // used to mutate another user's pages.
+  //
+  // 404 when the page doesn't exist or belongs to a different user —
+  // we don't distinguish the two so a caller can't probe for foreign
+  // page-id existence.
+  router.post('/pages/:pageId/override', async (req, res) => {
+    const userId = String(req.query['userId'] ?? '');
+    if (!UUID_REGEX.test(userId)) {
+      return res.status(400).json({ error: 'invalid userId' });
+    }
+    const pageId = String(req.params['pageId'] ?? '');
+    if (!pageId) {
+      return res.status(400).json({ error: 'missing pageId' });
+    }
+    const body = (req.body ?? {}) as { override?: unknown };
+    if (
+      body.override !== 'pinned' &&
+      body.override !== 'hidden' &&
+      body.override !== null
+    ) {
+      return res.status(400).json({
+        error: "override must be 'pinned', 'hidden', or null",
+      });
+    }
+    try {
+      // JSONB || merges; passing `userOverride: null` removes the key on
+      // PostgreSQL's strip-nulls behavior. CRDB matches PG here.
+      const patch =
+        body.override === null
+          ? { userOverride: null }
+          : { userOverride: body.override };
+      const affected = await updatePageMetadata(userId, pageId, patch);
+      if (affected === 0) {
+        return res.status(404).json({ error: 'page not found' });
+      }
+      return res.json({ ok: true, pageId, override: body.override });
+    } catch (err) {
+      log.error('pages override POST failed', {
+        userId,
+        pageId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return res.status(500).json({ error: 'failed to update page override' });
+    }
+  });
+
+  // POST per-sender bulk hide (#251 privacy follow-up). Body:
+  // `{ fromAddress: string }`. Sets `metadata.userOverride='hidden'`
+  // on every brain_page where `metadata.fromAddress` equals (case-
+  // insensitively) the supplied address. The connector lower-cases at
+  // write time so the query is exact-match.
+  router.post('/senders/hide', async (req, res) => {
+    const userId = String(req.query['userId'] ?? '');
+    if (!UUID_REGEX.test(userId)) {
+      return res.status(400).json({ error: 'invalid userId' });
+    }
+    const body = (req.body ?? {}) as { fromAddress?: unknown };
+    if (typeof body.fromAddress !== 'string' || body.fromAddress.trim().length === 0) {
+      return res.status(400).json({ error: 'fromAddress (string) is required' });
+    }
+    try {
+      const hidden = await hideAllPagesFromSender(userId, body.fromAddress);
+      return res.json({ ok: true, fromAddress: body.fromAddress.toLowerCase(), hidden });
+    } catch (err) {
+      log.error('senders hide POST failed', {
+        userId,
+        fromAddress: body.fromAddress,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return res.status(500).json({ error: 'failed to hide sender' });
+    }
+  });
+
   // POST dismiss the "your twin got smarter" notification.
   router.post('/dismiss-notification', async (req, res) => {
     const userId = String(req.query['userId'] ?? '');
@@ -282,11 +363,13 @@ export function createMemoryConfigRouter(): Router {
 
       // Sanitize recent pages for the wire — strip the embedding vector
       // (large, irrelevant for UI) and surface only the fields the dashboard
-      // actually renders. Tier comes from metadata.authoringTier.
+      // actually renders. Tier comes from metadata.authoringTier;
+      // fromAddress is what the per-sender bulk-hide UI sends back.
       const formattedPages = recentPages.map((p) => {
         const meta = (p.metadata ?? {}) as Record<string, unknown>;
         const tier = typeof meta['authoringTier'] === 'string' ? (meta['authoringTier'] as string) : null;
         const userOverride = typeof meta['userOverride'] === 'string' ? (meta['userOverride'] as string) : null;
+        const fromAddress = typeof meta['fromAddress'] === 'string' ? (meta['fromAddress'] as string) : null;
         return {
           id: p.id,
           title: p.title,
@@ -294,6 +377,7 @@ export function createMemoryConfigRouter(): Router {
           createdAt: p.created_at,
           authoringTier: tier,
           userOverride,
+          fromAddress,
         };
       });
 

--- a/apps/web/public/js/pages/memory-settings.js
+++ b/apps/web/public/js/pages/memory-settings.js
@@ -136,6 +136,74 @@ function ensurePageListener() {
       }
       return;
     }
+
+    // #251 privacy: per-page pin/hide. Sends the chosen override
+    // (or null to clear) to /pages/:pageId/override.
+    if (action === 'page-override') {
+      const pageId = target.dataset.pageId;
+      const override = target.dataset.override === 'null' ? null : target.dataset.override;
+      if (!pageId) return;
+      target.disabled = true;
+      try {
+        const res = await api(
+          `/api/memory-config/pages/${encodeURIComponent(pageId)}/override`,
+          {
+            method: 'POST',
+            body: JSON.stringify({ override }),
+          },
+        );
+        if (!res.ok) {
+          showErrorToast('Failed to update page');
+          return;
+        }
+        const label =
+          override === 'pinned' ? 'Pinned' : override === 'hidden' ? 'Hidden' : 'Cleared';
+        showSavedToast(label);
+        const container = document.getElementById('page-content');
+        if (container) await renderMemorySettings(container, getCurrentUserId());
+      } catch {
+        showErrorToast('Failed to update page');
+      } finally {
+        target.disabled = false;
+      }
+      return;
+    }
+
+    // #251 privacy: per-sender bulk hide. Confirms with the user first
+    // since this can hide many rows at once.
+    if (action === 'hide-sender') {
+      const fromAddress = target.dataset.fromAddress;
+      if (!fromAddress) return;
+      // Native confirm — not a custom modal because nothing on this page
+      // surfaces a generic confirmation UI yet, and "stop indexing all
+      // mail from X" is exactly the kind of action that deserves a
+      // friction prompt.
+      // eslint-disable-next-line no-alert
+      const ok = window.confirm(
+        `Hide all indexed pages from ${fromAddress}? This won't delete the data — they just won't surface in memory search any more.`,
+      );
+      if (!ok) return;
+      target.disabled = true;
+      try {
+        const res = await api('/api/memory-config/senders/hide', {
+          method: 'POST',
+          body: JSON.stringify({ fromAddress }),
+        });
+        if (!res.ok) {
+          showErrorToast('Failed to hide sender');
+          return;
+        }
+        const json = (await res.json()) ?? {};
+        showSavedToast(`Hid ${json.hidden ?? 0} pages from ${fromAddress}`);
+        const container = document.getElementById('page-content');
+        if (container) await renderMemorySettings(container, getCurrentUserId());
+      } catch {
+        showErrorToast('Failed to hide sender');
+      } finally {
+        target.disabled = false;
+      }
+      return;
+    }
   });
 }
 
@@ -339,7 +407,7 @@ function renderDashboard(dashboard) {
   const pagesBlock = recentPages.length === 0
     ? `<p class="card-subtitle">No pages indexed yet. Connect a signal source to start.</p>`
     : `<table class="data-table" style="margin-top: 0.5rem; width: 100%;">
-        <thead><tr><th>When</th><th>Tier</th><th>Source</th><th>Title</th></tr></thead>
+        <thead><tr><th>When</th><th>Tier</th><th>Source</th><th>Title</th><th style="text-align:right;">Actions</th></tr></thead>
         <tbody>
           ${recentPages.map((p) => `
             <tr>
@@ -347,6 +415,7 @@ function renderDashboard(dashboard) {
               <td>${renderTierBadge(p.authoringTier, p.userOverride)}</td>
               <td>${escapeHtml(p.source ?? '')}</td>
               <td>${escapeHtml(p.title ?? '')}</td>
+              <td style="text-align:right; white-space:nowrap;">${renderPageActions(p)}</td>
             </tr>`).join('')}
         </tbody>
       </table>`;
@@ -369,6 +438,46 @@ function renderDashboard(dashboard) {
       ${entitiesBlock}
       ${typeBlock}
     </div>
+  `;
+}
+
+/**
+ * #251 privacy: per-row actions for the Recent pages table. The pin and
+ * hide buttons swap between "set" and "clear" depending on the current
+ * override. The "hide sender" button only shows up for pages that have a
+ * fromAddress stamped on metadata (which is most email-derived pages —
+ * calendar invites and idle-miner code pages skip it).
+ *
+ * Buttons emit `data-action` events that the singleton click delegator
+ * in `ensurePageListener` catches. No inline onclick — see CLAUDE.md
+ * "Frontend Event Handling".
+ */
+function renderPageActions(page) {
+  const pageId = String(page.id ?? '');
+  const fromAddress = typeof page.fromAddress === 'string' ? page.fromAddress : '';
+  const override = page.userOverride ?? null;
+  const pinned = override === 'pinned';
+  const hidden = override === 'hidden';
+  // If currently pinned/hidden, the button clears; otherwise it sets.
+  const pinNext = pinned ? 'null' : 'pinned';
+  const hideNext = hidden ? 'null' : 'hidden';
+  const pinLabel = pinned ? 'Unpin' : 'Pin';
+  const hideLabel = hidden ? 'Unhide' : 'Hide';
+  const senderBtn = fromAddress
+    ? `<button class="btn btn-sm btn-outline" data-action="hide-sender"
+              data-from-address="${escapeHtml(fromAddress)}"
+              title="Hide all pages from ${escapeHtml(fromAddress)}"
+              style="margin-left: 0.25rem;">Hide sender</button>`
+    : '';
+  return `
+    <button class="btn btn-sm btn-outline" data-action="page-override"
+            data-page-id="${escapeHtml(pageId)}"
+            data-override="${pinNext}">${pinLabel}</button>
+    <button class="btn btn-sm btn-outline" data-action="page-override"
+            data-page-id="${escapeHtml(pageId)}"
+            data-override="${hideNext}"
+            style="margin-left: 0.25rem;">${hideLabel}</button>
+    ${senderBtn}
   `;
 }
 

--- a/packages/memory-gbrain-crdb-adapter/src/__tests__/in-memory-repository.test.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/__tests__/in-memory-repository.test.ts
@@ -258,3 +258,103 @@ describe('InMemoryBrainStore — settings + embedding queue', () => {
     expect(store.pendingEmbeddingJobs()).toBe(0);
   });
 });
+
+describe('InMemoryBrainStore — metadata overrides (#251 privacy)', () => {
+  let store: InMemoryBrainStore;
+  beforeEach(() => {
+    store = new InMemoryBrainStore();
+  });
+
+  it('updatePageMetadata merges a patch, preserving other metadata keys', () => {
+    const page = store.insertPage({
+      userId: 'u1',
+      content: 'hello',
+      source: 'signal',
+      metadata: { signalSource: 'gmail', authoringTier: 'inbox_personal', bodyLen: 5 },
+    });
+    const n = store.updatePageMetadata('u1', page.id, { userOverride: 'pinned' });
+    expect(n).toBe(1);
+    const after = store.getRecentPages('u1', 1)[0]!;
+    expect(after.metadata).toEqual({
+      signalSource: 'gmail',
+      authoringTier: 'inbox_personal',
+      bodyLen: 5,
+      userOverride: 'pinned',
+    });
+  });
+
+  it("updatePageMetadata returns 0 when the page isn't owned by the user", () => {
+    const page = store.insertPage({
+      userId: 'u1',
+      content: 'x',
+      source: 'signal',
+    });
+    // u2 tries to mutate u1's page — must be a no-op.
+    const n = store.updatePageMetadata('u2', page.id, { userOverride: 'hidden' });
+    expect(n).toBe(0);
+    const after = store.getRecentPages('u1', 1)[0]!;
+    expect((after.metadata as Record<string, unknown>)['userOverride']).toBeUndefined();
+  });
+
+  it('updatePageMetadata returns 0 for a missing page id', () => {
+    const n = store.updatePageMetadata('u1', 'nonexistent', { userOverride: 'pinned' });
+    expect(n).toBe(0);
+  });
+
+  it('hideAllPagesFromSender hides every matching page (case-insensitive)', () => {
+    store.insertPage({
+      userId: 'u1',
+      content: 'a',
+      source: 'signal',
+      metadata: { fromAddress: 'spam@vendor.example.com' },
+    });
+    store.insertPage({
+      userId: 'u1',
+      content: 'b',
+      source: 'signal',
+      metadata: { fromAddress: 'spam@vendor.example.com', authoringTier: 'inbox_newsletter' },
+    });
+    store.insertPage({
+      userId: 'u1',
+      content: 'c',
+      source: 'signal',
+      metadata: { fromAddress: 'someone-else@example.com' },
+    });
+    // Different user — must not be touched.
+    store.insertPage({
+      userId: 'u2',
+      content: 'd',
+      source: 'signal',
+      metadata: { fromAddress: 'spam@vendor.example.com' },
+    });
+
+    // Upper-case input still matches lower-case stored values.
+    const n = store.hideAllPagesFromSender('u1', 'SPAM@VENDOR.EXAMPLE.COM');
+    expect(n).toBe(2);
+
+    const u1Pages = store.getRecentPages('u1', 10);
+    for (const p of u1Pages) {
+      const meta = p.metadata as Record<string, unknown>;
+      if (meta['fromAddress'] === 'spam@vendor.example.com') {
+        expect(meta['userOverride']).toBe('hidden');
+      } else {
+        expect(meta['userOverride']).toBeUndefined();
+      }
+    }
+
+    // u2's page is untouched.
+    const u2Pages = store.getRecentPages('u2', 10);
+    expect((u2Pages[0]!.metadata as Record<string, unknown>)['userOverride']).toBeUndefined();
+  });
+
+  it('hideAllPagesFromSender returns 0 when no pages match the sender', () => {
+    store.insertPage({
+      userId: 'u1',
+      content: 'x',
+      source: 'signal',
+      metadata: { fromAddress: 'alice@example.com' },
+    });
+    const n = store.hideAllPagesFromSender('u1', 'bob@example.com');
+    expect(n).toBe(0);
+  });
+});

--- a/packages/memory-gbrain-crdb-adapter/src/__tests__/in-memory-repository.test.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/__tests__/in-memory-repository.test.ts
@@ -283,6 +283,25 @@ describe('InMemoryBrainStore — metadata overrides (#251 privacy)', () => {
     });
   });
 
+  it('updatePageMetadata treats null patch values as a delete-key request', async () => {
+    const page = store.insertPage({
+      userId: 'u1',
+      content: 'x',
+      source: 'signal',
+      metadata: { authoringTier: 'inbox_newsletter', userOverride: 'pinned', bodyLen: 200 },
+    });
+    const n = store.updatePageMetadata('u1', page.id, { userOverride: null });
+    expect(n).toBe(1);
+    const after = store.getRecentPages('u1', 1)[0]!;
+    const meta = after.metadata as Record<string, unknown>;
+    // Key is gone — not set to null — so downstream consumers that
+    // distinguish "absent" from "present-but-null" see the cleared shape.
+    expect('userOverride' in meta).toBe(false);
+    // Other keys preserved.
+    expect(meta['authoringTier']).toBe('inbox_newsletter');
+    expect(meta['bodyLen']).toBe(200);
+  });
+
   it("updatePageMetadata returns 0 when the page isn't owned by the user", () => {
     const page = store.insertPage({
       userId: 'u1',

--- a/packages/memory-gbrain-crdb-adapter/src/in-memory-repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/in-memory-repository.ts
@@ -189,7 +189,12 @@ export class InMemoryBrainStore {
       .slice(0, limit);
   }
 
-  /** Mirror of `repository.updatePageMetadata`. Returns row count. */
+  /**
+   * Mirror of `repository.updatePageMetadata`. Returns row count. Treats
+   * `null` values in `patch` as a delete-request — matches the SQL helper
+   * which uses `jsonb - 'key'` for those, so downstream consumers can't
+   * tell the in-memory and CRDB paths apart.
+   */
   updatePageMetadata(
     userId: string,
     pageId: string,
@@ -197,10 +202,12 @@ export class InMemoryBrainStore {
   ): number {
     const page = this.pages.get(pageId);
     if (!page || page.user_id !== userId) return 0;
-    page.metadata = {
-      ...(page.metadata as Record<string, unknown>),
-      ...patch,
-    };
+    const next = { ...(page.metadata as Record<string, unknown>) };
+    for (const [k, v] of Object.entries(patch)) {
+      if (v === null) delete next[k];
+      else next[k] = v;
+    }
+    page.metadata = next;
     page.updated_at = new Date();
     return 1;
   }

--- a/packages/memory-gbrain-crdb-adapter/src/in-memory-repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/in-memory-repository.ts
@@ -189,6 +189,37 @@ export class InMemoryBrainStore {
       .slice(0, limit);
   }
 
+  /** Mirror of `repository.updatePageMetadata`. Returns row count. */
+  updatePageMetadata(
+    userId: string,
+    pageId: string,
+    patch: Record<string, unknown>,
+  ): number {
+    const page = this.pages.get(pageId);
+    if (!page || page.user_id !== userId) return 0;
+    page.metadata = {
+      ...(page.metadata as Record<string, unknown>),
+      ...patch,
+    };
+    page.updated_at = new Date();
+    return 1;
+  }
+
+  /** Mirror of `repository.hideAllPagesFromSender`. */
+  hideAllPagesFromSender(userId: string, fromAddress: string): number {
+    const target = fromAddress.toLowerCase();
+    let n = 0;
+    for (const page of this.pages.values()) {
+      if (page.user_id !== userId) continue;
+      const meta = (page.metadata ?? {}) as Record<string, unknown>;
+      if (meta['fromAddress'] !== target) continue;
+      page.metadata = { ...meta, userOverride: 'hidden' };
+      page.updated_at = new Date();
+      n++;
+    }
+    return n;
+  }
+
   countPages(userId: string): { total: number; embedded: number } {
     let total = 0;
     let embedded = 0;

--- a/packages/memory-gbrain-crdb-adapter/src/index.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/index.ts
@@ -72,5 +72,7 @@ export {
   getRecentPages,
   countPages,
   countUserSentPages,
+  updatePageMetadata,
+  hideAllPagesFromSender,
 } from './repository.js';
 export type { HybridSearchOptions } from './repository.js';

--- a/packages/memory-gbrain-crdb-adapter/src/repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/repository.ts
@@ -90,6 +90,61 @@ export async function updatePageEmbedding(
   );
 }
 
+/**
+ * Merge a partial metadata patch into `brain_pages.metadata`, scoped to
+ * the owning user. Uses CRDB's JSONB `||` concat-merge so existing keys
+ * are overwritten but other keys are preserved. Used by the per-page
+ * pin/hide actions (#251 privacy follow-up) — sets
+ * `metadata.userOverride` to `'pinned' | 'hidden' | null` without
+ * touching the connector-stamped `authoringTier`/`fromAddress`/`bodyLen`
+ * fields.
+ *
+ * Returns the affected row count. A return value of 0 means the page
+ * wasn't found or belonged to a different user — the route layer
+ * surfaces that as 404. The `user_id` predicate is load-bearing — it
+ * stops a caller from mutating another user's pages even if they hold
+ * a guessable page id.
+ */
+export async function updatePageMetadata(
+  userId: string,
+  pageId: string,
+  patch: Record<string, unknown>,
+): Promise<number> {
+  const result = await query(
+    `UPDATE brain_pages
+       SET metadata = COALESCE(metadata, '{}'::JSONB) || $3::JSONB,
+           updated_at = now()
+     WHERE id = $1 AND user_id = $2`,
+    [pageId, userId, JSON.stringify(patch)],
+  );
+  return result.rowCount ?? 0;
+}
+
+/**
+ * Bulk-hide every brain_page where `metadata.fromAddress` matches the
+ * given sender. Used by the per-sender "stop indexing this address"
+ * action (#251 privacy follow-up). Returns the affected row count so
+ * the UI can show "hid N pages from X".
+ *
+ * Address match is exact-equality after lowering — the indexer stamps
+ * `fromAddress` lowercased at write time, so this query doesn't have
+ * to do anything case-aware.
+ */
+export async function hideAllPagesFromSender(
+  userId: string,
+  fromAddress: string,
+): Promise<number> {
+  const result = await query(
+    `UPDATE brain_pages
+       SET metadata = COALESCE(metadata, '{}'::JSONB) || '{"userOverride":"hidden"}'::JSONB,
+           updated_at = now()
+     WHERE user_id = $1
+       AND metadata->>'fromAddress' = $2`,
+    [userId, fromAddress.toLowerCase()],
+  );
+  return result.rowCount ?? 0;
+}
+
 // ── Hybrid retrieval (RRF) ──────────────────────────────────────────────────
 
 export interface HybridSearchOptions {

--- a/packages/memory-gbrain-crdb-adapter/src/repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/repository.ts
@@ -94,10 +94,13 @@ export async function updatePageEmbedding(
  * Merge a partial metadata patch into `brain_pages.metadata`, scoped to
  * the owning user. Uses CRDB's JSONB `||` concat-merge so existing keys
  * are overwritten but other keys are preserved. Used by the per-page
- * pin/hide actions (#251 privacy follow-up) — sets
- * `metadata.userOverride` to `'pinned' | 'hidden' | null` without
- * touching the connector-stamped `authoringTier`/`fromAddress`/`bodyLen`
- * fields.
+ * pin/hide actions (#251 privacy follow-up).
+ *
+ * Keys with a value of `null` in `patch` are treated as a *delete*
+ * request — they're removed from `metadata` rather than written as a
+ * JSON-null. `jsonb ||` would otherwise store `{"userOverride": null}`
+ * which would (a) clutter the row indefinitely and (b) confuse any
+ * downstream code that distinguishes "key absent" from "key is null".
  *
  * Returns the affected row count. A return value of 0 means the page
  * wasn't found or belonged to a different user — the route layer
@@ -110,12 +113,34 @@ export async function updatePageMetadata(
   pageId: string,
   patch: Record<string, unknown>,
 ): Promise<number> {
+  // Split the patch into "set" entries (non-null values) and "drop"
+  // keys (null values). Set entries go through JSONB ||; drop keys go
+  // through repeated JSONB - operators so the column shape stays clean.
+  const setPatch: Record<string, unknown> = {};
+  const dropKeys: string[] = [];
+  for (const [k, v] of Object.entries(patch)) {
+    if (v === null) dropKeys.push(k);
+    else setPatch[k] = v;
+  }
+  // Build the metadata expression: start from existing column, apply
+  // each drop key via `- 'key'`, then merge the set patch.
+  let expr = `COALESCE(metadata, '{}'::JSONB)`;
+  const params: unknown[] = [pageId, userId];
+  for (const key of dropKeys) {
+    params.push(key);
+    expr = `${expr} - $${params.length}`;
+  }
+  const hasSet = Object.keys(setPatch).length > 0;
+  if (hasSet) {
+    params.push(JSON.stringify(setPatch));
+    expr = `${expr} || $${params.length}::JSONB`;
+  }
   const result = await query(
     `UPDATE brain_pages
-       SET metadata = COALESCE(metadata, '{}'::JSONB) || $3::JSONB,
+       SET metadata = ${expr},
            updated_at = now()
      WHERE id = $1 AND user_id = $2`,
-    [pageId, userId, JSON.stringify(patch)],
+    params,
   );
   return result.rowCount ?? 0;
 }

--- a/packages/memory-gbrain/src/__tests__/embedded-port.test.ts
+++ b/packages/memory-gbrain/src/__tests__/embedded-port.test.ts
@@ -116,6 +116,54 @@ describe('EmbeddedGbrainMemoryPort — recordSignal', () => {
     expect(meta['authoringTier']).toBeUndefined();
   });
 
+  // #251 privacy follow-up: stamp the From address on metadata so the
+  // "hide all from this sender" bulk-action has something to query against.
+  it('stamps lower-cased fromAddress on metadata from data.from', async () => {
+    const sig: RawSignal = {
+      id: 'sig-from',
+      source: 'gmail',
+      type: 'email',
+      timestamp: new Date('2026-05-01'),
+      data: {
+        subject: 'Newsletter',
+        from: 'Acme <Newsletter@Acme.Example.com>',
+      },
+    };
+    await port.recordSignal(sig);
+    const pages = store.getAllPages(USER);
+    expect((pages[0]!.metadata as Record<string, unknown>)['fromAddress']).toBe(
+      'newsletter@acme.example.com',
+    );
+  });
+
+  it('handles a bare address (no display name) for fromAddress', async () => {
+    const sig: RawSignal = {
+      id: 'sig-from-bare',
+      source: 'gmail',
+      type: 'email',
+      timestamp: new Date('2026-05-01'),
+      data: { from: 'BARE@Example.com' },
+    };
+    await port.recordSignal(sig);
+    const pages = store.getAllPages(USER);
+    expect((pages[0]!.metadata as Record<string, unknown>)['fromAddress']).toBe(
+      'bare@example.com',
+    );
+  });
+
+  it('omits fromAddress when data.from is missing or empty', async () => {
+    const sig: RawSignal = {
+      id: 'sig-from-missing',
+      source: 'cal',
+      type: 'event',
+      timestamp: new Date('2026-05-01'),
+      data: { subject: 'Standup' },
+    };
+    await port.recordSignal(sig);
+    const pages = store.getAllPages(USER);
+    expect((pages[0]!.metadata as Record<string, unknown>)['fromAddress']).toBeUndefined();
+  });
+
   it('ignores non-string authoringTier values defensively', async () => {
     const sig: RawSignal = {
       id: 'sig-bad-tier',

--- a/packages/memory-gbrain/src/embedded-port.ts
+++ b/packages/memory-gbrain/src/embedded-port.ts
@@ -207,12 +207,15 @@ export class EmbeddedGbrainMemoryPort implements MemoryPort {
 
   /**
    * Build the `brain_pages.metadata` object for a signal-derived page.
-   * Always carries `signalSource` / `signalType`; carries `authoringTier`
-   * only when the connector stamped one on `data.authoringTier`. Also
-   * stamps `bodyLen` (length of the summarised content) so Layer 2's
-   * brief-reply downweight has something to read. Kept tolerant of
-   * unknown shapes — defensive against future connectors that may pass
-   * an object or null instead of a tier string.
+   * Always carries `signalSource` / `signalType` and `bodyLen` (length of
+   * the summarised content, for Layer 2's brief-reply downweight). Carries
+   * `authoringTier` and `fromAddress` only when the connector supplied
+   * them — `fromAddress` is the From header (or equivalent) extracted from
+   * `data`, used by the per-sender bulk hide action so a user can "stop
+   * indexing this sender" without having to delete pages one by one.
+   *
+   * Kept tolerant of unknown shapes — defensive against future connectors
+   * that may pass an object or null where we expect a string.
    */
   private buildPageMetadata(
     s: RawSignal,
@@ -227,6 +230,20 @@ export class EmbeddedGbrainMemoryPort implements MemoryPort {
     const tier = data['authoringTier'];
     if (typeof tier === 'string' && tier.length > 0) {
       metadata['authoringTier'] = tier;
+    }
+    // Normalize fromAddress at write time so the bulk-hide query is a
+    // simple equality match against `metadata->>'fromAddress'`. We lower
+    // the address to avoid case-sensitivity bugs at query time. The same
+    // shape lives in `@skytwin/connectors` as `extractBareAddress`; inlined
+    // here as a 3-line helper to avoid pulling the connectors package
+    // into the memory layer's dependency graph.
+    const rawFrom = data['from'];
+    if (typeof rawFrom === 'string' && rawFrom.trim().length > 0) {
+      const angle = rawFrom.match(/<([^>]+)>/);
+      const bare = angle?.[1]
+        ? angle[1].trim().toLowerCase()
+        : rawFrom.trim().toLowerCase();
+      if (bare.length > 0) metadata['fromAddress'] = bare;
     }
     return metadata;
   }


### PR DESCRIPTION
## Summary

The privacy guardrail that gates Layer 2's default-on rollout. Users can now:

- **Pin** an individual page (×2 RRF score boost).
- **Hide** an individual page (dropped from search entirely).
- **Hide all from this sender** — bulk action over every indexed page sharing a `fromAddress`.

All three composable with the tier multiplier already shipped in #259 + the rebalanced weights from #260.

**Closes (partial): #251 privacy follow-up.** With this and the ablation eval landed, Layer 2 default-on is no longer blocked on user-side disclaim controls.

## Engine

- **`EmbeddedGbrainMemoryPort.buildPageMetadata`** now stamps `fromAddress` (lower-cased bare address pulled from `data.from`) on every page that has one. Inlines a 3-line display-name stripper instead of pulling `@skytwin/connectors` into the memory layer's dep graph.
- **`updatePageMetadata(userId, pageId, patch)`** (new repo helper): JSONB-merges a partial patch into `brain_pages.metadata`, scoped by `user_id`. A caller with another user's page id can't mutate that row. Returns affected count; 0 → 404 at the route.
- **`hideAllPagesFromSender(userId, fromAddress)`** (new repo helper): bulk `UPDATE` setting `metadata.userOverride='hidden'` on every page where `metadata->>'fromAddress'` matches the lower-cased input.
- Both have matching in-memory mirrors.

## API

- `POST /api/memory-config/pages/:pageId/override` body `{ override: 'pinned' \| 'hidden' \| null }`. 404 on missing/foreign-owned pages — collapsed deliberately so the response shape can't be used to probe for foreign page-id existence.
- `POST /api/memory-config/senders/hide` body `{ fromAddress: string }`. Returns `{ ok, fromAddress, hidden: <count> }`.
- `GET /api/memory-config/dashboard` payload's `pages.recent[]` now includes `fromAddress` so the UI knows what to send to the sender route.

## Web

New per-row action column on the **Recent pages indexed** table:

- **Pin** / **Unpin** — swaps action based on current state.
- **Hide** / **Unhide** — same.
- **Hide sender** — only shown when the row has a `fromAddress` (i.e. email-derived). Surfaces a `window.confirm` before firing since one click can hide hundreds of rows.

All buttons use `data-action` attributes and the singleton click delegator from `ensurePageListener`, per CLAUDE.md "Frontend Event Handling."

## Tests

- 5 new `in-memory-repository.test.ts` cases: merge-preserves-keys, user-scoping for `updatePageMetadata`, 404 on missing/foreign, `hideAllPagesFromSender` matches case-insensitively + scopes by user + reports 0 when nothing matches.
- 3 new `embedded-port.test.ts` cases: `fromAddress` lower-cases display-name addresses, handles bare addresses, omits when `data.from` is missing.
- 6 new `memory-config-routes.test.ts` cases: per-page override rejects bogus values, accepts pinned/hidden/null, 404s on adapter's zero-row return; sender bulk-hide rejects missing `fromAddress`, lower-cases on the wire, surfaces affected count; dashboard payload includes `userOverride` + `fromAddress`.

## Test plan

- [x] `pnpm build --concurrency=1` → 35/35 packages.
- [x] `pnpm test` → 70/70 turbo tasks.
- [x] Specifically: `pnpm --filter @skytwin/memory-gbrain-crdb-adapter test` → 75 pass; `pnpm --filter @skytwin/memory-gbrain test` → 98 pass; `pnpm --filter @skytwin/api test -- memory-config-routes` → 25 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)