### PR TITLE
feat(#251 Phase 4): draft_email candidate generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 All notable changes to SkyTwin will be documented in this file.
 
+## [unreleased] — draft_email candidate generator (#251 Phase 4)
+
+The marquee feature Layers 1+2+3 were building toward. When an inbound email needs a reply, a new candidate generator drafts the body in the user's voice using their authored corpus as few-shot grounding.
+
+### What's new
+
+- `packages/decision-engine/src/strategies/draft-email-candidate.ts` — `DraftEmailCandidateGenerator` implementing `CandidateGenerator`. Fires only when `decision.domain === 'email'` and `rawData.requiresResponse` is truthy. Produces one `CandidateAction` with `actionType: 'draft_email'`.
+- `AuthoredExamplesPort` interface — the minimal port the generator needs from the memory layer. Decoupled from `@skytwin/memory-port` so the decision-engine package stays leaf-level.
+- `buildDraftPrompt(input)` — exported helper that renders the few-shot prompt. Structure is load-bearing for voice match, so it's testable directly.
+
+### Wiring approach: opt-in
+
+The generator is **exported but not wired into `DecisionMaker.evaluate` by default**. The deploy decision (which LLM client, when to flip it on, eval gates) lives outside the decision-engine layer. Callers instantiate it explicitly and add it to their generator list. This phase ships the building block.
+
+### Confidence and safety
+
+- `reversible: true` (the candidate is reversible up to the user clicking Send; the policy engine handles the actual send threshold)
+- `MODERATE` confidence when ≥ 3 authored examples were available, `LOW` otherwise — the approval UI surfaces "drafted from N of your prior emails" via `parameters.examplesUsed` so the user sees the grounding strength
+- Always requires explicit approval at v1 regardless of trust tier (no auto-send)
+- Fail-open on memory error (drafts without grounding, `LOW` confidence, copy explicitly warns about weak voice match)
+- Fail-closed on LLM error (returns no candidate rather than shipping a bad template-y draft)
+
+### Prompt shape
+
+- System prompt instructs the LLM to match voice/length/opening/closing/vocabulary from the few-shot examples; output ONLY the body, no subject/signature/preamble; 1–4 short paragraphs
+- Few-shot examples are truncated at `MAX_EXAMPLE_CHARS = 800` to stop a 5KB email from dominating context
+- Default `DEFAULT_AUTHORED_EXAMPLE_COUNT = 6` (~1500 prompt tokens budget for examples)
+- Query for the memory search is composed from inbound subject + first body line + from address, capped at 500 chars
+
+### Tests
+
+20 cases in `__tests__/draft-email-candidate.test.ts`: domain gating (email + requiresResponse), happy-path candidate shape and parameter projection, confidence based on example count, fail-open / fail-closed on subsystem failure, rawData fallbacks (snippet → body, messageId → emailId), prompt rendering (with/without examples, truncation at MAX_EXAMPLE_CHARS, placeholder copy for empty fields), query construction (500-char cap, empty-field stripping).
+
 ## [unreleased] — Cross-channel tier: calendar events get authoringTier (#251 Phase 3)
 
 Calendar events now carry the same `authoringTier` vocabulary as Gmail signals. The classification logic lives in `packages/connectors/src/calendar-authoring-tier.ts` and runs at signal-build time in `GoogleCalendarConnector.eventToSignal`. The result lands on `brain_pages.metadata.authoringTier` exactly like Gmail-derived pages do — same RRF fold, same Phase 1 additive bonuses, same Phase 2 relationship-tier composition.

--- a/packages/decision-engine/src/__tests__/draft-email-candidate.test.ts
+++ b/packages/decision-engine/src/__tests__/draft-email-candidate.test.ts
@@ -1,0 +1,425 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ConfidenceLevel,
+  SituationType,
+  type DecisionContext,
+  type DecisionObject,
+  type TwinProfile,
+} from '@skytwin/shared-types';
+import type { LlmClient } from '@skytwin/llm-client';
+import {
+  DraftEmailCandidateGenerator,
+  buildDraftPrompt,
+  DEFAULT_AUTHORED_EXAMPLE_COUNT,
+  MAX_EXAMPLE_CHARS,
+  type AuthoredExamplesPort,
+} from '../strategies/draft-email-candidate.js';
+
+/**
+ * Minimal LlmClient double — only `.generate()` is touched. Cast to
+ * `LlmClient` keeps the public class private to the package.
+ */
+function makeFakeLlm(
+  responseContent: string,
+  opts: { throwOnGenerate?: boolean } = {},
+): { client: LlmClient; calls: Array<{ prompt: unknown; options: unknown }> } {
+  const calls: Array<{ prompt: unknown; options: unknown }> = [];
+  const client = {
+    generate: async (prompt: unknown, options: unknown) => {
+      calls.push({ prompt, options });
+      if (opts.throwOnGenerate) throw new Error('llm-down');
+      return {
+        content: responseContent,
+        provider: 'anthropic',
+        model: 'fake',
+        latencyMs: 1,
+      };
+    },
+  } as unknown as LlmClient;
+  return { client, calls };
+}
+
+function makeFakeExamples(
+  examples: Array<{ content: string; subject?: string }>,
+  opts: { throwOnSearch?: boolean } = {},
+): { port: AuthoredExamplesPort; calls: Array<{ query: string; k: number }> } {
+  const calls: Array<{ query: string; k: number }> = [];
+  const port: AuthoredExamplesPort = {
+    searchAuthoredExamples: async (query: string, k: number) => {
+      calls.push({ query, k });
+      if (opts.throwOnSearch) throw new Error('memory-down');
+      return examples;
+    },
+  };
+  return { port, calls };
+}
+
+const PROFILE: TwinProfile = {
+  id: 'p',
+  userId: 'u',
+  version: 1,
+  preferences: [],
+  inferences: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const CONTEXT: DecisionContext = {
+  userId: 'u',
+  decision: {} as DecisionObject,
+  trustTier: 'moderate_autonomy' as DecisionContext['trustTier'],
+  relevantPreferences: [],
+  timestamp: new Date(),
+  patterns: [],
+  traits: [],
+  temporalProfile: {
+    userId: 'u',
+    activeHours: { start: 8, end: 18 },
+    peakResponseTimes: {},
+    weekdayPatterns: {},
+    urgencyThresholds: {},
+  },
+};
+
+function makeEmailDecision(args: {
+  requiresResponse?: boolean;
+  domain?: string;
+  subject?: string;
+  body?: string;
+  from?: string;
+  emailId?: string;
+}): DecisionObject {
+  return {
+    id: 'd-' + Math.random().toString(36).slice(2, 8),
+    situationType: SituationType.EMAIL_TRIAGE,
+    domain: args.domain ?? 'email',
+    urgency: 'medium',
+    summary: args.subject ?? '',
+    rawData: {
+      emailId: args.emailId ?? 'msg-1',
+      from: args.from ?? 'partner@example.com',
+      subject: args.subject ?? '',
+      body: args.body ?? '',
+      requiresResponse: args.requiresResponse ?? true,
+    },
+    interpretedAt: new Date(),
+  };
+}
+
+describe('DraftEmailCandidateGenerator — domain gating', () => {
+  it('returns no candidates for non-email decisions', async () => {
+    const { client } = makeFakeLlm('reply body');
+    const { port } = makeFakeExamples([]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const decision = makeEmailDecision({ domain: 'calendar' });
+    const out = await gen.generate(decision, PROFILE, CONTEXT);
+    expect(out).toHaveLength(0);
+  });
+
+  it('returns no candidates when requiresResponse is false', async () => {
+    const { client } = makeFakeLlm('reply body');
+    const { port } = makeFakeExamples([]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const decision = makeEmailDecision({ requiresResponse: false });
+    const out = await gen.generate(decision, PROFILE, CONTEXT);
+    expect(out).toHaveLength(0);
+  });
+
+  it('returns no candidates when requiresResponse is missing', async () => {
+    const { client } = makeFakeLlm('reply body');
+    const { port } = makeFakeExamples([]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const decision: DecisionObject = {
+      id: 'd-no-flag',
+      situationType: SituationType.EMAIL_TRIAGE,
+      domain: 'email',
+      urgency: 'low',
+      summary: '',
+      rawData: { emailId: 'x', from: 'a@b.c', subject: 's' },
+      interpretedAt: new Date(),
+    };
+    const out = await gen.generate(decision, PROFILE, CONTEXT);
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe('DraftEmailCandidateGenerator — happy path', () => {
+  it('returns a draft_email candidate with the LLM body', async () => {
+    const { client, calls } = makeFakeLlm('Thanks for the note — let me check and get back to you.');
+    const { port, calls: searchCalls } = makeFakeExamples([
+      { content: 'Sounds good — Tuesday works.', subject: 'Re: sync' },
+      { content: 'Let me check my calendar.', subject: 'Re: timing' },
+      { content: 'Thanks for the heads-up.' },
+    ]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const decision = makeEmailDecision({
+      subject: 'Quick question',
+      body: 'Are you free Tuesday?\nLet me know.',
+      from: 'colleague@example.com',
+      emailId: 'msg-42',
+    });
+    const out = await gen.generate(decision, PROFILE, CONTEXT);
+
+    expect(out).toHaveLength(1);
+    const c = out[0]!;
+    expect(c.actionType).toBe('draft_email');
+    expect(c.domain).toBe('email');
+    expect(c.reversible).toBe(true);
+    expect(c.estimatedCostCents).toBe(0);
+    expect(c.parameters['emailId']).toBe('msg-42');
+    expect(c.parameters['replyToFrom']).toBe('colleague@example.com');
+    expect(c.parameters['replyToSubject']).toBe('Quick question');
+    expect(c.parameters['draftBody']).toBe(
+      'Thanks for the note — let me check and get back to you.',
+    );
+    expect(c.parameters['examplesUsed']).toBe(3);
+    // 3 examples → MEDIUM confidence
+    expect(c.confidence).toBe(ConfidenceLevel.MODERATE);
+    expect(c.reasoning).toMatch(/3 similar emails/);
+
+    // Memory port was queried with the right shape
+    expect(searchCalls).toHaveLength(1);
+    expect(searchCalls[0]!.k).toBe(DEFAULT_AUTHORED_EXAMPLE_COUNT);
+    expect(searchCalls[0]!.query).toContain('Quick question');
+    expect(searchCalls[0]!.query).toContain('Are you free Tuesday?');
+    expect(searchCalls[0]!.query).toContain('colleague@example.com');
+
+    // LLM was invoked with a system prompt and tempurature ≈ 0.5
+    expect(calls).toHaveLength(1);
+    expect(typeof calls[0]!.prompt).toBe('string');
+    const opts = calls[0]!.options as { temperature?: number; systemPrompt?: string };
+    expect(opts.temperature).toBe(0.5);
+    expect(opts.systemPrompt).toMatch(/voice/i);
+  });
+
+  it('honors a custom exampleCount', async () => {
+    const { client } = makeFakeLlm('draft');
+    const { port, calls } = makeFakeExamples([]);
+    const gen = new DraftEmailCandidateGenerator(client, port, 2);
+    await gen.generate(makeEmailDecision({ subject: 's' }), PROFILE, CONTEXT);
+    expect(calls[0]!.k).toBe(2);
+  });
+
+  it('trims whitespace from the LLM response body', async () => {
+    const { client } = makeFakeLlm('   \n  Final draft body.   \n\n');
+    const { port } = makeFakeExamples([]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const out = await gen.generate(makeEmailDecision({ subject: 's' }), PROFILE, CONTEXT);
+    expect(out[0]!.parameters['draftBody']).toBe('Final draft body.');
+  });
+});
+
+describe('DraftEmailCandidateGenerator — confidence', () => {
+  it('LOW confidence with fewer than 3 examples', async () => {
+    const { client } = makeFakeLlm('body');
+    const { port } = makeFakeExamples([
+      { content: 'one' },
+      { content: 'two' },
+    ]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const out = await gen.generate(makeEmailDecision({ subject: 's' }), PROFILE, CONTEXT);
+    expect(out[0]!.confidence).toBe(ConfidenceLevel.LOW);
+  });
+
+  it('MEDIUM confidence with 3 or more examples', async () => {
+    const { client } = makeFakeLlm('body');
+    const { port } = makeFakeExamples([
+      { content: 'one' },
+      { content: 'two' },
+      { content: 'three' },
+    ]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const out = await gen.generate(makeEmailDecision({ subject: 's' }), PROFILE, CONTEXT);
+    expect(out[0]!.confidence).toBe(ConfidenceLevel.MODERATE);
+  });
+
+  it('LOW confidence with zero examples and the right reasoning copy', async () => {
+    const { client } = makeFakeLlm('body');
+    const { port } = makeFakeExamples([]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const out = await gen.generate(makeEmailDecision({ subject: 's' }), PROFILE, CONTEXT);
+    expect(out[0]!.confidence).toBe(ConfidenceLevel.LOW);
+    expect(out[0]!.reasoning).toMatch(/without authored-context grounding/);
+  });
+});
+
+describe('DraftEmailCandidateGenerator — failure modes', () => {
+  it('fails open on memory port error — still drafts with no examples', async () => {
+    const { client, calls: llmCalls } = makeFakeLlm('Best, X');
+    const { port } = makeFakeExamples([], { throwOnSearch: true });
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const out = await gen.generate(makeEmailDecision({ subject: 's' }), PROFILE, CONTEXT);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.parameters['examplesUsed']).toBe(0);
+    expect(out[0]!.confidence).toBe(ConfidenceLevel.LOW);
+    // LLM still got called
+    expect(llmCalls).toHaveLength(1);
+  });
+
+  it('returns no candidate when the LLM call fails', async () => {
+    const { client } = makeFakeLlm('', { throwOnGenerate: true });
+    const { port } = makeFakeExamples([{ content: 'one' }]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const out = await gen.generate(makeEmailDecision({ subject: 's' }), PROFILE, CONTEXT);
+    expect(out).toHaveLength(0);
+  });
+
+  it('returns no candidate when the LLM produces an empty body', async () => {
+    const { client } = makeFakeLlm('   \n\n   ');
+    const { port } = makeFakeExamples([]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const out = await gen.generate(makeEmailDecision({ subject: 's' }), PROFILE, CONTEXT);
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe('DraftEmailCandidateGenerator — rawData fallbacks', () => {
+  it('falls back to snippet when body is missing', async () => {
+    const { client } = makeFakeLlm('reply');
+    const { port, calls } = makeFakeExamples([]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const decision: DecisionObject = {
+      id: 'd1',
+      situationType: SituationType.EMAIL_TRIAGE,
+      domain: 'email',
+      urgency: 'medium',
+      summary: '',
+      rawData: {
+        emailId: 'm1',
+        from: 'sender@example.com',
+        subject: 'Hi',
+        snippet: 'First line from snippet\nrest is truncated',
+        requiresResponse: true,
+      },
+      interpretedAt: new Date(),
+    };
+    await gen.generate(decision, PROFILE, CONTEXT);
+    expect(calls[0]!.query).toContain('First line from snippet');
+  });
+
+  it('uses messageId when emailId is absent', async () => {
+    const { client } = makeFakeLlm('reply');
+    const { port } = makeFakeExamples([]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const decision: DecisionObject = {
+      id: 'd2',
+      situationType: SituationType.EMAIL_TRIAGE,
+      domain: 'email',
+      urgency: 'medium',
+      summary: '',
+      rawData: {
+        messageId: 'mid-7',
+        from: 'a@b.c',
+        subject: 's',
+        body: 'b',
+        requiresResponse: true,
+      },
+      interpretedAt: new Date(),
+    };
+    const out = await gen.generate(decision, PROFILE, CONTEXT);
+    expect(out[0]!.parameters['emailId']).toBe('mid-7');
+  });
+});
+
+describe('buildDraftPrompt', () => {
+  it('emits authored examples block when examples present', () => {
+    const prompt = buildDraftPrompt({
+      inboundFrom: 'sender@example.com',
+      inboundSubject: 'Hello',
+      inboundBody: 'Body.',
+      examples: [
+        { content: 'Voice sample 1', subject: 'Re: foo' },
+        { content: 'Voice sample 2' },
+      ],
+    });
+    expect(prompt).toContain('Match their voice');
+    expect(prompt).toContain('Example 1');
+    expect(prompt).toContain('(subject: "Re: foo")');
+    expect(prompt).toContain('Voice sample 1');
+    expect(prompt).toContain('Example 2');
+    expect(prompt).toContain('Voice sample 2');
+    expect(prompt).toContain('From: sender@example.com');
+    expect(prompt).toContain('Subject: Hello');
+    expect(prompt).toContain('Body.');
+    expect(prompt).toContain('Draft the reply body');
+  });
+
+  it('emits no-examples warning copy when examples is empty', () => {
+    const prompt = buildDraftPrompt({
+      inboundFrom: 'sender@example.com',
+      inboundSubject: 'Hi',
+      inboundBody: 'B',
+      examples: [],
+    });
+    expect(prompt).toContain('No prior authored examples available');
+    expect(prompt).not.toContain('Example 1');
+  });
+
+  it('truncates examples longer than MAX_EXAMPLE_CHARS', () => {
+    const huge = 'A'.repeat(MAX_EXAMPLE_CHARS + 500);
+    const prompt = buildDraftPrompt({
+      inboundFrom: 'x',
+      inboundSubject: 'y',
+      inboundBody: 'z',
+      examples: [{ content: huge }],
+    });
+    // The truncated block should contain a run of exactly MAX_EXAMPLE_CHARS
+    // 'A's — and NOT any longer run (we cut at the cap).
+    expect(prompt).toContain('A'.repeat(MAX_EXAMPLE_CHARS));
+    expect(prompt).not.toContain('A'.repeat(MAX_EXAMPLE_CHARS + 1));
+  });
+
+  it('uses placeholder text when inbound fields are empty', () => {
+    const prompt = buildDraftPrompt({
+      inboundFrom: '',
+      inboundSubject: '',
+      inboundBody: '',
+      examples: [],
+    });
+    expect(prompt).toContain('From: (unknown sender)');
+    expect(prompt).toContain('Subject: (no subject)');
+    expect(prompt).toContain('(empty body)');
+  });
+});
+
+describe('DraftEmailCandidateGenerator — query construction', () => {
+  it('caps the query at 500 chars', async () => {
+    const { client } = makeFakeLlm('reply');
+    const { port, calls } = makeFakeExamples([]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const longSubject = 'S'.repeat(600);
+    await gen.generate(
+      makeEmailDecision({ subject: longSubject, body: 'b' }),
+      PROFILE,
+      CONTEXT,
+    );
+    expect(calls[0]!.query.length).toBeLessThanOrEqual(500);
+  });
+
+  it('drops empty fields from the query', async () => {
+    const { client } = makeFakeLlm('reply');
+    const { port, calls } = makeFakeExamples([]);
+    const gen = new DraftEmailCandidateGenerator(client, port);
+    const decision: DecisionObject = {
+      id: 'd3',
+      situationType: SituationType.EMAIL_TRIAGE,
+      domain: 'email',
+      urgency: 'medium',
+      summary: '',
+      rawData: {
+        emailId: 'mx',
+        from: '',
+        subject: 'Only subject here',
+        body: '',
+        requiresResponse: true,
+      },
+      interpretedAt: new Date(),
+    };
+    await gen.generate(decision, PROFILE, CONTEXT);
+    // No double spaces from empty join fields
+    expect(calls[0]!.query).toBe('Only subject here');
+  });
+});
+
+// Quiet a vitest warning about unused imports if a refactor drops these.
+void vi;

--- a/packages/decision-engine/src/__tests__/draft-email-candidate.test.ts
+++ b/packages/decision-engine/src/__tests__/draft-email-candidate.test.ts
@@ -184,7 +184,7 @@ describe('DraftEmailCandidateGenerator — happy path', () => {
     expect(searchCalls[0]!.query).toContain('Are you free Tuesday?');
     expect(searchCalls[0]!.query).toContain('colleague@example.com');
 
-    // LLM was invoked with a system prompt and tempurature ≈ 0.5
+    // LLM was invoked with a system prompt and temperature ≈ 0.5
     expect(calls).toHaveLength(1);
     expect(typeof calls[0]!.prompt).toBe('string');
     const opts = calls[0]!.options as { temperature?: number; systemPrompt?: string };

--- a/packages/decision-engine/src/index.ts
+++ b/packages/decision-engine/src/index.ts
@@ -16,6 +16,13 @@ export { LlmCandidateGenerator } from './strategies/llm-candidates.js';
 export { FallbackSituationStrategy, FallbackCandidateGenerator } from './strategies/fallback-strategy.js';
 export { RuleBasedCandidateGenerator } from './strategies/rule-based-candidates.js';
 export { SenderAwareCandidateGenerator } from './strategies/sender-aware-candidates.js';
+export {
+  DraftEmailCandidateGenerator,
+  buildDraftPrompt,
+  DEFAULT_AUTHORED_EXAMPLE_COUNT,
+  MAX_EXAMPLE_CHARS,
+} from './strategies/draft-email-candidate.js';
+export type { AuthoredExamplesPort } from './strategies/draft-email-candidate.js';
 
 export type {
   WhatWouldIDoRequest,

--- a/packages/decision-engine/src/strategies/draft-email-candidate.ts
+++ b/packages/decision-engine/src/strategies/draft-email-candidate.ts
@@ -1,0 +1,238 @@
+/**
+ * Draft-email candidate generator (#251 Phase 4).
+ *
+ * The marquee feature Layer 1 + Layer 2 were building toward. When an
+ * inbound email needs a reply, this generator proposes a `draft_email`
+ * candidate whose body is composed using the user's authored corpus as
+ * voice / style grounding.
+ *
+ * Architecture in one paragraph: the generator queries the user's
+ * `authoringTier: user_sent_*` corpus (via an injected memory-search
+ * port) for the top-K most similar emails the user has written. Those
+ * examples are passed as few-shot context to the LLM along with the
+ * inbound email. The LLM produces a draft body in the user's voice.
+ * The result lands as a `CandidateAction` with `actionType: 'draft_email'`
+ * which flows through the normal policy / approval pipeline — at v1 it
+ * always requires explicit approval (no auto-send regardless of trust
+ * tier).
+ *
+ * Composition with the rest of the engine: this is OPT-IN. The
+ * generator is exported as a class callers can instantiate; it's NOT
+ * wired into `DecisionMaker.evaluate` by default. The deploy decision
+ * (which LLM client to use, when to wire it in) lives outside the
+ * decision engine. Once wired, the generator runs alongside the rule-
+ * based candidates and the LLM-based candidates, producing one
+ * additional `draft_email` candidate when the inbound email looks
+ * reply-worthy.
+ *
+ * Eval and tuning are separate work — this PR ships the building block.
+ */
+
+import { ConfidenceLevel } from '@skytwin/shared-types';
+import type {
+  DecisionObject,
+  DecisionContext,
+  CandidateAction,
+  TwinProfile,
+} from '@skytwin/shared-types';
+import type { LlmClient } from '@skytwin/llm-client';
+import type { CandidateGenerator } from './candidate-strategy.js';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * Minimal port the draft generator needs from the memory layer. We
+ * deliberately don't depend on `@skytwin/memory-port` here — the
+ * decision-engine layer should be able to consume any source of
+ * authored-style examples.
+ */
+export interface AuthoredExamplesPort {
+  /**
+   * Return up to `k` examples from the user's `user_sent_*` corpus
+   * most similar to `query`. The generator concatenates these as
+   * few-shot context.
+   */
+  searchAuthoredExamples(
+    query: string,
+    k: number,
+  ): Promise<Array<{ content: string; subject?: string }>>;
+}
+
+/**
+ * Cap on prompt context size. Anthropic + OpenAI both happily eat ~10k
+ * tokens of context, but each authored example is ~250 tokens average,
+ * so 6 examples × 250 ≈ 1500 tokens — well within budget without
+ * making the prompt unreadable to a future maintainer.
+ */
+export const DEFAULT_AUTHORED_EXAMPLE_COUNT = 6;
+
+/**
+ * Maximum body length (chars) of any one authored example included in
+ * the prompt. Longer-than-this gets head-truncated. Stops a 5KB email
+ * the user once sent from dominating context.
+ */
+export const MAX_EXAMPLE_CHARS = 800;
+
+export class DraftEmailCandidateGenerator implements CandidateGenerator {
+  constructor(
+    private readonly llmClient: LlmClient,
+    private readonly examples: AuthoredExamplesPort,
+    private readonly exampleCount: number = DEFAULT_AUTHORED_EXAMPLE_COUNT,
+  ) {}
+
+  async generate(
+    decision: DecisionObject,
+    _profile: TwinProfile,
+    _context: DecisionContext,
+  ): Promise<CandidateAction[]> {
+    // Only fires for email signals that need a response. Calendar,
+    // notifications, etc. are someone else's job.
+    if (decision.domain !== 'email') return [];
+    if (!decision.rawData['requiresResponse']) return [];
+
+    const inboundSubject =
+      typeof decision.rawData['subject'] === 'string'
+        ? (decision.rawData['subject'] as string)
+        : '';
+    const inboundBody =
+      typeof decision.rawData['body'] === 'string'
+        ? (decision.rawData['body'] as string)
+        : typeof decision.rawData['snippet'] === 'string'
+          ? (decision.rawData['snippet'] as string)
+          : '';
+    const inboundFrom =
+      typeof decision.rawData['from'] === 'string'
+        ? (decision.rawData['from'] as string)
+        : '';
+    const inboundId =
+      typeof decision.rawData['emailId'] === 'string'
+        ? (decision.rawData['emailId'] as string)
+        : typeof decision.rawData['messageId'] === 'string'
+          ? (decision.rawData['messageId'] as string)
+          : '';
+
+    // Build the query the memory layer will use to pull similar
+    // authored examples. Subject + first line of body usually carries
+    // the topical signal; the From address gives weight to "what does
+    // the user usually say to this person."
+    const query = [inboundSubject, inboundBody.split('\n')[0] ?? '', inboundFrom]
+      .filter(Boolean)
+      .join(' ')
+      .slice(0, 500);
+
+    let examples: Array<{ content: string; subject?: string }> = [];
+    try {
+      examples = await this.examples.searchAuthoredExamples(query, this.exampleCount);
+    } catch (err) {
+      // Fail open: a memory-layer hiccup shouldn't lose the candidate.
+      // We'll generate the draft without the voice-grounding context.
+      examples = [];
+      // (No log call here — the decision-engine package doesn't pull in
+      // a logger; callers wrap us in their own error handling.)
+      void err;
+    }
+
+    const prompt = buildDraftPrompt({
+      inboundFrom,
+      inboundSubject,
+      inboundBody,
+      examples,
+    });
+
+    let draftBody: string;
+    try {
+      const response = await this.llmClient.generate(prompt, {
+        temperature: 0.5,
+        maxTokens: 1024,
+        systemPrompt:
+          "You are drafting a reply on the user's behalf in their voice. " +
+          "Use the user's prior writing samples as the source of tone, " +
+          "length, opening / closing patterns, and vocabulary. " +
+          'Output ONLY the body of the reply — no subject, no signature, ' +
+          'no preamble. Keep the response to one to four short paragraphs.',
+      });
+      draftBody = response.content.trim();
+    } catch (err) {
+      // If the LLM call fails the whole feature degrades to "no draft
+      // proposed this time" — that's strictly better than a bad
+      // template-based draft that doesn't match the user's voice.
+      void err;
+      return [];
+    }
+
+    if (!draftBody) return [];
+
+    const candidate: CandidateAction = {
+      id: randomUUID(),
+      decisionId: decision.id,
+      actionType: 'draft_email',
+      description: `Draft a reply to "${inboundSubject || inboundFrom || 'this email'}" in your voice.`,
+      domain: 'email',
+      parameters: {
+        emailId: inboundId,
+        replyToFrom: inboundFrom,
+        replyToSubject: inboundSubject,
+        draftBody,
+        // Surface how much grounding context the draft had so the
+        // approval UI can show "drafted from N of your prior emails."
+        examplesUsed: examples.length,
+      },
+      estimatedCostCents: 0,
+      // Drafting is reversible right up to the user clicking Send.
+      // The candidate ITSELF is reversible; it's the user's subsequent
+      // approval-to-send that crosses an irreversible threshold (which
+      // the policy engine treats accordingly).
+      reversible: true,
+      confidence:
+        examples.length >= 3 ? ConfidenceLevel.MODERATE : ConfidenceLevel.LOW,
+      reasoning:
+        examples.length > 0
+          ? `Drafted using ${examples.length} similar emails you've written. ` +
+            'Review for voice + accuracy before sending.'
+          : 'Drafted without authored-context grounding (memory layer ' +
+            'returned no examples). Voice match may be weak — review carefully.',
+    };
+
+    return [candidate];
+  }
+}
+
+interface BuildDraftPromptInput {
+  inboundFrom: string;
+  inboundSubject: string;
+  inboundBody: string;
+  examples: Array<{ content: string; subject?: string }>;
+}
+
+/**
+ * Render the prompt sent to the LLM. Exported for testability — the
+ * structure of this prompt is a load-bearing piece of the feature.
+ */
+export function buildDraftPrompt(input: BuildDraftPromptInput): string {
+  const lines: string[] = [];
+  if (input.examples.length > 0) {
+    lines.push("Here are some emails the user has written. Match their voice — opening, length, vocabulary, closing — when drafting the reply.");
+    lines.push('');
+    for (let i = 0; i < input.examples.length; i++) {
+      const ex = input.examples[i]!;
+      const body = ex.content.slice(0, MAX_EXAMPLE_CHARS);
+      lines.push(`Example ${i + 1}${ex.subject ? ` (subject: "${ex.subject}")` : ''}:`);
+      lines.push(body);
+      lines.push('');
+    }
+    lines.push('---');
+    lines.push('');
+  } else {
+    lines.push("(No prior authored examples available — draft in a professional but warm tone.)");
+    lines.push('');
+  }
+  lines.push("Now draft a reply to the following inbound email:");
+  lines.push('');
+  lines.push(`From: ${input.inboundFrom || '(unknown sender)'}`);
+  lines.push(`Subject: ${input.inboundSubject || '(no subject)'}`);
+  lines.push('');
+  lines.push('Body:');
+  lines.push(input.inboundBody || '(empty body)');
+  lines.push('');
+  lines.push('Draft the reply body (no subject line, no signature, no preamble):');
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

Phase 4 of #251 — the marquee feature Layers 1+2+3 were building toward. Adds `DraftEmailCandidateGenerator` that drafts a reply body in the user's voice using their authored corpus as few-shot grounding.

This builds on the tier-aware retrieval shipped in Phase 1.1 (additive bonuses), Phase 2 (relationshipTier axis), and Phase 3 (cross-channel tiers). When the memory layer returns the top-K most similar emails the user has written, those become the voice/style training for the LLM.

## What ships

- **`DraftEmailCandidateGenerator`** (`packages/decision-engine/src/strategies/draft-email-candidate.ts`) — implements `CandidateGenerator`. Fires when `decision.domain === 'email'` and `rawData.requiresResponse` is truthy. Produces one `CandidateAction` with `actionType: 'draft_email'`.
- **`AuthoredExamplesPort`** interface — minimal port the generator needs from memory. Decoupled from `@skytwin/memory-port` so the decision-engine package stays leaf-level. Implementations live wherever the caller wires things up (typically `MemoryPort.searchAuthored` with a tier filter).
- **`buildDraftPrompt(input)`** — exported helper that renders the few-shot prompt. Structure is load-bearing for voice match, so it's testable directly.

## Wiring approach: opt-in

Exported from the package but **NOT wired into `DecisionMaker.evaluate` by default**. The deploy decision (which LLM client, when to flip it on, eval gates, cost gating) lives outside the decision-engine layer. Callers instantiate it explicitly. This phase ships the building block — the eval / rollout work follows.

## Safety

- `reversible: true` — the candidate itself is reversible; the user's send is what crosses the threshold (policy engine handles that)
- `MODERATE` confidence when ≥ 3 authored examples were available, `LOW` otherwise
- Always requires explicit approval at v1 regardless of trust tier (no auto-send)
- Fail-open on memory error (drafts without grounding, warns about voice match in reasoning)
- Fail-closed on LLM error (returns no candidate rather than shipping a template-y draft)
- `parameters.examplesUsed` surfaces grounding strength to the approval UI

## Prompt shape

- System prompt: match voice/length/opening/closing/vocabulary from few-shot examples; output ONLY the body, no subject/signature/preamble; 1–4 short paragraphs
- Few-shot examples truncated at `MAX_EXAMPLE_CHARS = 800` (stops a 5KB email from dominating context)
- Default `DEFAULT_AUTHORED_EXAMPLE_COUNT = 6` (~1500 prompt tokens for examples)
- Memory query composed from inbound subject + first body line + from address, capped at 500 chars

## Test plan

- [x] 20 unit tests in `__tests__/draft-email-candidate.test.ts` covering: domain gating (email + requiresResponse), candidate shape and parameter projection, confidence bands (LOW < 3 examples, MODERATE ≥ 3), fail-open / fail-closed on subsystem failure, rawData fallbacks (snippet→body, messageId→emailId), `buildDraftPrompt` rendering (with/without examples, truncation, placeholder copy), query construction (500-char cap, empty-field stripping)
- [x] Full decision-engine suite: 129 tests green
- [x] Full workspace build (serial): 35 packages
- [x] Full workspace test: 70 tasks pass

## Stacking note

Stacked atop Phase 2 (#275) and Phase 3 (#276); base is `main` but the diff includes Phase 2+3 commits until those merge. Once Phase 2/3 land, this PR rebases cleanly to its own delta (one commit, ~700 LOC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)