### PR TITLE
feat(#251 Phase 3): cross-channel tier — calendar events get authoringTier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — Cross-channel tier: calendar events get authoringTier (#251 Phase 3)
+
+Calendar events now carry the same `authoringTier` vocabulary as Gmail signals. The classification logic lives in `packages/connectors/src/calendar-authoring-tier.ts` and runs at signal-build time in `GoogleCalendarConnector.eventToSignal`. The result lands on `brain_pages.metadata.authoringTier` exactly like Gmail-derived pages do — same RRF fold, same Phase 1 additive bonuses, same Phase 2 relationship-tier composition.
+
+### Mapping
+
+| Calendar shape | AuthoringTier |
+|---|---|
+| User organized the event (organizer email = self) | `user_sent_originated` |
+| Auto-generated event (Google Contacts birthdays, holidays feed) | `inbox_automated` |
+| Multi-attendee invite the user is on (>2 attendees) | `inbox_broadcast` |
+| 1-on-1 invite or shared calendar entry | `inbox_personal` |
+
+`user_sent_reply` and `inbox_newsletter` aren't applicable to calendar and aren't used.
+
+### Engine
+
+- New file `packages/connectors/src/calendar-authoring-tier.ts` with `classifyCalendarAuthoringTier(input)`. Recognizes Google Contacts birthdays (`addressbook#contacts@`), holiday calendars (`en.usa#holiday@`), and weather feeds via regex.
+- `GoogleCalendarConnector.eventToSignal` now calls the classifier and stamps both `authoringTier` and `from` (organizer email) on `signal.data`. The `from` field matters because the embedded port's `buildPageMetadata` reads it to populate `metadata.fromAddress` — that's what Phase 2's relationship-tier worker queries, and what the per-sender bulk-hide UI from PR #270 sends to.
+
+### Why the vocabulary is reused (not extended)
+
+The original #251 spec deliberately picked tier value names that generalize across channels — `user_sent_originated` reads as "user authored, fresh," not as "an email the user sent." Reusing the same enum keeps the retrieval pipeline channel-agnostic: one bonus table, one set of weights, one eval covers everything.
+
+### Tests
+
+- 8 cases in `calendar-authoring-tier.test.ts`: user-organized (case-insensitive), birthdays/holidays/weather → automated, multi-attendee → broadcast, 1-on-1 → personal, edge cases for empty `selfEmail`.
+
+### Out of scope for this phase
+
+- GitHub authoring tier — no GitHub connector currently in the codebase. The vocabulary is already channel-agnostic, so a future GitHub connector can stamp tiers the same way without engine changes.
+
 ## [unreleased] — relationshipTier: second retrieval axis (#251 Phase 2)
 
 Adds a second dimension to gbrain's tier weighting: how strong the user's back-and-forth has been with the contact over the last 90 days. Composes additively with `authoringTier` from Phase 1.1.

--- a/packages/connectors/src/__tests__/calendar-authoring-tier.test.ts
+++ b/packages/connectors/src/__tests__/calendar-authoring-tier.test.ts
@@ -46,6 +46,19 @@ describe('classifyCalendarAuthoringTier', () => {
     ).toBe('inbox_automated');
   });
 
+  it('returns inbox_automated for weather-feed organizer', () => {
+    // Matches the /^.+#weather@/i pattern in AUTOMATED_ORGANIZER_PATTERNS.
+    // Without this case the regex could regress silently — only birthdays
+    // and holidays were exercised previously.
+    expect(
+      classifyCalendarAuthoringTier({
+        organizerEmail: 'en.usa#weather@group.v.calendar.google.com',
+        selfEmail: 'me@example.com',
+        attendeeCount: 0,
+      }),
+    ).toBe('inbox_automated');
+  });
+
   it('returns inbox_broadcast for multi-attendee invites the user is on', () => {
     expect(
       classifyCalendarAuthoringTier({

--- a/packages/connectors/src/__tests__/calendar-authoring-tier.test.ts
+++ b/packages/connectors/src/__tests__/calendar-authoring-tier.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the calendar authoring-tier classifier (#251 Phase 3).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { classifyCalendarAuthoringTier } from '../calendar-authoring-tier.js';
+
+describe('classifyCalendarAuthoringTier', () => {
+  it('returns user_sent_originated when the user organized the event', () => {
+    expect(
+      classifyCalendarAuthoringTier({
+        organizerEmail: 'me@example.com',
+        selfEmail: 'me@example.com',
+        attendeeCount: 3,
+      }),
+    ).toBe('user_sent_originated');
+  });
+
+  it('is case-insensitive on the email comparison', () => {
+    expect(
+      classifyCalendarAuthoringTier({
+        organizerEmail: 'Me@Example.com',
+        selfEmail: 'me@EXAMPLE.com',
+        attendeeCount: 5,
+      }),
+    ).toBe('user_sent_originated');
+  });
+
+  it('returns inbox_automated for Google Contacts birthdays feed', () => {
+    expect(
+      classifyCalendarAuthoringTier({
+        organizerEmail: 'addressbook#contacts@group.v.calendar.google.com',
+        selfEmail: 'me@example.com',
+        attendeeCount: 0,
+      }),
+    ).toBe('inbox_automated');
+  });
+
+  it('returns inbox_automated for holiday calendar', () => {
+    expect(
+      classifyCalendarAuthoringTier({
+        organizerEmail: 'en.usa#holiday@group.v.calendar.google.com',
+        selfEmail: 'me@example.com',
+        attendeeCount: 0,
+      }),
+    ).toBe('inbox_automated');
+  });
+
+  it('returns inbox_broadcast for multi-attendee invites the user is on', () => {
+    expect(
+      classifyCalendarAuthoringTier({
+        organizerEmail: 'organizer@example.com',
+        selfEmail: 'me@example.com',
+        attendeeCount: 5,
+      }),
+    ).toBe('inbox_broadcast');
+  });
+
+  it('returns inbox_personal for 1-on-1 invites from a known organizer', () => {
+    expect(
+      classifyCalendarAuthoringTier({
+        organizerEmail: 'colleague@example.com',
+        selfEmail: 'me@example.com',
+        attendeeCount: 2,
+      }),
+    ).toBe('inbox_personal');
+  });
+
+  it('returns inbox_personal for solo events with a known organizer', () => {
+    // E.g. a calendar entry someone shared with the user but didn't
+    // formally invite anyone else.
+    expect(
+      classifyCalendarAuthoringTier({
+        organizerEmail: 'colleague@example.com',
+        selfEmail: '',
+        attendeeCount: 0,
+      }),
+    ).toBe('inbox_personal');
+  });
+
+  it('handles empty self email — defaults to organizer being someone else', () => {
+    expect(
+      classifyCalendarAuthoringTier({
+        organizerEmail: 'someone@example.com',
+        selfEmail: '',
+        attendeeCount: 3,
+      }),
+    ).toBe('inbox_broadcast');
+  });
+});

--- a/packages/connectors/src/calendar-authoring-tier.ts
+++ b/packages/connectors/src/calendar-authoring-tier.ts
@@ -1,0 +1,87 @@
+/**
+ * Calendar authoring-tier classification (#251 Phase 3).
+ *
+ * Calendar events get the same `AuthoringTier` vocabulary as Gmail —
+ * the values are deliberately channel-agnostic (per the original #251
+ * spec discussion). What "authored" means just shifts: for email it's
+ * "the user typed and sent it"; for calendar it's "the user created
+ * the event."
+ *
+ *   user_sent_originated — user organized the event (their email
+ *                          appears as the organizer)
+ *   user_sent_reply     — N/A on calendar; not used
+ *   inbox_personal      — 1-on-1 invite (only self + one other
+ *                         attendee) from a known organizer
+ *   inbox_broadcast     — multi-attendee invite the user is on
+ *   inbox_newsletter    — N/A on calendar; not used
+ *   inbox_automated     — auto-generated event (recurring birthdays
+ *                         feed, holidays calendar) — heuristic:
+ *                         organizer is a known automated-domain
+ *                         pattern, e.g. `addressbook#contacts@`
+ *
+ * Per Phase 1.1's promote-only configuration, only the authored tier
+ * (the user organized this event) gets a positive bonus in retrieval.
+ * Other tiers contribute nothing — the goal is to lift the user's own
+ * agenda above broadcast invites, not to suppress invites.
+ */
+
+import type { AuthoringTier } from './authoring-tier.js';
+
+export interface CalendarAuthoringInputs {
+  /** Organizer's email (from `event.organizer.email`). */
+  organizerEmail: string;
+  /** Email of the `self: true` attendee, if any. Empty string if no self. */
+  selfEmail: string;
+  /** Total attendee count, including the self attendee. */
+  attendeeCount: number;
+}
+
+/**
+ * Heuristic patterns for organizer emails that indicate an auto-generated
+ * event (recurring birthdays, automatic holiday calendars, addressbook
+ * sync). The `addressbook#contacts@` pattern is the canonical Google
+ * Contacts birthdays feed.
+ */
+const AUTOMATED_ORGANIZER_PATTERNS: RegExp[] = [
+  /^addressbook#contacts@/i,
+  /^holiday@/i,
+  /^en\.usa#holiday@/i,
+  /^.+#weather@/i,
+];
+
+function isAutomatedOrganizer(email: string): boolean {
+  const trimmed = email.trim();
+  return AUTOMATED_ORGANIZER_PATTERNS.some((re) => re.test(trimmed));
+}
+
+/**
+ * Classify a calendar event into one of the AuthoringTier values.
+ *
+ * Order of checks:
+ *
+ *   1. User organized (selfEmail === organizerEmail) → user_sent_originated.
+ *      The user explicitly created this event; high-trust signal.
+ *   2. Automated organizer → inbox_automated. Birthdays / holidays.
+ *   3. Multi-attendee invite (>2 total) → inbox_broadcast.
+ *   4. Default: inbox_personal — 1-on-1 invite from a known organizer.
+ */
+export function classifyCalendarAuthoringTier(
+  input: CalendarAuthoringInputs,
+): AuthoringTier {
+  const self = input.selfEmail.trim().toLowerCase();
+  const organizer = input.organizerEmail.trim().toLowerCase();
+
+  if (self.length > 0 && self === organizer) {
+    return 'user_sent_originated';
+  }
+
+  if (isAutomatedOrganizer(organizer)) {
+    return 'inbox_automated';
+  }
+
+  if (input.attendeeCount > 2) {
+    return 'inbox_broadcast';
+  }
+
+  return 'inbox_personal';
+}

--- a/packages/connectors/src/google-calendar-connector.ts
+++ b/packages/connectors/src/google-calendar-connector.ts
@@ -2,6 +2,7 @@ import type { SignalConnector, RawSignal, SignalHandler } from './connector-inte
 import type { OAuthTokenStore } from './oauth/token-store.js';
 import type { CursorStore } from './gmail-connector.js';
 import { withRetry, RetryableHttpError, parseRetryAfter } from '@skytwin/core';
+import { classifyCalendarAuthoringTier } from './calendar-authoring-tier.js';
 
 const SYNC_TOKEN_KIND = 'sync_token';
 
@@ -196,6 +197,18 @@ export class GoogleCalendarConnector implements SignalConnector {
     const version = (event.updated ?? event.created ?? event.start.dateTime ?? event.start.date ?? 'unknown')
       .replace(/[^a-zA-Z0-9]/g, '');
 
+    // #251 Phase 3: stamp authoringTier on calendar signals using the
+    // same six-value vocabulary as Gmail. Events the user organized get
+    // `user_sent_originated`; invites the user is on get `inbox_personal`
+    // (1-on-1) or `inbox_broadcast` (multi-attendee); auto-generated
+    // calendar entries get `inbox_automated`. The downstream RRF fold
+    // treats these the same as email tiers.
+    const authoringTier = classifyCalendarAuthoringTier({
+      organizerEmail: event.organizer.email,
+      selfEmail: selfAttendee?.email ?? '',
+      attendeeCount: event.attendees?.length ?? 0,
+    });
+
     return {
       id: `sig_cal_${event.id}_${version || 'unknown'}`,
       source: 'google_calendar',
@@ -208,6 +221,10 @@ export class GoogleCalendarConnector implements SignalConnector {
         endTime: event.end.dateTime ?? event.end.date ?? '',
         organizer: event.organizer.email,
         organizerName: event.organizer.displayName ?? '',
+        // Mirror Gmail's data.from so embedded-port.buildPageMetadata
+        // stamps fromAddress consistently across channels — that's what
+        // the per-sender bulk-hide and Phase-2 relationship tier read.
+        from: event.organizer.email,
         attendees: (event.attendees ?? []).map((a) => ({
           email: a.email,
           responseStatus: a.responseStatus,
@@ -217,6 +234,7 @@ export class GoogleCalendarConnector implements SignalConnector {
         hasConflict,
         requiresResponse: needsResponse,
         htmlLink: event.htmlLink,
+        authoringTier,
       },
       timestamp: new Date(event.updated ?? event.created),
     };

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -25,6 +25,8 @@ export {
   splitAddressList,
 } from './authoring-tier.js';
 export type { AuthoringTier, EmailAuthoringInputs } from './authoring-tier.js';
+export { classifyCalendarAuthoringTier } from './calendar-authoring-tier.js';
+export type { CalendarAuthoringInputs } from './calendar-authoring-tier.js';
 export { GoogleCalendarConnector } from './google-calendar-connector.js';
 
 // OAuth

--- a/packages/memory-gbrain-crdb-adapter/src/__tests__/tier-weights.test.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/__tests__/tier-weights.test.ts
@@ -254,6 +254,48 @@ describe('relationshipTier — Phase 2 axis composes additively with authoring',
       ),
     ).toBe(HIDDEN_SENTINEL);
   });
+
+  // Axis independence — Copilot finding on Phase 3.
+  it('applies relationship bonus when authoringTier is missing entirely', () => {
+    // A page with no authoringTier (e.g. pre-Phase-3 calendar page, or
+    // any source that doesn't author-classify yet) should still get the
+    // relationship boost. The two axes are independent — neither blocks
+    // the other.
+    expect(
+      tierBonus({ relationshipTier: 'core' }, 'normal'),
+    ).toBeCloseTo(0.004);
+    expect(
+      tierBonus({ relationshipTier: 'frequent' }, 'normal'),
+    ).toBeCloseTo(0.002);
+  });
+
+  it('applies relationship bonus when authoringTier is unrecognized', () => {
+    expect(
+      tierBonus(
+        { authoringTier: 'made_up_tier', relationshipTier: 'core' },
+        'normal',
+      ),
+    ).toBeCloseTo(0.004);
+  });
+
+  it('applies relationship bonus when authoringTier is non-string', () => {
+    expect(
+      tierBonus(
+        { authoringTier: 42, relationshipTier: 'core' },
+        'normal',
+      ),
+    ).toBeCloseTo(0.004);
+  });
+
+  it('composes pinned + relationship even without authoringTier', () => {
+    // pinned (0.012) + core (0.004) + no authoring (0) = 0.016
+    expect(
+      tierBonus(
+        { relationshipTier: 'core', userOverride: 'pinned' },
+        'normal',
+      ),
+    ).toBeCloseTo(0.016);
+  });
 });
 
 describe('relationshipTierFromThreadCount thresholds', () => {

--- a/packages/memory-gbrain-crdb-adapter/src/tier-weights.ts
+++ b/packages/memory-gbrain-crdb-adapter/src/tier-weights.ts
@@ -225,26 +225,34 @@ export function tierBonus(metadata: unknown, calibration: TierCalibration): numb
   if (override === 'hidden') return HIDDEN_SENTINEL;
   const pinnedBoost = override === 'pinned' ? PINNED_BOOST : 0;
 
+  // Authoring + relationship are two independent axes. A page can have
+  // a recognized relationshipTier even if authoringTier is missing
+  // (e.g. a calendar event before Phase 3 classification lands, or a
+  // page from a channel that doesn't author-classify yet). Compute
+  // each contribution separately so neither axis blocks the other.
+  let base = 0;
   const tier = m['authoringTier'];
-  if (typeof tier !== 'string') return pinnedBoost;
-
-  const table = TABLES[calibration];
-  let base = (table as unknown as Record<string, number>)[tier];
-  if (typeof base !== 'number') return pinnedBoost;
-
-  // Brief-reply downweight: short authored body gets inbox_personal
-  // bonus (zero) instead of full authored. Cheap heuristic — no need to
-  // look at recipient tier or edit time yet.
-  if (tier === 'user_sent_originated' || tier === 'user_sent_reply') {
-    const bodyLen = m['bodyLen'];
-    if (typeof bodyLen === 'number' && bodyLen < BRIEF_BODY_THRESHOLD) {
-      base = table.inbox_personal;
+  if (typeof tier === 'string') {
+    const table = TABLES[calibration];
+    const lookup = (table as unknown as Record<string, number>)[tier];
+    if (typeof lookup === 'number') {
+      base = lookup;
+      // Brief-reply downweight: short authored body gets inbox_personal
+      // bonus (zero) instead of full authored. Cheap heuristic — no need
+      // to look at recipient tier or edit time yet.
+      if (tier === 'user_sent_originated' || tier === 'user_sent_reply') {
+        const bodyLen = m['bodyLen'];
+        if (typeof bodyLen === 'number' && bodyLen < BRIEF_BODY_THRESHOLD) {
+          base = table.inbox_personal;
+        }
+      }
     }
   }
 
   // Phase 2: relationship-tier bonus composes additively with authoring.
   // Missing or unrecognized → 0 contribution; the page just doesn't get
-  // the relationship boost.
+  // the relationship boost. Applied regardless of authoring presence so
+  // the two axes stay independent (Copilot finding on Phase 3).
   const relRaw = m['relationshipTier'];
   let relBonus = 0;
   if (typeof relRaw === 'string') {


### PR DESCRIPTION
## Summary

Phase 3 of #251 — extends the `authoringTier` vocabulary to calendar events. Calendar entries now flow through the same RRF-fold + Phase-1 bonuses + Phase-2 relationship composition as Gmail signals.

**Stacked on Phase 2 (#275).** Will rebase clean once Phase 2 merges.

## Mapping

| Calendar shape | AuthoringTier |
|---|---|
| User organized the event (organizer email = `self`) | `user_sent_originated` |
| Auto-generated event — Google Contacts birthdays, holidays feed, weather | `inbox_automated` |
| Multi-attendee invite (> 2 attendees) | `inbox_broadcast` |
| 1-on-1 invite or shared calendar entry | `inbox_personal` |

`user_sent_reply` and `inbox_newsletter` aren't applicable to calendar and aren't produced.

## Why reuse the vocabulary instead of extending it

The #251 spec deliberately named tier values to generalize across channels. `user_sent_originated` reads as "user authored, fresh" not "email the user sent." Reusing the same enum keeps everything downstream channel-agnostic: one bonus table, one set of weights in `tier-weights.ts`, one eval covers both Gmail and calendar.

## Engine

- New `classifyCalendarAuthoringTier(input)` in `packages/connectors/src/calendar-authoring-tier.ts`. Recognizes the Google Contacts birthdays feed (`addressbook#contacts@`), holiday calendars (`en.usa#holiday@`), and weather feeds via regex.
- `GoogleCalendarConnector.eventToSignal` calls the classifier and stamps both `authoringTier` and `from` (organizer email) on `signal.data`. The `from` field matters because `EmbeddedGbrainMemoryPort.buildPageMetadata` reads it to populate `metadata.fromAddress` — which is what Phase 2's relationship-tier worker queries and what the per-sender bulk-hide UI from PR #270 sends to.

## Tests

- 8 cases in `calendar-authoring-tier.test.ts` — user-organized (case-insensitive), birthdays/holidays/weather → automated, multi-attendee → broadcast, 1-on-1 → personal, edge cases for empty `selfEmail`.

## Out of scope

- GitHub authoring tier — no GitHub connector exists in this codebase. The vocabulary is already channel-agnostic, so a future GitHub connector can stamp tiers the same way without any engine changes.

## Test plan

- [x] `pnpm build --concurrency=1` → 35/35 packages
- [x] `pnpm test` → 70/70 turbo tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)