### PR TITLE
feat(#251 follow-up): authoring-tier backfill worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Authoring-tier backfill worker (#251 follow-up)
+
+Pages indexed before Layer 1 of #251 (where the Gmail connector started stamping `authoringTier` on every signal) had no tier on their metadata — which meant the Layer 2 multiplier did nothing for them. This adds a worker job that retroactively fills in the tier for those pages, plus the connector keeps the raw headers needed to reclassify going forward.
+
+### What's running now
+
+- A new **`runTierBackfillJob`** worker runs hourly. It scans `brain_pages` for rows where `metadata->>'authoringTier' IS NULL`, joins on `brain_signals` via `source_ref`, and either:
+  1. Copies `signal.data.authoringTier` to page metadata when it already exists (post-#252 ingest paths that bypassed the metadata projection for any reason — cheap and lossless).
+  2. Runs the classifier locally on the raw `to` / `cc` / `inReplyTo` / `listUnsubscribe` / `listId` / `labels` headers (post-this-PR signal shape).
+  3. Logs an "unreclassifiable" count and leaves the page alone (pre-Layer-1 signals that don't carry classification headers — full re-fetch from Gmail is a separate sub-issue).
+- The Gmail connector now persists those raw header fields in `signal.data` so option (2) becomes available for every page indexed after this lands. Cost: a few extra short strings per row. The fields the classifier already consumed are now also queryable downstream.
+
+### Why bother
+
+Without this, existing-user corpora are silently stuck: their pages have no tier, so they see no Layer 2 benefit even if they enable the toggle. With it, the multiplier becomes useful on day one — the worker converges the back-catalog within a few passes (batch size 200, hourly cadence) and is a strict no-op once it's done.
+
+The job is idempotent and bounded — re-running on a fully-tagged corpus does nothing because the find query filters on `metadata->>'authoringTier' IS NULL`.
+
+### Engine
+
+- **`findPagesMissingAuthoringTier(userId | null, limit)`** (new adapter helper): JOIN brain_pages ↔ brain_signals on `source_ref = id`, filter on tier-missing, optional user scope. Returns `{ page_id, user_id, signal_data }[]`.
+- **`apps/worker/src/jobs/tier-backfill.ts`** (new): the worker job. Reclassifies via the two paths above, calls `updatePageMetadata` to write `{ authoringTier, fromAddress }`, returns a summary with attempted / copied-from-signal / reclassified / unreclassifiable / failed counts.
+- **Gmail connector**: `messageToSignal` now stamps `to` / `cc` / `inReplyTo` / `listUnsubscribe` on `signal.data` alongside the existing fields. No behavior change to the classifier; just preserves the raw inputs for downstream reclassification.
+- In-memory adapter mirror for tests.
+
+### Tests
+
+- 9 new worker unit tests (`tier-backfill.test.ts`) cover: signal-tier copy path, header reclassification (SENT label / List-Unsubscribe), unreclassifiable count, failed-update isolation, find-query throwing yields empty summary, fromAddress omission when missing, userId scoping, default null-scope.
+- 4 new in-memory repository tests on `findPagesMissingAuthoringTier`: page-with-tier excluded, signal-missing page skipped, userId scoping, limit cap.
+
+### Deferred
+
+- Pre-#252 signals that don't carry classification headers stay untagged after this lands. Recovering those requires an OAuth-token-dependent re-fetch from Gmail — separate sub-issue, lower priority since each pass converges new ingest quickly.
+
 ## [unreleased] — Tier-aware privacy controls: pin / hide / hide-sender (#251 follow-up)
 
 The memory dashboard's "Recent pages indexed" table now shows three action buttons per row: **Pin**, **Hide**, and **Hide sender**. The first two flip `metadata.userOverride` between `'pinned'`, `'hidden'`, and unset (the gbrain RRF fold already reads this — pinned doubles the rrfScore, hidden drops the page from search entirely). The third one bulk-hides every indexed page from the same sender — useful for tidying out a newsletter or transactional sender you don't want the twin learning from.

--- a/apps/worker/src/__tests__/tier-backfill.test.ts
+++ b/apps/worker/src/__tests__/tier-backfill.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for the tier-backfill worker job (#251 follow-up).
+ *
+ * Mocks the @skytwin/memory-gbrain-crdb-adapter functions so we can drive
+ * the worker through every reclassification path without a live database:
+ *
+ *   1. Trust the signal: signal.data.authoringTier already present →
+ *      copy it through to page metadata.
+ *   2. Reclassify: only raw headers in signal.data → run the local
+ *      classifier and produce a tier.
+ *   3. Unreclassifiable: signal too thin (no labels, no from) → leave
+ *      the page alone but count it.
+ *   4. Failed update: adapter throws → counted in `failed`, keeps going.
+ *   5. The find query throwing is non-fatal — returns an empty summary.
+ *   6. fromAddress is also copied / normalized when data.from is present.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockFind, mockUpdate } = vi.hoisted(() => ({
+  mockFind: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock('@skytwin/memory-gbrain-crdb-adapter', async () => {
+  const actual: typeof import('@skytwin/memory-gbrain-crdb-adapter') =
+    await vi.importActual('@skytwin/memory-gbrain-crdb-adapter');
+  return {
+    ...actual,
+    findPagesMissingAuthoringTier: mockFind,
+    updatePageMetadata: mockUpdate,
+  };
+});
+
+vi.mock('@skytwin/core', async () => {
+  const actual: typeof import('@skytwin/core') = await vi.importActual('@skytwin/core');
+  return {
+    ...actual,
+    createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  };
+});
+
+import { runTierBackfillJob } from '../jobs/tier-backfill.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFind.mockResolvedValue([]);
+  mockUpdate.mockResolvedValue(1);
+});
+
+describe('runTierBackfillJob', () => {
+  it('copies an existing signal.data.authoringTier straight to page metadata', async () => {
+    mockFind.mockResolvedValueOnce([
+      {
+        page_id: 'p-1',
+        user_id: 'u-1',
+        signal_data: {
+          authoringTier: 'inbox_newsletter',
+          from: 'newsletter@vendor.example.com',
+        },
+      },
+    ]);
+    const summary = await runTierBackfillJob({ batchSize: 5 });
+    expect(summary.attempted).toBe(1);
+    expect(summary.copiedFromSignal).toBe(1);
+    expect(summary.reclassified).toBe(0);
+    expect(mockUpdate).toHaveBeenCalledWith('u-1', 'p-1', {
+      authoringTier: 'inbox_newsletter',
+      fromAddress: 'newsletter@vendor.example.com',
+    });
+  });
+
+  it('reclassifies from raw headers when signal.data has no authoringTier', async () => {
+    mockFind.mockResolvedValueOnce([
+      {
+        page_id: 'p-2',
+        user_id: 'u-1',
+        signal_data: {
+          // No authoringTier — but headers + labels are present, so the
+          // classifier can derive it. SENT label → user_sent_*.
+          labels: ['SENT', 'INBOX'],
+          from: 'me@example.com',
+          to: 'colleague@example.com',
+          cc: '',
+          inReplyTo: '',
+          listUnsubscribe: '',
+          listId: '',
+        },
+      },
+    ]);
+    const summary = await runTierBackfillJob({ batchSize: 5 });
+    expect(summary.reclassified).toBe(1);
+    expect(summary.copiedFromSignal).toBe(0);
+    expect(mockUpdate).toHaveBeenCalledWith('u-1', 'p-2', {
+      authoringTier: 'user_sent_originated',
+      fromAddress: 'me@example.com',
+    });
+  });
+
+  it('reclassifies a newsletter via List-Unsubscribe header', async () => {
+    mockFind.mockResolvedValueOnce([
+      {
+        page_id: 'p-3',
+        user_id: 'u-1',
+        signal_data: {
+          labels: ['INBOX'],
+          from: 'news@example.com',
+          to: 'me@example.com',
+          cc: '',
+          inReplyTo: '',
+          listUnsubscribe: '<mailto:unsubscribe@example.com>',
+          listId: '',
+        },
+      },
+    ]);
+    const summary = await runTierBackfillJob({ batchSize: 5 });
+    expect(summary.reclassified).toBe(1);
+    expect(mockUpdate).toHaveBeenCalledWith('u-1', 'p-3', {
+      authoringTier: 'inbox_newsletter',
+      fromAddress: 'news@example.com',
+    });
+  });
+
+  it("counts a signal with no usable data as 'unreclassifiable' and doesn't call updatePageMetadata", async () => {
+    mockFind.mockResolvedValueOnce([
+      {
+        page_id: 'p-4',
+        user_id: 'u-1',
+        signal_data: { subject: 'just a subject line' },
+      },
+    ]);
+    const summary = await runTierBackfillJob({ batchSize: 5 });
+    expect(summary.unreclassifiable).toBe(1);
+    expect(summary.copiedFromSignal).toBe(0);
+    expect(summary.reclassified).toBe(0);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('counts update failures and continues with the next page', async () => {
+    mockFind.mockResolvedValueOnce([
+      {
+        page_id: 'fails',
+        user_id: 'u-1',
+        signal_data: { authoringTier: 'inbox_personal', from: 'a@example.com' },
+      },
+      {
+        page_id: 'works',
+        user_id: 'u-1',
+        signal_data: { authoringTier: 'user_sent_originated', from: 'me@example.com' },
+      },
+    ]);
+    mockUpdate.mockImplementation(async (_userId, pageId) => {
+      if (pageId === 'fails') throw new Error('db down');
+      return 1;
+    });
+    const summary = await runTierBackfillJob({ batchSize: 5 });
+    expect(summary.attempted).toBe(2);
+    expect(summary.failed).toBe(1);
+    // The second update still went through — the failure didn't stop the loop.
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
+    expect(mockUpdate).toHaveBeenLastCalledWith('u-1', 'works', {
+      authoringTier: 'user_sent_originated',
+      fromAddress: 'me@example.com',
+    });
+  });
+
+  it('returns an empty summary when the find query throws', async () => {
+    mockFind.mockRejectedValueOnce(new Error('connection refused'));
+    const summary = await runTierBackfillJob({ batchSize: 5 });
+    expect(summary).toEqual({
+      attempted: 0,
+      copiedFromSignal: 0,
+      reclassified: 0,
+      unreclassifiable: 0,
+      failed: 0,
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('omits fromAddress from the patch when signal.data.from is missing', async () => {
+    mockFind.mockResolvedValueOnce([
+      {
+        page_id: 'p-no-from',
+        user_id: 'u-1',
+        signal_data: { authoringTier: 'inbox_automated' },
+      },
+    ]);
+    const summary = await runTierBackfillJob({ batchSize: 5 });
+    expect(summary.copiedFromSignal).toBe(1);
+    expect(mockUpdate).toHaveBeenCalledWith('u-1', 'p-no-from', {
+      authoringTier: 'inbox_automated',
+    });
+  });
+
+  it('respects the userId scope when provided', async () => {
+    await runTierBackfillJob({ batchSize: 10, userId: 'u-target' });
+    expect(mockFind).toHaveBeenCalledWith('u-target', 10);
+  });
+
+  it('uses null scope (all users) by default', async () => {
+    await runTierBackfillJob({ batchSize: 50 });
+    expect(mockFind).toHaveBeenCalledWith(null, 50);
+  });
+});

--- a/apps/worker/src/__tests__/tier-backfill.test.ts
+++ b/apps/worker/src/__tests__/tier-backfill.test.ts
@@ -164,6 +164,23 @@ describe('runTierBackfillJob', () => {
     });
   });
 
+  it('counts updatePageMetadata returning 0 affected rows as failed', async () => {
+    mockFind.mockResolvedValueOnce([
+      {
+        page_id: 'p-gone',
+        user_id: 'u-1',
+        signal_data: { authoringTier: 'inbox_personal', from: 'a@example.com' },
+      },
+    ]);
+    // Simulate a race where the page got deleted between find + update.
+    mockUpdate.mockResolvedValueOnce(0);
+    const summary = await runTierBackfillJob({ batchSize: 5 });
+    expect(summary.attempted).toBe(1);
+    expect(summary.failed).toBe(1);
+    expect(summary.copiedFromSignal).toBe(0);
+    expect(summary.reclassified).toBe(0);
+  });
+
   it('returns an empty summary when the find query throws', async () => {
     mockFind.mockRejectedValueOnce(new Error('connection refused'));
     const summary = await runTierBackfillJob({ batchSize: 5 });

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -28,6 +28,7 @@ import { runChangelogPollJob } from './jobs/changelog-poll.js';
 import { runDomainExtractionJob } from './jobs/domain-extraction.js';
 import { runFederationSyncJob } from './jobs/federation-sync.js';
 import { runEmbeddingBackfillJob } from './jobs/embedding-backfill.js';
+import { runTierBackfillJob } from './jobs/tier-backfill.js';
 
 const config = loadConfig();
 const log = createLogger('worker');
@@ -492,6 +493,14 @@ async function main(): Promise<void> {
   // multiple worker instances simultaneously.
   const EMBEDDING_BACKFILL_INTERVAL_MS = 30_000;
 
+  let lastTierBackfillAt = 0;
+  // Backfill `metadata.authoringTier` on pages that predate Layer 1 of
+  // #251. Hourly cadence is plenty — the find query is `metadata->>'authoringTier'
+  // IS NULL` so once the corpus is fully tagged the worker becomes a no-op.
+  // Batch size keeps each pass bounded; multiple passes converge the corpus
+  // over a few hours for a heavy mailbox.
+  const TIER_BACKFILL_INTERVAL_MS = 60 * 60 * 1000;
+
   // Poll loop
   while (running) {
     for (const uc of userConnectors) {
@@ -551,6 +560,17 @@ async function main(): Promise<void> {
         });
       });
       lastEmbeddingBackfillAt = nowMs;
+    }
+
+    // Backfill authoringTier on pre-Layer-1 pages (#251 follow-up).
+    // Hourly; converges to no-op once the corpus is fully tagged.
+    if (nowMs - lastTierBackfillAt >= TIER_BACKFILL_INTERVAL_MS) {
+      await runTierBackfillJob().catch((err) => {
+        log.warn('Tier backfill job failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+      lastTierBackfillAt = nowMs;
     }
 
     // Expire stale approval requests every 10 poll cycles

--- a/apps/worker/src/jobs/tier-backfill.ts
+++ b/apps/worker/src/jobs/tier-backfill.ts
@@ -98,7 +98,19 @@ export async function runTierBackfillJob(
       patch['fromAddress'] = result.fromAddress;
     }
     try {
-      await updatePageMetadata(row.user_id, row.page_id, patch);
+      const affected = await updatePageMetadata(row.user_id, row.page_id, patch);
+      if (affected === 0) {
+        // updatePageMetadata returns 0 when the page disappeared between
+        // the find query and the update (deleted, user reassigned, etc.),
+        // or when ownership doesn't match. Counted as failed so the
+        // summary surfaces it instead of silently lying about success.
+        summary.failed++;
+        log.warn('tier backfill: updatePageMetadata reported 0 affected rows', {
+          pageId: row.page_id,
+          userId: row.user_id,
+        });
+        continue;
+      }
       if (result.source === 'signal-tier') summary.copiedFromSignal++;
       else summary.reclassified++;
     } catch (err) {

--- a/apps/worker/src/jobs/tier-backfill.ts
+++ b/apps/worker/src/jobs/tier-backfill.ts
@@ -1,0 +1,185 @@
+import { createLogger } from '@skytwin/core';
+import {
+  findPagesMissingAuthoringTier,
+  updatePageMetadata,
+} from '@skytwin/memory-gbrain-crdb-adapter';
+import {
+  classifyEmailAuthoringTier,
+  extractBareAddress,
+  splitAddressList,
+  type AuthoringTier,
+} from '@skytwin/connectors';
+
+const log = createLogger('tier-backfill');
+
+/**
+ * Backfill `metadata.authoringTier` (and `metadata.fromAddress`) on
+ * brain_pages that predate Layer 1 of #251 — pages that were indexed
+ * before the Gmail connector started stamping the tier on signal data,
+ * or pages where the metadata projection was skipped for any reason.
+ *
+ * Two reclassification paths, tried in order:
+ *
+ *   1. **Trust the signal.** If `signal.data.authoringTier` already
+ *      exists (post-#252 ingest), copy it straight to the page metadata.
+ *      Cheap and lossless — same tier the connector would produce.
+ *   2. **Reclassify from raw headers.** Post-#251-backfill the connector
+ *      also persists `to` / `cc` / `inReplyTo` / `listUnsubscribe` /
+ *      `listId` / `labels` in `signal.data`. Run the classifier locally.
+ *
+ * Pages whose signal carries neither path (very old pre-Layer-1 ingest)
+ * are logged as "unreclassifiable" and left alone — the only way to
+ * recover their tier is a re-fetch from Gmail, which lives in a
+ * separate sub-issue.
+ *
+ * The job is idempotent: running it twice on the same corpus does
+ * nothing the second time, since the find query filters on
+ * `metadata->>'authoringTier' IS NULL`.
+ */
+export interface TierBackfillOptions {
+  /** Max pages to process per pass. Default 200. */
+  batchSize?: number;
+  /** When set, only backfill pages owned by this user. Default: all users. */
+  userId?: string | null;
+}
+
+export interface TierBackfillSummary {
+  attempted: number;
+  /** Tier copied from `signal.data.authoringTier`. */
+  copiedFromSignal: number;
+  /** Tier re-derived by running the classifier on raw headers. */
+  reclassified: number;
+  /** Signal had no usable data; left unchanged. */
+  unreclassifiable: number;
+  /** updatePageMetadata threw. */
+  failed: number;
+}
+
+/**
+ * Run a single tier-backfill pass.
+ */
+export async function runTierBackfillJob(
+  opts: TierBackfillOptions = {},
+): Promise<TierBackfillSummary> {
+  const batchSize = opts.batchSize ?? 200;
+  const scope = opts.userId ?? null;
+
+  const summary: TierBackfillSummary = {
+    attempted: 0,
+    copiedFromSignal: 0,
+    reclassified: 0,
+    unreclassifiable: 0,
+    failed: 0,
+  };
+
+  let pages: Array<{
+    page_id: string;
+    user_id: string;
+    signal_data: Record<string, unknown>;
+  }>;
+  try {
+    pages = await findPagesMissingAuthoringTier(scope, batchSize);
+  } catch (err) {
+    log.warn('findPagesMissingAuthoringTier failed; skipping pass', {
+      reason: err instanceof Error ? err.message : String(err),
+    });
+    return summary;
+  }
+
+  for (const row of pages) {
+    summary.attempted++;
+    const result = deriveTierFromSignal(row.signal_data);
+    if (result === null) {
+      summary.unreclassifiable++;
+      continue;
+    }
+    const patch: Record<string, unknown> = { authoringTier: result.tier };
+    if (result.fromAddress) {
+      patch['fromAddress'] = result.fromAddress;
+    }
+    try {
+      await updatePageMetadata(row.user_id, row.page_id, patch);
+      if (result.source === 'signal-tier') summary.copiedFromSignal++;
+      else summary.reclassified++;
+    } catch (err) {
+      summary.failed++;
+      log.warn('tier backfill: updatePageMetadata failed', {
+        pageId: row.page_id,
+        userId: row.user_id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (summary.attempted > 0) {
+    log.info('tier backfill pass complete', { ...summary });
+  }
+  return summary;
+}
+
+interface DerivedTier {
+  tier: AuthoringTier;
+  /** Normalized bare address; undefined when `data.from` was missing. */
+  fromAddress?: string;
+  source: 'signal-tier' | 'reclassified';
+}
+
+/**
+ * Pull an `AuthoringTier` out of a stored signal's `data` blob. Prefers
+ * the already-classified `data.authoringTier` (when present); falls back
+ * to running the classifier locally on the raw headers. Returns `null`
+ * if neither path works — caller logs as unreclassifiable.
+ */
+function deriveTierFromSignal(data: Record<string, unknown>): DerivedTier | null {
+  const tier = data['authoringTier'];
+  const rawFrom = typeof data['from'] === 'string' ? (data['from'] as string) : '';
+  const fromAddress = rawFrom ? extractBareAddress(rawFrom) : '';
+
+  if (isAuthoringTier(tier)) {
+    return {
+      tier,
+      ...(fromAddress ? { fromAddress } : {}),
+      source: 'signal-tier',
+    };
+  }
+
+  // Reclassify path requires at least labels OR from to produce a
+  // meaningful tier. Anything less and the classifier defaults to
+  // inbox_personal, which would silently wrong-tier pages.
+  const labels = Array.isArray(data['labels']) ? (data['labels'] as string[]) : [];
+  const toRaw = typeof data['to'] === 'string' ? (data['to'] as string) : '';
+  const ccRaw = typeof data['cc'] === 'string' ? (data['cc'] as string) : '';
+  const inReplyTo = typeof data['inReplyTo'] === 'string' ? (data['inReplyTo'] as string) : '';
+  const listUnsubscribe =
+    typeof data['listUnsubscribe'] === 'string' ? (data['listUnsubscribe'] as string) : '';
+  const listId = typeof data['listId'] === 'string' ? (data['listId'] as string) : '';
+
+  const enoughData = labels.length > 0 || rawFrom.length > 0;
+  if (!enoughData) return null;
+
+  const classified = classifyEmailAuthoringTier({
+    labels,
+    fromAddress: rawFrom,
+    toAddresses: splitAddressList(toRaw),
+    ccAddresses: splitAddressList(ccRaw),
+    hasInReplyTo: inReplyTo.trim().length > 0,
+    hasListUnsubscribe: listUnsubscribe.trim().length > 0,
+    listId,
+  });
+  return {
+    tier: classified,
+    ...(fromAddress ? { fromAddress } : {}),
+    source: 'reclassified',
+  };
+}
+
+function isAuthoringTier(v: unknown): v is AuthoringTier {
+  return (
+    v === 'user_sent_originated' ||
+    v === 'user_sent_reply' ||
+    v === 'inbox_personal' ||
+    v === 'inbox_broadcast' ||
+    v === 'inbox_newsletter' ||
+    v === 'inbox_automated'
+  );
+}

--- a/packages/connectors/src/gmail-connector.ts
+++ b/packages/connectors/src/gmail-connector.ts
@@ -394,14 +394,18 @@ export class GmailConnector implements SignalConnector {
     const from = getHeader('From');
     const subject = getHeader('Subject');
     const listId = parseListId(getHeader('List-Id'));
+    const toRaw = getHeader('To');
+    const ccRaw = getHeader('Cc');
+    const inReplyTo = getHeader('In-Reply-To').trim();
+    const listUnsubscribe = getHeader('List-Unsubscribe').trim();
     const type = this.inferEmailType(from, subject, message.labelIds);
     const authoringTier: AuthoringTier = classifyEmailAuthoringTier({
       labels: message.labelIds ?? [],
       fromAddress: from,
-      toAddresses: splitAddressList(getHeader('To')),
-      ccAddresses: splitAddressList(getHeader('Cc')),
-      hasInReplyTo: getHeader('In-Reply-To').trim().length > 0,
-      hasListUnsubscribe: getHeader('List-Unsubscribe').trim().length > 0,
+      toAddresses: splitAddressList(toRaw),
+      ccAddresses: splitAddressList(ccRaw),
+      hasInReplyTo: inReplyTo.length > 0,
+      hasListUnsubscribe: listUnsubscribe.length > 0,
       listId,
     });
 
@@ -413,6 +417,14 @@ export class GmailConnector implements SignalConnector {
         messageId: message.id,
         threadId: message.threadId,
         from,
+        // Persist the raw header fields used by the classifier so the
+        // tier-backfill worker (#251 follow-up) can reclassify any page
+        // that's missing `authoringTier` without re-fetching from Gmail.
+        // Cheap — these are short strings already pulled into memory.
+        to: toRaw,
+        cc: ccRaw,
+        inReplyTo,
+        listUnsubscribe,
         subject,
         snippet: message.snippet,
         labels: message.labelIds,

--- a/packages/memory-gbrain-crdb-adapter/src/__tests__/in-memory-repository.test.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/__tests__/in-memory-repository.test.ts
@@ -377,3 +377,121 @@ describe('InMemoryBrainStore — metadata overrides (#251 privacy)', () => {
     expect(n).toBe(0);
   });
 });
+
+describe('InMemoryBrainStore — findPagesMissingAuthoringTier (#251 backfill)', () => {
+  let store: InMemoryBrainStore;
+  beforeEach(() => {
+    store = new InMemoryBrainStore();
+  });
+
+  it('returns pages missing authoringTier paired with their signal data', () => {
+    // Seed a signal + a page that references it via source_ref.
+    store.insertSignal({
+      id: 'sig-1',
+      userId: 'u1',
+      source: 'gmail',
+      type: 'email',
+      data: { from: 'me@example.com', labels: ['SENT'] },
+      signalTimestamp: new Date(),
+    });
+    store.insertPage({
+      userId: 'u1',
+      content: 'a',
+      source: 'signal',
+      sourceRef: 'sig-1',
+      metadata: { signalSource: 'gmail' }, // intentionally no authoringTier
+    });
+    // A second page that already HAS a tier — must not be returned.
+    store.insertSignal({
+      id: 'sig-2',
+      userId: 'u1',
+      source: 'gmail',
+      type: 'email',
+      data: { from: 'a@example.com' },
+      signalTimestamp: new Date(),
+    });
+    store.insertPage({
+      userId: 'u1',
+      content: 'b',
+      source: 'signal',
+      sourceRef: 'sig-2',
+      metadata: { authoringTier: 'inbox_personal' },
+    });
+
+    const rows = store.findPagesMissingAuthoringTier(null, 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.user_id).toBe('u1');
+    expect(rows[0]!.signal_data['from']).toBe('me@example.com');
+  });
+
+  it('skips pages whose source_ref does not match a stored signal', () => {
+    store.insertPage({
+      userId: 'u1',
+      content: 'orphan',
+      source: 'signal',
+      sourceRef: 'no-such-signal',
+      metadata: {},
+    });
+    const rows = store.findPagesMissingAuthoringTier(null, 10);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('scopes by userId when supplied', () => {
+    store.insertSignal({
+      id: 'sig-a',
+      userId: 'u1',
+      source: 'gmail',
+      type: 'email',
+      data: { from: 'x@example.com' },
+      signalTimestamp: new Date(),
+    });
+    store.insertSignal({
+      id: 'sig-b',
+      userId: 'u2',
+      source: 'gmail',
+      type: 'email',
+      data: { from: 'y@example.com' },
+      signalTimestamp: new Date(),
+    });
+    store.insertPage({
+      userId: 'u1',
+      content: 'a',
+      source: 'signal',
+      sourceRef: 'sig-a',
+      metadata: {},
+    });
+    store.insertPage({
+      userId: 'u2',
+      content: 'b',
+      source: 'signal',
+      sourceRef: 'sig-b',
+      metadata: {},
+    });
+
+    expect(store.findPagesMissingAuthoringTier('u1', 10)).toHaveLength(1);
+    expect(store.findPagesMissingAuthoringTier('u2', 10)).toHaveLength(1);
+    expect(store.findPagesMissingAuthoringTier(null, 10)).toHaveLength(2);
+  });
+
+  it('caps the result set at `limit`', () => {
+    for (let i = 0; i < 5; i++) {
+      const id = `sig-${i}`;
+      store.insertSignal({
+        id,
+        userId: 'u1',
+        source: 'gmail',
+        type: 'email',
+        data: { from: 'x@example.com' },
+        signalTimestamp: new Date(),
+      });
+      store.insertPage({
+        userId: 'u1',
+        content: `p${i}`,
+        source: 'signal',
+        sourceRef: id,
+        metadata: {},
+      });
+    }
+    expect(store.findPagesMissingAuthoringTier(null, 2)).toHaveLength(2);
+  });
+});

--- a/packages/memory-gbrain-crdb-adapter/src/in-memory-repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/in-memory-repository.ts
@@ -212,6 +212,37 @@ export class InMemoryBrainStore {
     return 1;
   }
 
+  /**
+   * Mirror of `repository.findPagesMissingAuthoringTier`. Returns at most
+   * `limit` pages whose metadata is missing `authoringTier` and whose
+   * `source_ref` matches a stored signal id.
+   */
+  findPagesMissingAuthoringTier(
+    userId: string | null,
+    limit: number,
+  ): Array<{ page_id: string; user_id: string; signal_data: Record<string, unknown> }> {
+    const out: Array<{
+      page_id: string;
+      user_id: string;
+      signal_data: Record<string, unknown>;
+    }> = [];
+    for (const page of this.pages.values()) {
+      if (userId !== null && page.user_id !== userId) continue;
+      const meta = (page.metadata ?? {}) as Record<string, unknown>;
+      if (typeof meta['authoringTier'] === 'string') continue;
+      if (!page.source_ref) continue;
+      const sig = this.signals.get(page.source_ref);
+      if (!sig) continue;
+      out.push({
+        page_id: page.id,
+        user_id: page.user_id,
+        signal_data: sig.data as Record<string, unknown>,
+      });
+      if (out.length >= limit) break;
+    }
+    return out;
+  }
+
   /** Mirror of `repository.hideAllPagesFromSender`. */
   hideAllPagesFromSender(userId: string, fromAddress: string): number {
     const target = fromAddress.toLowerCase();

--- a/packages/memory-gbrain-crdb-adapter/src/index.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/index.ts
@@ -74,5 +74,7 @@ export {
   countUserSentPages,
   updatePageMetadata,
   hideAllPagesFromSender,
+  findPagesMissingAuthoringTier,
 } from './repository.js';
+export type { PageMissingTierRow } from './repository.js';
 export type { HybridSearchOptions } from './repository.js';

--- a/packages/memory-gbrain-crdb-adapter/src/repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/repository.ts
@@ -146,6 +146,53 @@ export async function updatePageMetadata(
 }
 
 /**
+ * Find pages whose metadata is missing `authoringTier` and that have a
+ * matching brain_signals row (so the worker can reclassify from the
+ * stored signal data). Used by the tier-backfill worker (#251 follow-up).
+ *
+ * Returns rows scoped to a single user when `userId` is provided, or all
+ * users when called with `null`. The page's `source_ref` carries the
+ * signal id (`sig_gmail_*`), so we join brain_pages → brain_signals on
+ * `id = source_ref`. Pages without a matching signal row are skipped —
+ * those came from a non-signal write path (episode, entity) and don't
+ * have classifiable email headers.
+ *
+ * Limit is mandatory and caps the worker's per-pass work — a thousand
+ * pages per cycle is the default in the worker; callers can pass less
+ * for tests.
+ */
+export interface PageMissingTierRow {
+  page_id: string;
+  user_id: string;
+  signal_data: Record<string, unknown>;
+}
+
+export async function findPagesMissingAuthoringTier(
+  userId: string | null,
+  limit: number,
+): Promise<PageMissingTierRow[]> {
+  const userFilter = userId === null ? '' : 'AND p.user_id = $2';
+  const params: unknown[] = userId === null ? [limit] : [limit, userId];
+  const result = await query<PageMissingTierRow>(
+    `SELECT p.id AS page_id, p.user_id AS user_id, s.data AS signal_data
+       FROM brain_pages p
+       JOIN brain_signals s ON s.id = p.source_ref
+      WHERE p.metadata->>'authoringTier' IS NULL
+        ${userFilter}
+      LIMIT $1`,
+    params,
+  );
+  return result.rows.map((row) => ({
+    page_id: row.page_id,
+    user_id: row.user_id,
+    signal_data:
+      typeof row.signal_data === 'string'
+        ? (JSON.parse(row.signal_data) as Record<string, unknown>)
+        : (row.signal_data ?? {}),
+  }));
+}
+
+/**
  * Bulk-hide every brain_page where `metadata.fromAddress` matches the
  * given sender. Used by the per-sender "stop indexing this address"
  * action (#251 privacy follow-up). Returns the affected row count so

--- a/packages/memory-gbrain-crdb-adapter/src/repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/repository.ts
@@ -157,9 +157,9 @@ export async function updatePageMetadata(
  * those came from a non-signal write path (episode, entity) and don't
  * have classifiable email headers.
  *
- * Limit is mandatory and caps the worker's per-pass work — a thousand
- * pages per cycle is the default in the worker; callers can pass less
- * for tests.
+ * Limit is mandatory and caps the worker's per-pass work — the worker's
+ * default batch size is 200; callers can pass any value (lower for tests,
+ * higher if you're catching up a large back-catalog manually).
  */
 export interface PageMissingTierRow {
   page_id: string;
@@ -185,10 +185,11 @@ export async function findPagesMissingAuthoringTier(
   return result.rows.map((row) => ({
     page_id: row.page_id,
     user_id: row.user_id,
-    signal_data:
-      typeof row.signal_data === 'string'
-        ? (JSON.parse(row.signal_data) as Record<string, unknown>)
-        : (row.signal_data ?? {}),
+    // Reuse the file-local `parseJson` helper so a single malformed/corrupt
+    // signal row can't blow up the whole worker pass. parseJson returns
+    // null on JSON.parse failure; we coerce to {} so the worker logs the
+    // row as "unreclassifiable" rather than crashing.
+    signal_data: parseJson(row.signal_data) ?? {},
   }));
 }
 


### PR DESCRIPTION
## Summary

Pages indexed before #252 (Layer 1) have no `authoringTier` on metadata, which silently disables Layer 2 for their corpora — the multiplier reads `metadata.authoringTier` and there's nothing to read. This adds a worker that fills it in retroactively, plus the connector now persists the raw classification headers so reclassification works for every new signal going forward.

**Closes (partial): #251 backfill follow-up.** Pre-Layer-1 signals that don't carry classification headers stay untagged after this — full recovery for those needs a Gmail re-fetch (separate sub-issue, lower priority).

## What runs now

The worker schedules `runTierBackfillJob` every hour. Each pass:

1. Queries `brain_pages` for rows where `metadata->>'authoringTier' IS NULL`, joins on `brain_signals` via `source_ref`, returns up to 200 pairs.
2. For each page, tries two reclassification paths in order:
   - **Trust the signal** — copy `signal.data.authoringTier` to page metadata when it already exists. Cheap, lossless, same tier the connector produced at ingest time.
   - **Reclassify** — run `classifyEmailAuthoringTier` locally on the raw `to` / `cc` / `inReplyTo` / `listUnsubscribe` / `listId` / `labels` headers stored in `signal.data`.
3. Writes the result via `updatePageMetadata` (sets both `authoringTier` and a normalized `fromAddress` for the per-sender bulk-hide action shipped in PR #270).
4. Logs an "unreclassifiable" count for signals carrying neither path and leaves them alone.

Idempotent: re-running on a fully-tagged corpus returns 0 from the find query and the pass is a no-op.

## Engine changes

- **`findPagesMissingAuthoringTier(userId | null, limit)`** new adapter helper. JOIN `brain_pages` ↔ `brain_signals` on `source_ref = id`, filter on tier-missing, optional user scope. Returns `{ page_id, user_id, signal_data }[]`.
- **`apps/worker/src/jobs/tier-backfill.ts`** new worker job + scheduled in `apps/worker/src/index.ts` at `TIER_BACKFILL_INTERVAL_MS = 60 * 60 * 1000`. Bounded by `batchSize` (default 200).
- **Gmail connector** `messageToSignal` now also stamps `to`, `cc`, `inReplyTo`, `listUnsubscribe` on `signal.data`. The classifier already consumed these; now they're preserved in the signal row for future reclassification.
- In-memory mirror of the find query for tests.

## Tests

- 9 new worker unit tests (`tier-backfill.test.ts`) cover signal-tier copy, header reclassification (SENT label + List-Unsubscribe → newsletter), unreclassifiable count, failed-update isolation, find-query throw → empty summary, fromAddress omission when missing, userId scope, default null scope.
- 4 new in-memory repository tests on `findPagesMissingAuthoringTier`: tier-present page excluded, signal-missing page skipped, userId scoping, limit cap.

## Test plan

- [x] `pnpm build --concurrency=1` → 35/35 packages.
- [x] `pnpm test` → 70/70 turbo tasks green.
- [x] `pnpm --filter @skytwin/worker test -- tier-backfill` → 9 pass.
- [x] `pnpm --filter @skytwin/memory-gbrain-crdb-adapter test` → 80 pass / 6 skipped (DB-gated).

## Deferred

- Pre-#252 signals that don't carry classification headers (oldest mail in a long-connected mailbox) stay untagged after this lands. The worker logs them as `unreclassifiable`. Recovering their tier needs an OAuth-token-dependent re-fetch from Gmail — separate sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)