### PR TITLE
docs: full package table + accurate test count (docs-sync v2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,15 @@ CI is unaffected (clean dist on every run).
 | `@skytwin/memory-gbrain-crdb-adapter` | CockroachDB-backed driver for the gbrain backend. Repository functions, embedding providers (hash-trick fallback + OpenAI-compatible HTTP), in-memory store for tests, RRF fold with tier-weighted scoring (#251 Layer 2) that multiplies fused scores by per-tier weights tuned on the ablation corpus. Pin/hide controls (#270) and the authoring-tier backfill worker (#271) operate against the same `brain_pages.metadata.authoringTier` field. |
 | `@skytwin/memory-hybrid` | Composes any two `MemoryPort` impls. Reads route per-capability; writes dual-write best-effort. Exposes diagnostics counters. |
 | `@skytwin/memory-mempalace` | `MemPalaceMemoryPort` adapter — wraps the legacy `@skytwin/mempalace` classes against the `MemoryPort` contract. |
+| `@skytwin/assistant` | Stateless chat service that wraps `LlmClient` for text-only conversations with optional context enrichment (twin + memory) and action-intent routing (#135). |
+| `@skytwin/capability-engine` | Infers which user-facing apps the twin should learn capabilities for, from raw signals. Keyword matching in v1; LLM-verified service detection plus adaptive scoring landed in #202. |
+| `@skytwin/credential-vault` | Envelope encryption for OAuth tokens and other per-user secrets (AES-256-GCM with scrypt KDF) plus an in-process key cache (#212). Sits between the connectors and `db` so the encryption boundary is one obvious place. |
+| `@skytwin/idle-miner` | Filesystem scanner that runs during idle time, extracts project metadata, and emits signals that feed `capability-engine` (#201). Triggered by the desktop idle bridge (#239). |
+| `@skytwin/mcp-host` | Manages MCP servers (stdio / HTTP / SSE) — spawns, tool-call routing with per-server circuit breakers, telemetry, and Docker-isolated stdio servers when `zeroTrustMode` is on (#183 AC#4). |
+| `@skytwin/dxt` | Serializes / deserializes DXT artifacts — packed binary files that carry MCP server configs (with secrets redacted) so a twin can hand its tool set to another instance (#219). |
+| `@skytwin/observability` | In-memory metrics collection (latency, success rate, spend) with a ring-buffered rollup that powers the capability acquisition loop dashboards (#210). |
+| `@skytwin/policy-prompts` | Versioned LLM prompt templates with JSON-schema-validated outputs and deterministic fallbacks when no LLM is configured. Used by briefing prose, draft-email generation, and risk profiling (#200). |
+| `@skytwin/registry-client` | Loads the curated MCP registry, knows about each entry's OAuth quirks, and looks services up by keyword. Smithery-augmented when configured. |
 | `@skytwin/evals` | Evaluation framework for measuring decision quality over time. |
 
 ### Apps

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <a href="https://github.com/jayzalowitz/skytwin/actions/workflows/build.yml"><img src="https://github.com/jayzalowitz/skytwin/actions/workflows/build.yml/badge.svg" alt="Build"></a>
 <a href="https://github.com/jayzalowitz/skytwin/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
 <img src="https://img.shields.io/badge/version-0.6.21.0-green.svg" alt="Version">
-<img src="https://img.shields.io/badge/tests-1436%20passing-brightgreen.svg" alt="Tests">
+<img src="https://img.shields.io/badge/tests-2985%20passing-brightgreen.svg" alt="Tests">
 <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux%20%7C%20iOS%20%7C%20Android-lightgrey.svg" alt="Platform">
 
 </div>
@@ -180,7 +180,7 @@ The API starts on `localhost:3100`, the web dashboard on `localhost:3200`.
 ### Running Tests
 
 ```bash
-pnpm test   # 1,436 tests across 96 files
+pnpm test   # ~2,985 tests across 36 workspace packages
 ```
 
 ## Architecture
@@ -189,28 +189,44 @@ SkyTwin is a TypeScript monorepo (pnpm + Turborepo) with 29 packages and 7 apps:
 
 ```
 apps/
-  api/              HTTP API — decisions, user management, webhooks
-  web/              Dashboard — review decisions, manage preferences, configure policies
-  worker/           Background jobs — async execution, feedback processing
-  desktop/          Electron app — macOS (.dmg), Windows (.exe), Linux (.AppImage)
-  mobile/           React Native (Expo) — QR pairing, push notifications, SSE streaming
-  openclaw-bridge/  OpenClaw proxy — bridges local API to OpenClaw execution service
+  api/                HTTP API — decisions, user management, webhooks, /api/voice/*
+  web/                Dashboard — review decisions, manage preferences, configure policies
+  worker/             Background jobs — async execution, briefing generation, tier backfill
+  desktop/            Electron app — macOS (.dmg), Windows (.exe), Linux (.AppImage)
+  mobile/             React Native (Expo) — QR pairing, push notifications, SSE, voice capture
+  openclaw-bridge/    OpenClaw proxy — bridges local API to OpenClaw execution service
+  twin-mcp-server/    MCP server exposing the twin's read-only surface to external clients
 
 packages/
-  shared-types/     TypeScript interfaces — the dependency root for everything
-  config/           Env var loading and validation
-  core/             Retry logic, circuit breaker, error types, logging
-  db/               CockroachDB client, migrations, repositories
-  twin-model/       Twin profile CRUD, preference learning, confidence scoring
-  decision-engine/  Event interpretation, candidate generation, action selection
-  policy-engine/    Trust tiers, spend limits, domain policies, safety checks
-  ironclaw-adapter/ Execution adapter with HMAC auth, retries, circuit breaker
-  execution-router/ Adapter selection, fallback chains, risk modifiers, plugin discovery
-  llm-client/       Unified LLM client — Anthropic, OpenAI, Google, Ollama with provider chain
-  explanations/     Human-readable explanation generation
-  connectors/       Gmail, Calendar, and mock connectors with OAuth management
-  mempalace/        Episodic memory, knowledge graph, 4-layer retrieval stack
-  evals/            Decision quality evaluation and regression testing
+  shared-types/                   TypeScript interfaces — the dependency root for everything
+  config/                         Env var loading and validation
+  core/                           Retry logic, circuit breaker, error types, logging
+  db/                             CockroachDB client, migrations, repositories
+  twin-model/                     Twin profile CRUD, preference learning, confidence scoring
+  decision-engine/                Event interpretation, candidate generation, action selection
+  policy-engine/                  Trust tiers, spend limits, domain policies, safety checks
+  policy-prompts/                 Versioned LLM prompts with JSON schema validation and deterministic fallbacks
+  ironclaw-adapter/               Execution adapter with HMAC auth, retries, circuit breaker
+  execution-router/               Adapter selection, fallback chains, risk modifiers, plugin discovery
+  llm-client/                     Unified LLM client — Anthropic / OpenAI / Google / Ollama / embedded
+  embedded-llm/                   Local-first: llama.cpp text, whisper.cpp STT, Piper TTS — spawn-based
+  explanations/                   Human-readable explanation generation
+  connectors/                     Gmail / Calendar / mock connectors with OAuth, stamps AuthoringTier
+  assistant/                      Stateless chat service wrapping LlmClient with context enrichment
+  capability-engine/              Infers user app capabilities from signals (keyword v1 + LLM verification)
+  credential-vault/               Envelope encryption for OAuth tokens (AES-256-GCM + scrypt KDF)
+  idle-miner/                     Filesystem scanner that extracts project metadata during idle time
+  mcp-host/                       Manages MCP servers (stdio/HTTP/SSE) with circuit breakers + telemetry
+  dxt/                            Serializes/deserializes DXT artifacts (packed MCP server configs)
+  observability/                  In-memory metrics + ring-buffered rollup for the capability loop
+  registry-client/                Loads curated MCP registry entries with OAuth quirks and service lookup
+  mempalace/                      Legacy memory: episodic, knowledge graph, 4-layer retrieval (opt-in backend)
+  memory-port/                    Backend-agnostic MemoryPort interface + capability negotiation
+  memory-gbrain/                  Default memory backend — vector + tsvector RRF on CRDB brain_* tables
+  memory-gbrain-crdb-adapter/     CRDB driver for gbrain — tier-weighted RRF, pin/hide, embedding providers
+  memory-hybrid/                  Composes any two MemoryPort impls — per-capability read routing
+  memory-mempalace/               MemoryPort adapter for the legacy mempalace classes
+  evals/                          Decision quality evaluation and regression testing
 ```
 
 ### Tech Stack


### PR DESCRIPTION
## Summary

Closes the two cosmetic gaps the week-of audit surfaced:

1. **Test badge drift** — README said `1436 passing`. Local `pnpm test` on current main: **2,985 passing** across 36 workspace packages, 0 failures, 57 intentional skips (3 MCP integration tests tagged `TODO #173 AC#3`, rest are real-DB / real-embedding opt-ins).

2. **Pre-existing package-table drift** — README listed 14 of 29 packages. Last week's docs-sync (#273) couldn't justify expanding that table from the diff alone since most of those packages predated this week. Now they land via the audit follow-up.

Apps tree picks up `twin-mcp-server` (already in CLAUDE.md, missing from README). CLAUDE.md picks up rows for the same 9 newly-documented packages.

## Test plan

- [x] `pnpm test` clean — same 2,985-passing number used in the badge
- [x] `pnpm build` clean
- [x] Cross-checked every new row against `ls packages/` + each package's `src/index.ts`
- [ ] Reviewer eyes on description voice — these should read like the existing rows: terse, concrete, names a capability

## Notes

No code changes. No behavior changes. No CHANGELOG entry — docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)