### PR TITLE
feat(#251 follow-up): real-embedding ablation result + opt-in test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The regression is structural to the multiplicative weighting approach:
 - Switch from multiplicative weighting (`score *= tier_weight`) to additive bonuses (`score += tier_bonus`) sized to flip close calls without leapfrogging strong matches. Estimated +0.005 for authored-originated, -0.005 for automated, on raw RRF scores in the 0.016–0.033 range — enough to break ties without overwhelming relevance.
 - Re-run the ablation with the additive approach. Target: received_content MRR ≥ 0.95 while preserving user_behavior MRR = 1.0.
 
-That's a separate sub-issue — out of scope for tonight.
+That's a separate sub-issue — out of scope for this PR.
 
 ### What ships now
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Real-embedding ablation result for Layer 2 (#251 follow-up)
+
+Ran the tier-ablation eval against a real semantic embedding model (Ollama's `nomic-embed-text`) to validate the hypothesis that hash-trick spurious overlap was the cause of the `received_content` MRR regression first surfaced in PR #260. **The hypothesis was wrong.**
+
+### Result
+
+| Metric | pure-RRF | tier-weighted |
+|---|---|---|
+| user_behavior MRR (n=3) | 0.667 | **1.000** |
+| received_content MRR (n=3) | 1.000 | **~0.54** |
+| neutral MRR (n=1) | 1.000 | 1.000 |
+
+The `received_content` number with real embeddings (~0.54) is essentially identical to the hash-trick floor (0.542 in PR #260). Hash-trick was not the cause.
+
+### Diagnosis
+
+The regression is structural to the multiplicative weighting approach:
+
+- `user_sent_originated × 1.5` vs `inbox_automated × 0.8` produces a **1.875×** swing. Any page within 53% of the top raw score that's `authored_*` will leapfrog a strong-but-demoted primary hit.
+- The floor-ratio gate (default 0.85) helps but isn't enough. With real semantic embeddings, an authored page from a *completely unrelated* query (e.g. q1 Series B pitch) has non-trivial similarity to q5 ("GitHub Actions CI failure") — enough to land in the candidate pool above the threshold. The 1.5× boost on that unrelated content then beats the 0.8× demote on the actually-relevant primary.
+- Diagnostic dump from the eval confirms: q5's primary lands at rank 8/9 with tier-on, behind three authored pages from unrelated queries plus several distractors.
+
+### Decision
+
+**Layer 2 stays opt-in.** The default-on rollout is blocked on a structural fix, not on environment / corpus / eval setup. The likely path:
+
+- Switch from multiplicative weighting (`score *= tier_weight`) to additive bonuses (`score += tier_bonus`) sized to flip close calls without leapfrogging strong matches. Estimated +0.005 for authored-originated, -0.005 for automated, on raw RRF scores in the 0.016–0.033 range — enough to break ties without overwhelming relevance.
+- Re-run the ablation with the additive approach. Target: received_content MRR ≥ 0.95 while preserving user_behavior MRR = 1.0.
+
+That's a separate sub-issue — out of scope for tonight.
+
+### What ships now
+
+- New opt-in test branch in `tier-ablation-eval.test.ts` gated on `RUN_REAL_EMBEDDING_EVAL=1`. Anyone with Ollama on `localhost:11434` and `nomic-embed-text` pulled can reproduce. Defaults respect `OPENAI_EMBEDDING_BASE_URL` / `OPENAI_EMBEDDING_MODEL` / `OPENAI_EMBEDDING_API_KEY` so a real OpenAI key works too.
+- `runOneMode` in the eval helper takes an optional `embedding` provider so the same harness drives both the always-on (hash-trick) and opt-in (real) tests.
+
+### Side note
+
+This is exactly what the eval was designed to surface — and exactly the kind of negative-result-with-clear-next-step that justifies the engineering effort of building an eval guardrail. PR #260's `received_content ≥ 0.40` assertion held; we just learned where the real ceiling sits under the current design.
+
 ## [unreleased] — Authoring-tier backfill worker (#251 follow-up)
 
 Pages indexed before Layer 1 of #251 (where the Gmail connector started stamping `authoringTier` on every signal) had no tier on their metadata — which meant the Layer 2 multiplier did nothing for them. This adds a worker job that retroactively fills in the tier for those pages, plus the connector keeps the raw headers needed to reclassify going forward.

--- a/packages/memory-gbrain/src/__tests__/tier-ablation-eval.test.ts
+++ b/packages/memory-gbrain/src/__tests__/tier-ablation-eval.test.ts
@@ -191,12 +191,12 @@ function printReport(off: AblationRun, on: AblationRun): void {
     // If the primary slipped off the top-10 with tier-on but was found
     // with pure-RRF, dump what's actually in the top-10 — this is the
     // signal for tuning the multipliers. Also dump when the primary
-    // degrades by more than 3 ranks — that's the case where Layer 2
-    // is reordering legitimately-strong primary hits behind other content.
+    // degrades by 3 or more ranks — that's the case where Layer 2 is
+    // reordering legitimately-strong primary hits behind other content.
     const degradedSignificantly =
       Number.isFinite(o.rankPrimary) &&
       Number.isFinite(n.rankPrimary) &&
-      n.rankPrimary - o.rankPrimary > 2;
+      n.rankPrimary - o.rankPrimary >= 3;
     if (
       (Number.isFinite(o.rankPrimary) && !Number.isFinite(n.rankPrimary)) ||
       degradedSignificantly
@@ -281,12 +281,15 @@ describe('#251 Layer 2 ablation — tier weighting vs pure RRF', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────
-// Real-embedding ablation — opt-in. Validates the working hypothesis that
-// hash-trick embeddings exaggerate the `received_content` MRR regression
-// because of spurious token overlap, and that real semantic embeddings
-// preserve the user_behavior lift WITHOUT the regression. Gated on
-// `RUN_REAL_EMBEDDING_EVAL=1` and an OpenAI-compatible endpoint reachable
-// at `OPENAI_EMBEDDING_BASE_URL` (defaults to local Ollama).
+// Real-embedding ablation — opt-in. Captures the side-by-side R@5 / P@5 /
+// MRR-primary numbers when the eval runs against a real semantic embedding
+// model (Ollama nomic-embed-text by default; any OpenAI-compatible
+// endpoint via OPENAI_EMBEDDING_BASE_URL). Originally added to test
+// whether real embeddings would close the `received_content` MRR gap; the
+// answer turned out to be no (see the long comment on the test below).
+// Now lives on as a permanent reproducible artifact so the next person
+// touching Layer 2 weighting can re-run the same harness against whatever
+// they ship. Gated on `RUN_REAL_EMBEDDING_EVAL=1`.
 // ─────────────────────────────────────────────────────────────────────────
 
 const RUN_REAL = process.env['RUN_REAL_EMBEDDING_EVAL'] === '1';

--- a/packages/memory-gbrain/src/__tests__/tier-ablation-eval.test.ts
+++ b/packages/memory-gbrain/src/__tests__/tier-ablation-eval.test.ts
@@ -30,6 +30,8 @@ import { EmbeddedGbrainMemoryPort } from '../embedded-port.js';
 import {
   HashEmbeddingProvider,
   InMemoryBrainStore,
+  OpenAiEmbeddingProvider,
+  type EmbeddingProvider,
 } from '@skytwin/memory-gbrain-crdb-adapter';
 import {
   buildTierAblationCorpus,
@@ -125,9 +127,10 @@ async function runOneMode(args: {
   enabled: boolean;
   queries: TierAblationQuery[];
   corpus: ReturnType<typeof buildTierAblationCorpus>;
+  embedding?: EmbeddingProvider;
 }): Promise<AblationRun> {
   const store = new InMemoryBrainStore();
-  const emb = new HashEmbeddingProvider(256);
+  const emb = args.embedding ?? new HashEmbeddingProvider(256);
   const port = new EmbeddedGbrainMemoryPort({
     userId: USER,
     backend: 'memory',
@@ -187,8 +190,17 @@ function printReport(off: AblationRun, on: AblationRun): void {
     );
     // If the primary slipped off the top-10 with tier-on but was found
     // with pure-RRF, dump what's actually in the top-10 — this is the
-    // signal for tuning the multipliers.
-    if (Number.isFinite(o.rankPrimary) && !Number.isFinite(n.rankPrimary)) {
+    // signal for tuning the multipliers. Also dump when the primary
+    // degrades by more than 3 ranks — that's the case where Layer 2
+    // is reordering legitimately-strong primary hits behind other content.
+    const degradedSignificantly =
+      Number.isFinite(o.rankPrimary) &&
+      Number.isFinite(n.rankPrimary) &&
+      n.rankPrimary - o.rankPrimary > 2;
+    if (
+      (Number.isFinite(o.rankPrimary) && !Number.isFinite(n.rankPrimary)) ||
+      degradedSignificantly
+    ) {
       console.log(`    └─ tier-on top-10: ${n.topIdsExpanded.slice(0, 10).join(', ')}`);
     }
   }
@@ -267,3 +279,86 @@ describe('#251 Layer 2 ablation — tier weighting vs pure RRF', () => {
     expect(on.meanRecallAt5).toBeGreaterThanOrEqual(0.7);
   }, 30_000);
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// Real-embedding ablation — opt-in. Validates the working hypothesis that
+// hash-trick embeddings exaggerate the `received_content` MRR regression
+// because of spurious token overlap, and that real semantic embeddings
+// preserve the user_behavior lift WITHOUT the regression. Gated on
+// `RUN_REAL_EMBEDDING_EVAL=1` and an OpenAI-compatible endpoint reachable
+// at `OPENAI_EMBEDDING_BASE_URL` (defaults to local Ollama).
+// ─────────────────────────────────────────────────────────────────────────
+
+const RUN_REAL = process.env['RUN_REAL_EMBEDDING_EVAL'] === '1';
+
+describe.runIf(RUN_REAL)(
+  '#251 Layer 2 ablation — REAL embeddings (Ollama / nomic-embed-text)',
+  () => {
+    /**
+     * Reality-check result from the real-embedding run:
+     *
+     *   user_behavior MRR       0.667 → 1.000   (intended lift, holds)
+     *   received_content MRR    1.000 → ~0.54   (structural regression)
+     *   neutral MRR             1.000 → 1.000
+     *
+     * The received_content number is essentially identical to the
+     * hash-trick floor (~0.54). My earlier hypothesis — that hash-trick
+     * spurious overlap was inflating the regression — was wrong. The
+     * regression is structural to the multiplicative approach:
+     *
+     *   - authored_originated × 1.5 vs inbox_automated × 0.8 = 1.875×
+     *     swing. Any page within 53% of the top raw score that's
+     *     `authored_*` will leapfrog a strong-but-demoted primary hit.
+     *   - The floor-ratio gate (0.85) helps but isn't enough: with real
+     *     semantic embeddings, q1 Series B authored content has
+     *     non-trivial similarity to q5 ("GitHub Actions CI failure")
+     *     even though they're topically unrelated. That q1 page lands
+     *     in the candidate pool above threshold, gets 1.5×, beats the
+     *     legitimate q5 primary.
+     *
+     * Conclusion: Layer 2 should NOT ship default-on as currently
+     * designed. The honest fix is structural — switch from
+     * multiplicative weighting to additive bonuses (e.g.
+     * `final = raw_rrf + bonus(tier)` with bonuses sized to flip
+     * close calls without leapfrogging strong matches). That's a
+     * follow-up sub-issue, not a knob change.
+     *
+     * For now: keep Layer 2 opt-in, keep the eval as a permanent
+     * artifact that anyone with Ollama can reproduce, and document
+     * the finding in the CHANGELOG / issue.
+     */
+    it('produces the side-by-side numbers + asserts the realistic guardrail bars', async () => {
+      const corpus = buildTierAblationCorpus();
+      const queries = buildTierAblationQueries();
+      const baseUrl =
+        process.env['OPENAI_EMBEDDING_BASE_URL'] ?? 'http://localhost:11434/v1';
+      const model = process.env['OPENAI_EMBEDDING_MODEL'] ?? 'nomic-embed-text';
+      const apiKey = process.env['OPENAI_EMBEDDING_API_KEY'] ?? 'ollama';
+      const real = new OpenAiEmbeddingProvider({ apiKey, model, baseUrl });
+
+      const off = await runOneMode({ enabled: false, queries, corpus, embedding: real });
+      const on = await runOneMode({ enabled: true, queries, corpus, embedding: real });
+
+      // Print the side-by-side numbers — the headline result this eval
+      // exists to produce. Captured in CHANGELOG entries when meaningful.
+      printReport(off, on);
+
+      // user_behavior queries must still lift with real embeddings.
+      expect(on.byClass.user_behavior.meanRRPrimary).toBeGreaterThanOrEqual(
+        off.byClass.user_behavior.meanRRPrimary,
+      );
+
+      // neutral queries must not regress.
+      expect(on.byClass.neutral.meanRRPrimary).toBeGreaterThanOrEqual(
+        off.byClass.neutral.meanRRPrimary - 0.05,
+      );
+
+      // received_content: realistic guardrail bar matches the hash-trick
+      // test (0.40). The known structural regression measured at ~0.54
+      // sits comfortably above. A future redesign (additive tier
+      // bonuses) should push this number toward 0.95; tighten the bar
+      // at that point.
+      expect(on.byClass.received_content.meanRRPrimary).toBeGreaterThanOrEqual(0.4);
+    }, 90_000);
+  },
+);


### PR DESCRIPTION
## Summary

Negative result with a clear next step. The working hypothesis going into this run was: hash-trick spurious overlap was inflating the `received_content` MRR regression first surfaced in PR #260; real semantic embeddings should improve the number materially. **The hypothesis was wrong.**

## Numbers

Ran the tier-ablation eval against Ollama + `nomic-embed-text` (a real semantic model, ~137M params, 768-dim) and compared to the hash-trick baseline:

| Metric | pure-RRF | tier-weighted (hash) | tier-weighted (real) |
|---|---|---|---|
| `user_behavior` MRR (n=3) | 0.667 | **1.000** | **1.000** |
| `received_content` MRR (n=3) | 1.000 | 0.542 | **~0.54** |
| `neutral` MRR (n=1) | 1.000 | 1.000 | 1.000 |

The real-embedding `received_content` number is essentially identical to the hash-trick floor. Hash-trick was not the cause.

## What's actually broken

The regression is structural to the multiplicative weighting approach:

- `user_sent_originated × 1.5` vs `inbox_automated × 0.8` = **1.875×** swing.
- Any page within 53% of the top raw score that's `authored_*` will leapfrog a strong-but-demoted primary hit on a `received_*` query.
- The floor-ratio gate (0.85 default) helps but isn't enough. With real semantic embeddings, an authored page from a *completely unrelated* query (e.g. q1's Series B pitch deck) has non-trivial similarity to q5 ("GitHub Actions CI failed on main") — enough to land in the candidate pool above threshold, where the 1.5× boost then beats the legitimate primary.
- Diagnostic dump from the eval, q5 top-10 with tier-on:
  `q7-authored-1, q3-authored-long, q1-authored-1, distractor-004, q2-received-1, distractor-014, distractor-034, q5-received-1, q6-received-1, distractor-024`
  The actual primary lands at rank 8.

## Decision

**Layer 2 stays opt-in.** The default-on rollout is blocked on a structural fix, not on environment / corpus / eval setup. Best-judgment path:

- Switch from multiplicative weighting (`score *= tier_weight`) to **additive bonuses** (`score += tier_bonus`) sized to flip close calls without leapfrogging strong matches. For RRF scores in the 0.016–0.033 range, bonuses around ±0.005 should give authored a tie-breaker edge without overwhelming a clear relevance gap.
- Re-run the ablation against the additive design. Target: `received_content` MRR ≥ 0.95 while preserving `user_behavior` MRR = 1.0.
- Separate sub-issue — out of scope for this PR.

## What this PR ships

- New opt-in `describe` block in `tier-ablation-eval.test.ts` gated on `RUN_REAL_EMBEDDING_EVAL=1`. Reproducible with any local Ollama or OpenAI key — defaults respect `OPENAI_EMBEDDING_BASE_URL` / `OPENAI_EMBEDDING_MODEL` / `OPENAI_EMBEDDING_API_KEY`. Pre-pulled Ollama with `nomic-embed-text` is the cheapest way to run it.
- `runOneMode` helper now takes an optional `embedding` provider so the same harness drives both the always-on hash-trick test and the opt-in real-embedding test. No duplication.
- Diagnostic dump in `printReport` now triggers for queries that degrade by more than 2 ranks (not just "missing"), so future tuning has better signal for partially-regressed cases.

The opt-in test asserts the realistic guardrail bars (`received_content ≥ 0.4`, user_behavior must lift, neutral must not regress) — same shape as the always-on test, so a future regression in the implementation surfaces in either mode.

## Why ship a negative result

Because the ENGINEERING DECISION is now made on data instead of vibes. PR #260 explicitly said "we'll know whether Layer 2 default-on is safe once we run this against real embeddings." We ran it. The answer is "not yet." That's worth committing — both as a permanent artifact and as a clear signal to the next person picking up the additive-redesign sub-issue.

## Test plan

- [x] `pnpm --filter @skytwin/memory-gbrain test -- tier-ablation-eval` → 1 pass, 1 skipped (gated test).
- [x] `RUN_REAL_EMBEDDING_EVAL=1 pnpm --filter @skytwin/memory-gbrain test -- tier-ablation-eval` → 2 pass (both modes), prints side-by-side report.
- [x] Build + workspace test pre-flight: was clean before this PR (most recent main: PR #271 merged 23:47Z).

🤖 Generated with [Claude Code](https://claude.com/claude-code)