### PR TITLE
fix(ci): release.yml — skip code signing when no cert secrets present

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,9 +162,18 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # Code-signing cert (each runner only has one platform's secret set)
+          # Code-signing cert (each runner only has one platform's secret set).
+          # When the secret is unset, the expression evaluates to '' (empty
+          # string), NOT undefined. electron-builder then interprets an
+          # empty CSC_LINK as a relative path-to-cert that resolves to the
+          # CWD — and crashes with `⨯ <cwd> not a file` before it even
+          # starts packaging. Pair CSC_LINK with CSC_IDENTITY_AUTO_DISCOVERY
+          # so an empty CSC_LINK falls through cleanly to "skip signing"
+          # rather than "look for a cert at CWD." When the secrets ARE set,
+          # CSC_LINK takes precedence and auto-discovery is moot.
           CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.MAC_CERT_P12_BASE64 || secrets.WIN_CERT_PFX_BASE64 }}
           CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.MAC_CERT_PASSWORD || secrets.WIN_CERT_PASSWORD }}
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ (matrix.os == 'macos-latest' && secrets.MAC_CERT_P12_BASE64 != '') || (matrix.os == 'windows-latest' && secrets.WIN_CERT_PFX_BASE64 != '') }}
         # Note: NO `--` separator before --publish always. pnpm forwards
         # `--` literally into the script's underlying shell command, so
         # `... run package:mac -- --publish always` ends up as


### PR DESCRIPTION
## Summary

Fourth release-pipeline fix. After PRs #352, #353, #354 the release workflow finally got past pnpm setup, workspace build, and arg forwarding — but immediately hit a NEW failure: \`⨯ apps/desktop not a file\` right after \`empty password will be used for code signing reason=CSC_KEY_PASSWORD is not defined\`.

**Root cause:** \`release.yml\`'s Build-and-publish step sets \`CSC_LINK\` from a ternary on a missing secret. When the secret is unset, the expression evaluates to \`''\` (empty string), NOT undefined. \`CSC_LINK\` is therefore IN the environment but empty. electron-builder treats empty \`CSC_LINK\` as a relative path-to-cert that resolves to CWD (apps/desktop) — finds a directory, errors before packaging.

**Fix:** pair \`CSC_LINK\` with \`CSC_IDENTITY_AUTO_DISCOVERY\` computed from whether the matching secret is non-empty. Falls through cleanly to \"skip signing\" when secrets are absent (producing the unsigned artifacts the workflow header already documents as expected pre-Apple-Developer-enrollment).

\`build.yml\` already dodged this by setting \`CSC_IDENTITY_AUTO_DISCOVERY: 'false'\` and never setting \`CSC_LINK\`. \`release.yml\` needed the same defensive guard.

## Test plan

After merge: re-tag v0.6.58.0 (fourth attempt) → finally publish artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)