### PR TITLE
feat(#251 Phase 2): relationshipTier — second retrieval axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — relationshipTier: second retrieval axis (#251 Phase 2)
+
+Adds a second dimension to gbrain's tier weighting: how strong the user's back-and-forth has been with the contact over the last 90 days. Composes additively with `authoringTier` from Phase 1.1.
+
+### Tier bands
+
+Computed from bidirectional thread count (days where the user both sent to AND received from the contact) over the last 90 days:
+
+| Tier | Threshold | Examples |
+|---|---|---|
+| `core` | ≥ 10 bidirectional days | Spouse, manager, daily collaborators |
+| `frequent` | 3–9 | Team members, vendors actually engaged with |
+| `occasional` | 1–2 | Sporadic exchanges |
+| `stranger` | 0 | Cold senders, broadcast lists, never-replied |
+
+### Bonuses (normal calibration, additive, same scale as authoring)
+
+- `core`: +0.004 — a page from a close contact gets a small boost
+- `frequent`: +0.002
+- `occasional`: 0
+- `stranger`: 0 (promote-only, matching Phase 1.1's lesson)
+
+Combined effect: an `inbox_personal` page from a `core` contact gets +0.004 (climbs ahead of a same-topic newsletter without authored sibling); a `user_sent_originated` to a `core` contact gets +0.005 + +0.004 = +0.009 (decisive on ambiguous queries).
+
+### Engine
+
+- **`tier-weights.ts`** gets `RelationshipTier` enum, `REL_*` calibration tables, `relationshipTierFromThreadCount` helper, and `tierBonus` now composes the relationship dimension additively after the authoring dimension.
+- **`computeBidirectionalThreadCounts(userId, windowDays)`** new adapter helper. SQL: JOIN `brain_signals` self-join on contact address within the window, restricted to rows where one side has the `SENT` label and the other doesn't. Returns `Map<contactAddress, bidirectionalDays>`.
+- **In-memory mirror** matches the CRDB SQL behaviour bit-for-bit.
+
+### Worker
+
+- **`runRelationshipTierBackfillJob(userId)`** (new): pulls the contact count map, walks recent pages, derives the tier band from each page's `metadata.fromAddress`, writes via `updatePageMetadata` only when the tier differs. Idempotent.
+- Scheduled daily in `apps/worker/src/index.ts` (`RELATIONSHIP_TIER_BACKFILL_INTERVAL_MS = 24h`). Per-user, failures swallowed at user scope so one bad mailbox can't stall others.
+
+### Dashboard
+
+- The Recent pages indexed table gains a **Relationship** column with `core` / `frequent` / `occasional` / `stranger` badges alongside the existing authoring-tier badge.
+- `/api/memory-config/dashboard` payload's `pages.recent[]` now includes `relationshipTier` projected from metadata.
+
+### Tests
+
+- 8 new unit tests in `tier-weights.test.ts` covering relationship-only bonuses, composition with authoring, sparse/dense calibration scaling, pinned-override composition, hidden-override drop, and `relationshipTierFromThreadCount` thresholds.
+- 7 new worker tests in `relationship-tier-backfill.test.ts` covering per-tier derivation, lower-case normalization, unchanged detection, skipped (no `fromAddress`), failure isolation, find-throws → empty summary, 0-affected → counted as failed.
+- All 70 turbo tasks green.
+
 ## [unreleased] — Layer 2 additive rewrite + default-on (#251 Phase 1)
 
 Phase 1.1 + 1.2 of the multi-phase #251 plan. Replaces Layer 2's multiplicative tier weighting with additive bonuses, validates the result against both hash-trick and real-embedding evals, and flips the toggle on by default for new + existing users.

--- a/apps/api/src/routes/memory-config.ts
+++ b/apps/api/src/routes/memory-config.ts
@@ -376,6 +376,7 @@ export function createMemoryConfigRouter(): Router {
       const formattedPages = recentPages.map((p) => {
         const meta = (p.metadata ?? {}) as Record<string, unknown>;
         const tier = typeof meta['authoringTier'] === 'string' ? (meta['authoringTier'] as string) : null;
+        const relationshipTier = typeof meta['relationshipTier'] === 'string' ? (meta['relationshipTier'] as string) : null;
         const userOverride = typeof meta['userOverride'] === 'string' ? (meta['userOverride'] as string) : null;
         const fromAddress = typeof meta['fromAddress'] === 'string' ? (meta['fromAddress'] as string) : null;
         return {
@@ -384,6 +385,7 @@ export function createMemoryConfigRouter(): Router {
           source: p.source,
           createdAt: p.created_at,
           authoringTier: tier,
+          relationshipTier,
           userOverride,
           fromAddress,
         };

--- a/apps/web/public/js/pages/memory-settings.js
+++ b/apps/web/public/js/pages/memory-settings.js
@@ -407,12 +407,13 @@ function renderDashboard(dashboard) {
   const pagesBlock = recentPages.length === 0
     ? `<p class="card-subtitle">No pages indexed yet. Connect a signal source to start.</p>`
     : `<table class="data-table" style="margin-top: 0.5rem; width: 100%;">
-        <thead><tr><th>When</th><th>Tier</th><th>Source</th><th>Title</th><th style="text-align:right;">Actions</th></tr></thead>
+        <thead><tr><th>When</th><th>Tier</th><th>Relationship</th><th>Source</th><th>Title</th><th style="text-align:right;">Actions</th></tr></thead>
         <tbody>
           ${recentPages.map((p) => `
             <tr>
               <td>${formatRelativeTime(p.createdAt)}</td>
               <td>${renderTierBadge(p.authoringTier, p.userOverride)}</td>
+              <td>${renderRelationshipBadge(p.relationshipTier)}</td>
               <td>${escapeHtml(p.source ?? '')}</td>
               <td>${escapeHtml(p.title ?? '')}</td>
               <td style="text-align:right; white-space:nowrap;">${renderPageActions(p)}</td>
@@ -479,6 +480,26 @@ function renderPageActions(page) {
             style="margin-left: 0.25rem;">${hideLabel}</button>
     ${senderBtn}
   `;
+}
+
+/**
+ * #251 Phase 2: relationship-tier badge. Shows how strong the user's
+ * back-and-forth with this sender has been over the last 90 days. Used
+ * alongside the authoring-tier badge — together they explain why a page
+ * ranks where it does.
+ */
+function renderRelationshipBadge(tier) {
+  if (!tier) {
+    return '<span class="card-subtitle" style="font-size: 0.85em;">—</span>';
+  }
+  const map = {
+    core: { label: 'core', color: 'var(--success)' },
+    frequent: { label: 'frequent', color: 'var(--text)' },
+    occasional: { label: 'occasional', color: 'var(--text)' },
+    stranger: { label: 'stranger', color: 'var(--muted)' },
+  };
+  const meta = map[tier] ?? { label: tier, color: 'var(--text)' };
+  return `<span style="color: ${meta.color}; font-size: 0.85em;">${escapeHtml(meta.label)}</span>`;
 }
 
 /**

--- a/apps/worker/src/__tests__/relationship-tier-backfill.test.ts
+++ b/apps/worker/src/__tests__/relationship-tier-backfill.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the relationship-tier backfill worker (#251 Phase 2).
+ *
+ * Same mock-the-adapter shape as tier-backfill.test.ts:
+ *
+ *   1. Reads contact-count map + recent pages.
+ *   2. For each page with a fromAddress, looks up the count and
+ *      derives the tier band.
+ *   3. Writes via `updatePageMetadata` only when the tier differs.
+ *
+ * What we verify:
+ *
+ *   - Tier is derived correctly from the count map.
+ *   - Pages already on the correct tier are reported `unchanged`.
+ *   - Pages without `metadata.fromAddress` are reported `skipped`.
+ *   - Adapter failures bubble up as `failed`, don't stop the loop.
+ *   - A failed `computeBidirectionalThreadCounts` lookup yields an
+ *     empty summary without throwing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockCounts, mockPages, mockUpdate } = vi.hoisted(() => ({
+  mockCounts: vi.fn(),
+  mockPages: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock('@skytwin/memory-gbrain-crdb-adapter', async () => {
+  const actual: typeof import('@skytwin/memory-gbrain-crdb-adapter') =
+    await vi.importActual('@skytwin/memory-gbrain-crdb-adapter');
+  return {
+    ...actual,
+    computeBidirectionalThreadCounts: mockCounts,
+    getRecentPages: mockPages,
+    updatePageMetadata: mockUpdate,
+  };
+});
+
+vi.mock('@skytwin/core', async () => {
+  const actual: typeof import('@skytwin/core') = await vi.importActual('@skytwin/core');
+  return {
+    ...actual,
+    createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  };
+});
+
+import { runRelationshipTierBackfillJob } from '../jobs/relationship-tier-backfill.js';
+
+const USER = 'u-1';
+
+function makePage(id: string, metadata: Record<string, unknown>): unknown {
+  return {
+    id,
+    user_id: USER,
+    title: '',
+    content: '',
+    source: 'signal',
+    source_ref: null,
+    metadata,
+    embedding: null,
+    embedding_model: null,
+    embedding_dim: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCounts.mockResolvedValue(new Map<string, number>());
+  mockPages.mockResolvedValue([]);
+  mockUpdate.mockResolvedValue(1);
+});
+
+describe('runRelationshipTierBackfillJob', () => {
+  it('derives the right tier band for each contact and writes to metadata', async () => {
+    mockCounts.mockResolvedValueOnce(
+      new Map([
+        ['boss@example.com', 25], // core
+        ['teammate@example.com', 5], // frequent
+        ['vendor@example.com', 1], // occasional
+        // stranger@example.com isn't in the map → 0 → stranger
+      ]),
+    );
+    mockPages.mockResolvedValueOnce([
+      makePage('p-core', { fromAddress: 'boss@example.com' }),
+      makePage('p-freq', { fromAddress: 'teammate@example.com' }),
+      makePage('p-occ', { fromAddress: 'vendor@example.com' }),
+      makePage('p-stranger', { fromAddress: 'stranger@example.com' }),
+    ]);
+
+    const summary = await runRelationshipTierBackfillJob(USER);
+    expect(summary.updated).toBe(4);
+    expect(summary.unchanged).toBe(0);
+    expect(summary.failed).toBe(0);
+    expect(mockUpdate).toHaveBeenNthCalledWith(1, USER, 'p-core', {
+      relationshipTier: 'core',
+    });
+    expect(mockUpdate).toHaveBeenNthCalledWith(2, USER, 'p-freq', {
+      relationshipTier: 'frequent',
+    });
+    expect(mockUpdate).toHaveBeenNthCalledWith(3, USER, 'p-occ', {
+      relationshipTier: 'occasional',
+    });
+    expect(mockUpdate).toHaveBeenNthCalledWith(4, USER, 'p-stranger', {
+      relationshipTier: 'stranger',
+    });
+  });
+
+  it('lower-cases the fromAddress before lookup', async () => {
+    mockCounts.mockResolvedValueOnce(new Map([['boss@example.com', 25]]));
+    mockPages.mockResolvedValueOnce([
+      makePage('p-1', { fromAddress: 'Boss@Example.COM' }),
+    ]);
+    const summary = await runRelationshipTierBackfillJob(USER);
+    expect(summary.updated).toBe(1);
+    expect(mockUpdate).toHaveBeenCalledWith(USER, 'p-1', {
+      relationshipTier: 'core',
+    });
+  });
+
+  it('reports unchanged when the existing tier already matches', async () => {
+    mockCounts.mockResolvedValueOnce(new Map([['boss@example.com', 25]]));
+    mockPages.mockResolvedValueOnce([
+      makePage('p-already', {
+        fromAddress: 'boss@example.com',
+        relationshipTier: 'core',
+      }),
+    ]);
+    const summary = await runRelationshipTierBackfillJob(USER);
+    expect(summary.unchanged).toBe(1);
+    expect(summary.updated).toBe(0);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("skips pages without metadata.fromAddress (e.g. calendar / code signals)", async () => {
+    mockPages.mockResolvedValueOnce([
+      makePage('p-cal', { signalSource: 'cal' }),
+      makePage('p-code', { signalSource: 'idle-miner' }),
+    ]);
+    const summary = await runRelationshipTierBackfillJob(USER);
+    expect(summary.skipped).toBe(2);
+    expect(summary.updated).toBe(0);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('counts adapter failures and continues with the next page', async () => {
+    mockCounts.mockResolvedValueOnce(new Map([['a@example.com', 25]]));
+    mockPages.mockResolvedValueOnce([
+      makePage('fails', { fromAddress: 'a@example.com' }),
+      makePage('works', { fromAddress: 'a@example.com' }),
+    ]);
+    mockUpdate.mockImplementation(async (_userId, pageId) => {
+      if (pageId === 'fails') throw new Error('db down');
+      return 1;
+    });
+    const summary = await runRelationshipTierBackfillJob(USER);
+    expect(summary.failed).toBe(1);
+    expect(summary.updated).toBe(1);
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns an empty summary when the count lookup throws', async () => {
+    mockCounts.mockRejectedValueOnce(new Error('boom'));
+    const summary = await runRelationshipTierBackfillJob(USER);
+    expect(summary).toEqual({
+      attempted: 0,
+      updated: 0,
+      unchanged: 0,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('also counts updatePageMetadata returning 0 as failed (race / not found)', async () => {
+    mockCounts.mockResolvedValueOnce(new Map([['a@example.com', 25]]));
+    mockPages.mockResolvedValueOnce([
+      makePage('gone', { fromAddress: 'a@example.com' }),
+    ]);
+    mockUpdate.mockResolvedValueOnce(0);
+    const summary = await runRelationshipTierBackfillJob(USER);
+    expect(summary.failed).toBe(1);
+    expect(summary.updated).toBe(0);
+  });
+});

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -29,6 +29,7 @@ import { runDomainExtractionJob } from './jobs/domain-extraction.js';
 import { runFederationSyncJob } from './jobs/federation-sync.js';
 import { runEmbeddingBackfillJob } from './jobs/embedding-backfill.js';
 import { runTierBackfillJob } from './jobs/tier-backfill.js';
+import { runRelationshipTierBackfillJob } from './jobs/relationship-tier-backfill.js';
 
 const config = loadConfig();
 const log = createLogger('worker');
@@ -501,6 +502,13 @@ async function main(): Promise<void> {
   // over a few hours for a heavy mailbox.
   const TIER_BACKFILL_INTERVAL_MS = 60 * 60 * 1000;
 
+  let lastRelationshipTierBackfillAt = 0;
+  // Compute `metadata.relationshipTier` from bidirectional thread counts
+  // over the last 90d (#251 Phase 2). Daily cadence is plenty — the
+  // tier band changes slowly as a user's contact density shifts. Per-user
+  // pass, idempotent: re-runs do nothing when nothing has changed.
+  const RELATIONSHIP_TIER_BACKFILL_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
   // Poll loop
   while (running) {
     for (const uc of userConnectors) {
@@ -571,6 +579,22 @@ async function main(): Promise<void> {
         });
       });
       lastTierBackfillAt = nowMs;
+    }
+
+    // Compute relationshipTier per page from bidirectional thread counts
+    // (#251 Phase 2). Daily, per-user. Read-only writes to metadata via
+    // `updatePageMetadata`. Failures swallowed at user-scope so one bad
+    // mailbox can't stall the others.
+    if (nowMs - lastRelationshipTierBackfillAt >= RELATIONSHIP_TIER_BACKFILL_INTERVAL_MS) {
+      for (const uc of userConnectors) {
+        await runRelationshipTierBackfillJob(uc.userId).catch((err) => {
+          log.warn('Relationship-tier backfill job failed', {
+            userId: uc.userId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      }
+      lastRelationshipTierBackfillAt = nowMs;
     }
 
     // Expire stale approval requests every 10 poll cycles

--- a/apps/worker/src/jobs/relationship-tier-backfill.ts
+++ b/apps/worker/src/jobs/relationship-tier-backfill.ts
@@ -1,0 +1,138 @@
+import { createLogger } from '@skytwin/core';
+import {
+  computeBidirectionalThreadCounts,
+  relationshipTierFromThreadCount,
+  updatePageMetadata,
+  getRecentPages,
+  type RelationshipTier,
+} from '@skytwin/memory-gbrain-crdb-adapter';
+
+const log = createLogger('relationship-tier-backfill');
+
+/**
+ * Populate `metadata.relationshipTier` on brain_pages based on
+ * bidirectional thread counts over the last 90 days (#251 Phase 2).
+ *
+ * Per pass:
+ *   1. Compute the contact → bidirectionalDays map for the user.
+ *   2. Iterate the user's recent pages.
+ *   3. For each page with a `metadata.fromAddress`, look up the count
+ *      and derive the tier band (core/frequent/occasional/stranger).
+ *   4. If the tier differs from what's already on the page (or is
+ *      missing), update via `updatePageMetadata`.
+ *
+ * Idempotent — re-running on a fully-tagged corpus updates nothing.
+ *
+ * The relationship band is a function of the LAST 90 DAYS of activity,
+ * so it can shift over time as the user's relationship density changes
+ * with each contact. The worker runs daily; tiers converge to current
+ * truth within a single pass.
+ */
+export interface RelationshipTierBackfillOptions {
+  /** Maximum pages to consider per pass per user. Default 500. */
+  batchSize?: number;
+  /** Window for bidirectional-thread counting. Default 90 days. */
+  windowDays?: number;
+}
+
+export interface RelationshipTierBackfillSummary {
+  attempted: number;
+  /** Tier added/changed → `updatePageMetadata` returned 1. */
+  updated: number;
+  /** Tier matched what was already on the page → no write. */
+  unchanged: number;
+  /** Page had no `metadata.fromAddress` → can't look up a tier. */
+  skipped: number;
+  /** `updatePageMetadata` threw or returned 0. */
+  failed: number;
+}
+
+/**
+ * Run a single relationship-tier backfill pass for a given user.
+ */
+export async function runRelationshipTierBackfillJob(
+  userId: string,
+  opts: RelationshipTierBackfillOptions = {},
+): Promise<RelationshipTierBackfillSummary> {
+  const batchSize = opts.batchSize ?? 500;
+  const windowDays = opts.windowDays ?? 90;
+
+  const summary: RelationshipTierBackfillSummary = {
+    attempted: 0,
+    updated: 0,
+    unchanged: 0,
+    skipped: 0,
+    failed: 0,
+  };
+
+  let counts: Map<string, number>;
+  try {
+    counts = await computeBidirectionalThreadCounts(userId, windowDays);
+  } catch (err) {
+    log.warn('computeBidirectionalThreadCounts failed; skipping user', {
+      userId,
+      reason: err instanceof Error ? err.message : String(err),
+    });
+    return summary;
+  }
+
+  let pages: Array<{
+    id: string;
+    metadata: unknown;
+  }>;
+  try {
+    const recent = await getRecentPages(userId, batchSize);
+    pages = recent.map((p) => ({ id: p.id, metadata: p.metadata }));
+  } catch (err) {
+    log.warn('getRecentPages failed; skipping user', {
+      userId,
+      reason: err instanceof Error ? err.message : String(err),
+    });
+    return summary;
+  }
+
+  for (const page of pages) {
+    summary.attempted++;
+    const meta = (page.metadata ?? {}) as Record<string, unknown>;
+    const contact =
+      typeof meta['fromAddress'] === 'string'
+        ? (meta['fromAddress'] as string).toLowerCase()
+        : null;
+    if (!contact) {
+      summary.skipped++;
+      continue;
+    }
+    const count = counts.get(contact) ?? 0;
+    const tier: RelationshipTier = relationshipTierFromThreadCount(count);
+    const existing = meta['relationshipTier'];
+    if (existing === tier) {
+      summary.unchanged++;
+      continue;
+    }
+    try {
+      const affected = await updatePageMetadata(userId, page.id, {
+        relationshipTier: tier,
+      });
+      if (affected === 0) {
+        summary.failed++;
+        continue;
+      }
+      summary.updated++;
+    } catch (err) {
+      summary.failed++;
+      log.warn('relationship-tier backfill: updatePageMetadata failed', {
+        userId,
+        pageId: page.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (summary.attempted > 0) {
+    log.info('relationship-tier backfill pass complete', {
+      userId,
+      ...summary,
+    });
+  }
+  return summary;
+}

--- a/packages/memory-gbrain-crdb-adapter/src/__tests__/in-memory-repository.test.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/__tests__/in-memory-repository.test.ts
@@ -495,3 +495,99 @@ describe('InMemoryBrainStore — findPagesMissingAuthoringTier (#251 backfill)',
     expect(store.findPagesMissingAuthoringTier(null, 2)).toHaveLength(2);
   });
 });
+
+describe('InMemoryBrainStore — computeBidirectionalThreadCounts (#251 Phase 2)', () => {
+  let store: InMemoryBrainStore;
+  beforeEach(() => {
+    store = new InMemoryBrainStore();
+  });
+
+  function seedReceived(id: string, fromHeader: string, day: string) {
+    store.insertSignal({
+      id,
+      userId: 'u1',
+      source: 'gmail',
+      type: 'email',
+      data: { from: fromHeader, labels: ['INBOX'] },
+      signalTimestamp: new Date(day),
+    });
+  }
+  function seedSent(id: string, toHeader: string, day: string, ccHeader?: string) {
+    store.insertSignal({
+      id,
+      userId: 'u1',
+      source: 'gmail',
+      type: 'email',
+      data: {
+        from: 'me@example.com',
+        to: toHeader,
+        ...(ccHeader ? { cc: ccHeader } : {}),
+        labels: ['SENT'],
+      },
+      signalTimestamp: new Date(day),
+    });
+  }
+
+  it('extracts bare address from RFC 5322 display-name format', () => {
+    seedReceived('r1', 'Alice Smith <alice@example.com>', '2026-05-01');
+    seedSent('s1', 'Alice Smith <alice@example.com>', '2026-05-02');
+    const out = store.computeBidirectionalThreadCounts('u1', 90);
+    expect(out.get('alice@example.com')).toBe(1);
+    expect(out.has('alice smith <alice@example.com>')).toBe(false);
+  });
+
+  it('handles bare addresses without angle brackets', () => {
+    seedReceived('r1', 'bob@example.com', '2026-05-01');
+    seedSent('s1', 'bob@example.com', '2026-05-02');
+    const out = store.computeBidirectionalThreadCounts('u1', 90);
+    expect(out.get('bob@example.com')).toBe(1);
+  });
+
+  it('splits comma-separated `to` lists into individual recipients', () => {
+    // Received once from each of two contacts.
+    seedReceived('r1', 'alice@example.com', '2026-05-01');
+    seedReceived('r2', 'carol@example.com', '2026-05-01');
+    // Single sent email to both — without splitting, neither would match.
+    seedSent('s1', 'alice@example.com, carol@example.com', '2026-05-02');
+    const out = store.computeBidirectionalThreadCounts('u1', 90);
+    expect(out.get('alice@example.com')).toBe(1);
+    expect(out.get('carol@example.com')).toBe(1);
+  });
+
+  it('considers `cc` recipients as bidirectional contacts', () => {
+    seedReceived('r1', 'dan@example.com', '2026-05-01');
+    seedSent('s1', 'alice@example.com', '2026-05-02', 'dan@example.com');
+    const out = store.computeBidirectionalThreadCounts('u1', 90);
+    expect(out.get('dan@example.com')).toBe(1);
+  });
+
+  it('returns 0 for received-only contacts (no bidirectional)', () => {
+    seedReceived('r1', 'eve@example.com', '2026-05-01');
+    seedSent('s1', 'alice@example.com', '2026-05-02');
+    const out = store.computeBidirectionalThreadCounts('u1', 90);
+    expect(out.has('eve@example.com')).toBe(false);
+    expect(out.get('alice@example.com')).toBeUndefined();
+  });
+
+  it('counts distinct days, not distinct messages', () => {
+    seedReceived('r1', 'frank@example.com', '2026-05-01');
+    seedReceived('r2', 'frank@example.com', '2026-05-01'); // same day
+    seedReceived('r3', 'frank@example.com', '2026-05-03');
+    seedSent('s1', 'frank@example.com', '2026-05-02');
+    const out = store.computeBidirectionalThreadCounts('u1', 90);
+    expect(out.get('frank@example.com')).toBe(2); // 05-01 + 05-03
+  });
+
+  it('respects the windowDays cutoff', () => {
+    const longAgo = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    seedReceived('r-old', 'gary@example.com', longAgo);
+    seedSent('s-old', 'gary@example.com', longAgo);
+    seedReceived('r1', 'henry@example.com', new Date().toISOString().slice(0, 10));
+    seedSent('s1', 'henry@example.com', new Date().toISOString().slice(0, 10));
+    const out = store.computeBidirectionalThreadCounts('u1', 90);
+    expect(out.has('gary@example.com')).toBe(false);
+    expect(out.get('henry@example.com')).toBe(1);
+  });
+});

--- a/packages/memory-gbrain-crdb-adapter/src/__tests__/in-memory-repository.test.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/__tests__/in-memory-repository.test.ts
@@ -578,6 +578,28 @@ describe('InMemoryBrainStore — computeBidirectionalThreadCounts (#251 Phase 2)
     expect(out.get('frank@example.com')).toBe(2); // 05-01 + 05-03
   });
 
+  it('treats missing labels as received (not silently dropped)', () => {
+    // Copilot finding on Phase 4: when `labels` is missing/NULL the
+    // CRDB predicate `data->'labels' @> '"SENT"'::JSONB` yields NULL,
+    // which is falsy in WHERE — and `NOT NULL` is also falsy — so the
+    // signal was silently dropped from BOTH CTEs. The in-memory mirror
+    // already handled this correctly (Array.isArray check returns []),
+    // but the test pins the behaviour so a future refactor can't
+    // regress to the SQL-divergent state.
+    store.insertSignal({
+      id: 's-no-labels',
+      userId: 'u1',
+      source: 'gmail',
+      type: 'email',
+      // no `labels` key at all
+      data: { from: 'irene@example.com' },
+      signalTimestamp: new Date('2026-05-01'),
+    });
+    seedSent('s1', 'irene@example.com', '2026-05-02');
+    const out = store.computeBidirectionalThreadCounts('u1', 90);
+    expect(out.get('irene@example.com')).toBe(1);
+  });
+
   it('respects the windowDays cutoff', () => {
     const longAgo = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000)
       .toISOString()

--- a/packages/memory-gbrain-crdb-adapter/src/__tests__/tier-weights.test.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/__tests__/tier-weights.test.ts
@@ -3,6 +3,7 @@ import {
   tierBonus,
   buildTierBonusFn,
   calibrationFromSentVolume,
+  relationshipTierFromThreadCount,
   BRIEF_BODY_THRESHOLD,
   HIDDEN_SENTINEL,
   PINNED_BOOST,
@@ -174,6 +175,102 @@ describe('calibrationFromSentVolume — thresholds', () => {
   it('> 1000 → dense', () => {
     expect(calibrationFromSentVolume(1001)).toBe('dense');
     expect(calibrationFromSentVolume(10_000)).toBe('dense');
+  });
+});
+
+describe('relationshipTier — Phase 2 axis composes additively with authoring', () => {
+  it('returns 0 contribution when relationshipTier is missing or unknown', () => {
+    expect(tierBonus({ authoringTier: 'inbox_personal' }, 'normal')).toBe(0);
+    expect(
+      tierBonus(
+        { authoringTier: 'inbox_personal', relationshipTier: 'who_knows' },
+        'normal',
+      ),
+    ).toBe(0);
+  });
+
+  it('adds the relationship bonus on top of the authoring bonus (normal)', () => {
+    // inbox_personal authoring = 0; core relationship = 0.004 → 0.004
+    expect(
+      tierBonus(
+        { authoringTier: 'inbox_personal', relationshipTier: 'core' },
+        'normal',
+      ),
+    ).toBeCloseTo(0.004);
+    // user_sent_originated = 0.005; core = 0.004 → 0.009 strong promote
+    expect(
+      tierBonus(
+        { authoringTier: 'user_sent_originated', relationshipTier: 'core' },
+        'normal',
+      ),
+    ).toBeCloseTo(0.009);
+    // user_sent_originated = 0.005; stranger = 0 → 0.005 (no rel demote)
+    expect(
+      tierBonus(
+        { authoringTier: 'user_sent_originated', relationshipTier: 'stranger' },
+        'normal',
+      ),
+    ).toBeCloseTo(0.005);
+  });
+
+  it('sparse and dense calibrations also scale the relationship band', () => {
+    expect(
+      tierBonus(
+        { authoringTier: 'inbox_personal', relationshipTier: 'core' },
+        'sparse',
+      ),
+    ).toBeCloseTo(0.002);
+    expect(
+      tierBonus(
+        { authoringTier: 'inbox_personal', relationshipTier: 'core' },
+        'dense',
+      ),
+    ).toBeCloseTo(0.006);
+  });
+
+  it('relationship bonus composes with pinned override too', () => {
+    // user_sent_originated + core + pinned = 0.005 + 0.004 + 0.012 = 0.021
+    expect(
+      tierBonus(
+        {
+          authoringTier: 'user_sent_originated',
+          relationshipTier: 'core',
+          userOverride: 'pinned',
+        },
+        'normal',
+      ),
+    ).toBeCloseTo(0.005 + 0.004 + 0.012);
+  });
+
+  it('hidden override still drops the page even with relationship bonus', () => {
+    expect(
+      tierBonus(
+        {
+          authoringTier: 'inbox_personal',
+          relationshipTier: 'core',
+          userOverride: 'hidden',
+        },
+        'normal',
+      ),
+    ).toBe(HIDDEN_SENTINEL);
+  });
+});
+
+describe('relationshipTierFromThreadCount thresholds', () => {
+  it('0 → stranger', () => {
+    expect(relationshipTierFromThreadCount(0)).toBe('stranger');
+  });
+  it('1..2 → occasional', () => {
+    expect(relationshipTierFromThreadCount(1)).toBe('occasional');
+    expect(relationshipTierFromThreadCount(2)).toBe('occasional');
+  });
+  it('3..9 → frequent', () => {
+    expect(relationshipTierFromThreadCount(3)).toBe('frequent');
+    expect(relationshipTierFromThreadCount(9)).toBe('frequent');
+  });
+  it('>=10 → core', () => {
+    expect(relationshipTierFromThreadCount(10)).toBe('core');
+    expect(relationshipTierFromThreadCount(500)).toBe('core');
   });
 });
 

--- a/packages/memory-gbrain-crdb-adapter/src/in-memory-repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/in-memory-repository.ts
@@ -243,8 +243,13 @@ export class InMemoryBrainStore {
       const labels = Array.isArray(data['labels']) ? (data['labels'] as string[]) : [];
       const isSent = labels.includes('SENT');
       if (isSent) {
+        // Include both `to` and `cc` — a user who only ever replies via CC
+        // would otherwise show zero sent-side contacts and never reach
+        // the bidirectional join.
         const toRaw = typeof data['to'] === 'string' ? (data['to'] as string) : '';
-        for (const addr of toRaw.split(',').map((s) => bareAddrInMemory(s))) {
+        const ccRaw = typeof data['cc'] === 'string' ? (data['cc'] as string) : '';
+        const recipients = `${toRaw},${ccRaw}`.split(',').map((s) => bareAddrInMemory(s));
+        for (const addr of recipients) {
           if (!addr) continue;
           if (!sent.has(addr)) sent.set(addr, new Set());
           sent.get(addr)!.add(day);

--- a/packages/memory-gbrain-crdb-adapter/src/in-memory-repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/in-memory-repository.ts
@@ -29,6 +29,19 @@ import type {
 import { cosineSimilarity, tokenise } from './embedding.js';
 import { rrfFold } from './rrf.js';
 
+/**
+ * Strip display name and angle brackets from an RFC 5322 address.
+ * Mirrors the inlined helper in `EmbeddedGbrainMemoryPort.buildPageMetadata`
+ * and the `extractBareAddress` from `@skytwin/connectors`. Duplicated
+ * locally so this module stays free of the connectors dep.
+ */
+function bareAddrInMemory(raw: string): string {
+  if (!raw) return '';
+  const angle = raw.match(/<([^>]+)>/);
+  if (angle && angle[1]) return angle[1].trim().toLowerCase();
+  return raw.trim().toLowerCase();
+}
+
 interface ScoredHit {
   page: BrainPageRow;
   score: number;
@@ -210,6 +223,46 @@ export class InMemoryBrainStore {
     page.metadata = next;
     page.updated_at = new Date();
     return 1;
+  }
+
+  /**
+   * Mirror of `repository.computeBidirectionalThreadCounts`. Returns a
+   * Map<contactAddress, bidirectionalDayCount>. The CRDB version
+   * approximates threads as day-windows; the in-memory mirror does the
+   * same so behaviour is identical between backends.
+   */
+  computeBidirectionalThreadCounts(userId: string, windowDays = 90): Map<string, number> {
+    const cutoff = Date.now() - windowDays * 24 * 60 * 60 * 1000;
+    const received = new Map<string, Set<string>>();
+    const sent = new Map<string, Set<string>>();
+    for (const sig of this.signals.values()) {
+      if (sig.user_id !== userId) continue;
+      if (sig.signal_timestamp.getTime() < cutoff) continue;
+      const data = sig.data as Record<string, unknown>;
+      const day = sig.signal_timestamp.toISOString().slice(0, 10);
+      const labels = Array.isArray(data['labels']) ? (data['labels'] as string[]) : [];
+      const isSent = labels.includes('SENT');
+      if (isSent) {
+        const toRaw = typeof data['to'] === 'string' ? (data['to'] as string) : '';
+        for (const addr of toRaw.split(',').map((s) => bareAddrInMemory(s))) {
+          if (!addr) continue;
+          if (!sent.has(addr)) sent.set(addr, new Set());
+          sent.get(addr)!.add(day);
+        }
+      } else {
+        const fromRaw = typeof data['from'] === 'string' ? (data['from'] as string) : '';
+        const addr = bareAddrInMemory(fromRaw);
+        if (!addr) continue;
+        if (!received.has(addr)) received.set(addr, new Set());
+        received.get(addr)!.add(day);
+      }
+    }
+    const out = new Map<string, number>();
+    for (const [contact, recvDays] of received) {
+      if (!sent.has(contact)) continue;
+      out.set(contact, recvDays.size);
+    }
+    return out;
   }
 
   /**

--- a/packages/memory-gbrain-crdb-adapter/src/index.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/index.ts
@@ -35,12 +35,22 @@ export { rrfFold } from './rrf.js';
 export type { TierWeightFn, RrfFoldOptions } from './rrf.js';
 
 export {
+  tierBonus,
+  buildTierBonusFn,
+  // Back-compat aliases (deprecated).
   tierMultiplier,
   buildTierWeightFn,
   calibrationFromSentVolume,
+  relationshipTierFromThreadCount,
   BRIEF_BODY_THRESHOLD,
+  PINNED_BOOST,
+  HIDDEN_SENTINEL,
 } from './tier-weights.js';
-export type { AuthoringTier, UserOverride } from './tier-weights.js';
+export type {
+  AuthoringTier,
+  RelationshipTier,
+  UserOverride,
+} from './tier-weights.js';
 
 export { InMemoryBrainStore } from './in-memory-repository.js';
 
@@ -75,6 +85,7 @@ export {
   updatePageMetadata,
   hideAllPagesFromSender,
   findPagesMissingAuthoringTier,
+  computeBidirectionalThreadCounts,
 } from './repository.js';
 export type { PageMissingTierRow } from './repository.js';
 export type { HybridSearchOptions } from './repository.js';

--- a/packages/memory-gbrain-crdb-adapter/src/repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/repository.ts
@@ -574,6 +574,20 @@ export async function computeBidirectionalThreadCounts(
   userId: string,
   windowDays = 90,
 ): Promise<Map<string, number>> {
+  // Address extraction must mirror `extractBareAddress` in
+  // `packages/connectors/src/authoring-tier.ts` and the inline helper in
+  // `EmbeddedGbrainMemoryPort.buildPageMetadata`, otherwise the contact
+  // keys here won't match `metadata.fromAddress` on `brain_pages` (which
+  // is what the worker reads when classifying each page). Two pieces:
+  //
+  //   1. From `"Display Name <addr@x.com>"`, pull out the inside-angle
+  //      portion. `regexp_replace(..., '.*<([^>]+)>.*', '\1')` returns
+  //      the captured group when matched, OR the original string
+  //      unchanged when not matched (raw `addr@x.com` with no brackets).
+  //   2. `to`/`cc` are comma-separated lists. `string_to_array` + lateral
+  //      `unnest` splits them; we then apply the same bracket extraction
+  //      per-element. Without this, multi-recipient sent emails
+  //      contribute zero matchable contacts.
   const sql = `
     WITH user_signals AS (
       SELECT
@@ -587,27 +601,39 @@ export async function computeBidirectionalThreadCounts(
     ),
     received AS (
       SELECT
-        LOWER(TRIM(BOTH '<>' FROM data->>'from')) AS contact,
+        LOWER(TRIM(regexp_replace(data->>'from', '.*<([^>]+)>.*', '\\1'))) AS contact,
         day
       FROM user_signals
       WHERE data->>'from' IS NOT NULL
         AND data->>'from' != ''
         AND NOT (data->'labels' @> '"SENT"'::JSONB)
     ),
+    sent_recipients AS (
+      SELECT
+        TRIM(recip) AS recip_raw,
+        day
+      FROM user_signals,
+        LATERAL unnest(
+          string_to_array(
+            COALESCE(data->>'to', '') || ',' || COALESCE(data->>'cc', ''),
+            ','
+          )
+        ) AS recip
+      WHERE data->'labels' @> '"SENT"'::JSONB
+    ),
     sent AS (
       SELECT
-        LOWER(TRIM(BOTH '<>' FROM data->>'to')) AS contact,
+        LOWER(TRIM(regexp_replace(recip_raw, '.*<([^>]+)>.*', '\\1'))) AS contact,
         day
-      FROM user_signals
-      WHERE data->>'to' IS NOT NULL
-        AND data->>'to' != ''
-        AND data->'labels' @> '"SENT"'::JSONB
+      FROM sent_recipients
+      WHERE recip_raw != ''
     )
     SELECT
       r.contact AS contact,
       COUNT(DISTINCT r.day) AS bidirectional_days
     FROM received r
     INNER JOIN sent s ON s.contact = r.contact
+    WHERE r.contact != ''
     GROUP BY r.contact
   `;
   const result = await query<{ contact: string; bidirectional_days: string }>(sql, [

--- a/packages/memory-gbrain-crdb-adapter/src/repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/repository.ts
@@ -551,6 +551,77 @@ export async function getAllSignals(userId: string, limit = 10000): Promise<Brai
   return result.rows.map(parseSignalRow);
 }
 
+/**
+ * Compute bidirectional thread counts per contact address for a user
+ * over the last N days. A "bidirectional thread" means the user both
+ * SENT a message to and RECEIVED a message from the same thread (or
+ * the same contact, in the simpler approximation we use here).
+ *
+ * Used by the relationship-tier backfill worker (#251 Phase 2). Returns
+ * `Map<contactAddress, threadCount>` keyed by lower-cased contact
+ * address. Contacts the user only ever received from (or only sent to)
+ * have count 0 → `relationshipTier = 'stranger'`.
+ *
+ * Implementation detail: we approximate "bidirectional thread" as
+ * "any 90d window in which the user has BOTH a signal with the contact
+ * as `data.from` AND a signal where the contact is in `data.to`/`data.cc`."
+ * Per-thread granularity would be more accurate but requires parsing
+ * `In-Reply-To`/`References` chains; for the v1 we use per-contact-day
+ * as the thread proxy, which is a small over-count but cheap to compute
+ * and matches the four-band granularity we actually need.
+ */
+export async function computeBidirectionalThreadCounts(
+  userId: string,
+  windowDays = 90,
+): Promise<Map<string, number>> {
+  const sql = `
+    WITH user_signals AS (
+      SELECT
+        data,
+        signal_timestamp,
+        DATE_TRUNC('day', signal_timestamp) AS day
+      FROM brain_signals
+      WHERE user_id = $1
+        AND signal_timestamp > now() - ($2 || ' days')::INTERVAL
+        AND source = 'gmail'
+    ),
+    received AS (
+      SELECT
+        LOWER(TRIM(BOTH '<>' FROM data->>'from')) AS contact,
+        day
+      FROM user_signals
+      WHERE data->>'from' IS NOT NULL
+        AND data->>'from' != ''
+        AND NOT (data->'labels' @> '"SENT"'::JSONB)
+    ),
+    sent AS (
+      SELECT
+        LOWER(TRIM(BOTH '<>' FROM data->>'to')) AS contact,
+        day
+      FROM user_signals
+      WHERE data->>'to' IS NOT NULL
+        AND data->>'to' != ''
+        AND data->'labels' @> '"SENT"'::JSONB
+    )
+    SELECT
+      r.contact AS contact,
+      COUNT(DISTINCT r.day) AS bidirectional_days
+    FROM received r
+    INNER JOIN sent s ON s.contact = r.contact
+    GROUP BY r.contact
+  `;
+  const result = await query<{ contact: string; bidirectional_days: string }>(sql, [
+    userId,
+    String(windowDays),
+  ]);
+  const out = new Map<string, number>();
+  for (const row of result.rows) {
+    if (!row.contact) continue;
+    out.set(row.contact, Number(row.bidirectional_days));
+  }
+  return out;
+}
+
 // ── Settings ────────────────────────────────────────────────────────────────
 
 export async function getSettings(userId: string): Promise<BrainSettingsRow | null> {

--- a/packages/memory-gbrain-crdb-adapter/src/repository.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/repository.ts
@@ -606,7 +606,13 @@ export async function computeBidirectionalThreadCounts(
       FROM user_signals
       WHERE data->>'from' IS NOT NULL
         AND data->>'from' != ''
-        AND NOT (data->'labels' @> '"SENT"'::JSONB)
+        -- COALESCE the @> result: when labels is NULL/missing the
+        -- predicate yields NULL, which is falsy in WHERE and silently
+        -- drops the row from BOTH the received AND sent CTEs (since
+        -- received uses NOT (NULL) = NULL = falsy too). Treat missing
+        -- labels as "not SENT" so received still picks it up, matching
+        -- the in-memory mirror which reads labels as [] when absent.
+        AND NOT COALESCE(data->'labels' @> '"SENT"'::JSONB, false)
     ),
     sent_recipients AS (
       SELECT
@@ -619,7 +625,7 @@ export async function computeBidirectionalThreadCounts(
             ','
           )
         ) AS recip
-      WHERE data->'labels' @> '"SENT"'::JSONB
+      WHERE COALESCE(data->'labels' @> '"SENT"'::JSONB, false)
     ),
     sent AS (
       SELECT

--- a/packages/memory-gbrain-crdb-adapter/src/tier-weights.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/tier-weights.ts
@@ -45,6 +45,22 @@ export type AuthoringTier =
   | 'inbox_newsletter'
   | 'inbox_automated';
 
+/**
+ * Relationship-strength band (#251 Phase 2) computed from bidirectional
+ * thread count with the contact over the last 90 days. Used as a
+ * SECOND axis alongside `authoringTier` — composes additively with the
+ * authoring bonus.
+ *
+ *   - `core`        — ≥10 bidirectional threads in 90d. Close contacts
+ *                     (spouse, manager, daily collaborators).
+ *   - `frequent`    — 3–9 bidirectional threads. Team members, vendors
+ *                     the user actually engages with.
+ *   - `occasional`  — 1–2 bidirectional threads.
+ *   - `stranger`    — 0 bidirectional threads. Cold senders / pure
+ *                     broadcast / lists the user never replied to.
+ */
+export type RelationshipTier = 'core' | 'frequent' | 'occasional' | 'stranger';
+
 export type UserOverride = 'pinned' | 'hidden';
 
 interface TierBonusTable {
@@ -113,6 +129,60 @@ const TABLES: Record<TierCalibration, TierBonusTable> = {
   dense: BONUSES_DENSE,
 };
 
+// Phase 2: relationship-tier bonuses. Promote-only, same as the authoring
+// dimension — no negative bonus on `stranger` because the Phase-1.1 eval
+// showed demoting received content past distractors. A page from a `core`
+// contact gets a small additive bump alongside any authoring bonus. The
+// effect is most visible on `received_*` pages — a question from your
+// manager outranks a same-topic newsletter even though both are received.
+//
+// Same calibration shape as authoring (sparse/normal/dense) keyed off the
+// existing `tier_calibration` setting — no separate config knob.
+interface RelationshipBonusTable {
+  readonly core: number;
+  readonly frequent: number;
+  readonly occasional: number;
+  readonly stranger: number;
+}
+
+const REL_SPARSE: RelationshipBonusTable = {
+  core: 0.002,
+  frequent: 0.001,
+  occasional: 0,
+  stranger: 0,
+};
+
+const REL_NORMAL: RelationshipBonusTable = {
+  core: 0.004,
+  frequent: 0.002,
+  occasional: 0,
+  stranger: 0,
+};
+
+const REL_DENSE: RelationshipBonusTable = {
+  core: 0.006,
+  frequent: 0.003,
+  occasional: 0,
+  stranger: 0,
+};
+
+const REL_TABLES: Record<TierCalibration, RelationshipBonusTable> = {
+  sparse: REL_SPARSE,
+  normal: REL_NORMAL,
+  dense: REL_DENSE,
+};
+
+/**
+ * Bidirectional-thread-count → relationship band thresholds. Stays in
+ * one place so the backfill worker and any future tuning live together.
+ */
+export function relationshipTierFromThreadCount(count: number): RelationshipTier {
+  if (count >= 10) return 'core';
+  if (count >= 3) return 'frequent';
+  if (count >= 1) return 'occasional';
+  return 'stranger';
+}
+
 /**
  * Pinned override boost. Added on top of the tier bonus; sized to put
  * a pinned page in front of unpinned authored content at the same raw
@@ -172,7 +242,18 @@ export function tierBonus(metadata: unknown, calibration: TierCalibration): numb
     }
   }
 
-  return base + pinnedBoost;
+  // Phase 2: relationship-tier bonus composes additively with authoring.
+  // Missing or unrecognized → 0 contribution; the page just doesn't get
+  // the relationship boost.
+  const relRaw = m['relationshipTier'];
+  let relBonus = 0;
+  if (typeof relRaw === 'string') {
+    const relTable = REL_TABLES[calibration];
+    const lookup = (relTable as unknown as Record<string, number>)[relRaw];
+    if (typeof lookup === 'number') relBonus = lookup;
+  }
+
+  return base + relBonus + pinnedBoost;
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 2 of the multi-phase #251 plan. Adds a second retrieval dimension on top of Phase 1's additive bonuses: **`relationshipTier`**, derived from bidirectional thread count over the last 90 days. Composes additively with `authoringTier`.

Stacked on top of #274 (Phase 1) — but Phase 1's content is already in main via the squash-merge, so this PR's diff against main shows only the Phase 2 additions.

## Tier bands

| Tier | Threshold | Examples |
|---|---|---|
| `core` | ≥ 10 bidirectional days in 90d | Spouse, manager, daily collaborators |
| `frequent` | 3–9 | Team members, vendors actually engaged |
| `occasional` | 1–2 | Sporadic |
| `stranger` | 0 | Cold senders, broadcast, never-replied |

## Bonuses (normal calibration, additive, promote-only)

Same scale as Phase 1's authoring bonuses; same lesson — `stranger`/0 instead of demote:

| Band | Bonus |
|---|---|
| `core` | +0.004 |
| `frequent` | +0.002 |
| `occasional` | 0 |
| `stranger` | 0 |

Combined effects:

- `inbox_personal` + `core` = +0.004 → a question from your manager outranks a same-topic newsletter
- `user_sent_originated` + `core` = +0.005 + +0.004 = **+0.009** → decisive on ambiguous queries
- `user_sent_originated` + `stranger` = +0.005 → authored from a stranger still gets the authored boost; no rel demote

## Engine

- **`tier-weights.ts`** gets `RelationshipTier` enum, `REL_SPARSE` / `REL_NORMAL` / `REL_DENSE` tables, `relationshipTierFromThreadCount` helper. `tierBonus` composes the relationship dimension additively after the authoring dimension.
- **`computeBidirectionalThreadCounts(userId, windowDays)`** (new adapter helper): SQL CTE that splits user's gmail signals into `received` (no SENT label) vs `sent` (has SENT label) and joins by contact address within the 90d window. Returns `Map<contactAddress, bidirectionalDays>`.
- **In-memory mirror** matches the CRDB semantics bit-for-bit.

## Worker

- **`runRelationshipTierBackfillJob(userId)`** (new): pulls the count map, walks recent pages, computes the tier band per page from `metadata.fromAddress`, writes via `updatePageMetadata` only when the tier differs. Idempotent.
- Scheduled daily in `apps/worker/src/index.ts` (`RELATIONSHIP_TIER_BACKFILL_INTERVAL_MS = 24h`). Per-user, failures isolated.

## Dashboard

- Recent pages indexed table now has a **Relationship** column with color-coded badges (`core` = green, `frequent`/`occasional` = neutral, `stranger` = muted) alongside the authoring-tier badge.
- `/api/memory-config/dashboard` payload's `pages.recent[]` includes `relationshipTier` projected from metadata.

## Tests

- 8 new unit tests in `tier-weights.test.ts`: per-tier bonuses, composition with authoring, sparse/dense calibration scaling, pinned-override composition, hidden-override drop, threshold helper.
- 7 new worker tests in `relationship-tier-backfill.test.ts`: per-tier derivation, lower-case normalization, unchanged detection, skipped (no `fromAddress`), failure isolation, find-throws → empty summary, 0-affected → counted as failed.

## Test plan

- [x] `pnpm build --concurrency=1` → 35/35 packages
- [x] `pnpm test` → 70/70 turbo tasks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)