### PR TITLE
fix(ci): drop `--` separator before --publish flags (third release-pipeline fix)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
         # GitHub Releases without the GH_TOKEN this workflow doesn't
         # set, failing the whole macOS job. release.yml is the
         # exclusive publish path; build.yml just validates packageability.
-        run: pnpm --filter skytwin-desktop run package:mac -- --publish never
+        run: pnpm --filter skytwin-desktop run package:mac --publish never
         env:
           # Skip code signing for CI builds (not notarized)
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
@@ -199,7 +199,7 @@ jobs:
 
       - name: Package Windows desktop app
         # See macOS comment re: --publish never; same reasoning here.
-        run: pnpm --filter skytwin-desktop run package:win -- --publish never
+        run: pnpm --filter skytwin-desktop run package:win --publish never
 
       - name: Upload Windows installer
         uses: actions/upload-artifact@v7
@@ -242,7 +242,7 @@ jobs:
 
       - name: Package Linux desktop app
         # See macOS comment re: --publish never; same reasoning here.
-        run: pnpm --filter skytwin-desktop run package:linux -- --publish never
+        run: pnpm --filter skytwin-desktop run package:linux --publish never
         continue-on-error: true
 
       - name: Upload Linux AppImage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,12 +165,22 @@ jobs:
           # Code-signing cert (each runner only has one platform's secret set)
           CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.MAC_CERT_P12_BASE64 || secrets.WIN_CERT_PFX_BASE64 }}
           CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.MAC_CERT_PASSWORD || secrets.WIN_CERT_PASSWORD }}
+        # Note: NO `--` separator before --publish always. pnpm forwards
+        # `--` literally into the script's underlying shell command, so
+        # `... run package:mac -- --publish always` ends up as
+        # `electron-builder --mac -- --publish always`, where the `--`
+        # tells electron-builder "end of options," and the post-`--`
+        # `--publish always` is then treated as a positional path arg.
+        # electron-builder then errors `apps/desktop not a file` because
+        # it's looking for a file at that pseudo-path. The v0.6.58.0 retry
+        # tag hit this on all three platforms — fix is to pass the args
+        # without the separator (pnpm 7+ forwards flag-args natively).
         run: |
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
-            pnpm --filter skytwin-desktop run package:mac -- --publish always
+            pnpm --filter skytwin-desktop run package:mac --publish always
           elif [ "${{ matrix.os }}" = "windows-latest" ]; then
-            pnpm --filter skytwin-desktop run package:win -- --publish always
+            pnpm --filter skytwin-desktop run package:win --publish always
           else
-            pnpm --filter skytwin-desktop run package:linux -- --publish always
+            pnpm --filter skytwin-desktop run package:linux --publish always
           fi
         shell: bash


### PR DESCRIPTION
## Summary

v0.6.58.0 release retry hit a new error on macOS:
\`\`\`
⨯ /Users/runner/work/skytwin/skytwin/apps/desktop not a file
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL skytwin-desktop@0.3.0 package:mac:
  \`tsc && pnpm run prepackage && electron-builder --mac \"--\" \"--publish\" \"always\"\`
\`\`\`

The literal `\"--\"` in the expanded command is the bug. pnpm forwards the YAML `-- --publish always` separator verbatim into the script's shell command, so the underlying invocation becomes `electron-builder --mac -- --publish always`. electron-builder treats `--` as \"end of options\" and parses `--publish always` as TWO positional args. The first positional is interpreted as a file path, doesn't exist → errors out reporting the CWD path.

**Fix:** drop the `--` separator. pnpm 7+ forwards flag args natively.

Build.yml had the same pattern with `--publish never` — fixed for consistency. It happened to work there because `--publish never` mis-parsed is a no-op (default in PR contexts is to not publish anyway).

## Test plan

After merge: force-re-tag v0.6.58.0 → release.yml runs with the corrected command → expected to actually publish artifacts this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)