### PR TITLE
P1.10: dynamic README version badge + CI guard (#380)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,18 @@ jobs:
       - run: pnpm build
       - run: pnpm test
 
+      # Guardrail (#380): block any push that hardcodes a literal
+      # version into the README badge URL. The badge is a dynamic
+      # shields.io URL that reads package.json on every render; any
+      # `badge/version-0.X.Y` literal would re-introduce the 35-release
+      # staleness this issue closed. grep returns 0 (match) → exit 1.
+      - name: README badge must stay dynamic (#380)
+        run: |
+          if grep -E "/badge/version-[0-9]" README.md; then
+            echo "::error file=README.md::README version badge appears to be hardcoded. Use the dynamic shields.io URL (img.shields.io/github/package-json/v/...) so it never goes stale."
+            exit 1
+          fi
+
   # ──────────────────────────────────────────────
   # Desktop — one job per OS, uploads installer artifacts
   # ──────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <a href="https://github.com/jayzalowitz/skytwin/actions/workflows/build.yml"><img src="https://github.com/jayzalowitz/skytwin/actions/workflows/build.yml/badge.svg" alt="Build"></a>
 <a href="https://github.com/jayzalowitz/skytwin/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
-<img src="https://img.shields.io/badge/version-0.6.23.2-green.svg" alt="Version">
+<img src="https://img.shields.io/github/package-json/v/jayzalowitz/skytwin?color=brightgreen&label=version" alt="Version">
 <img src="https://img.shields.io/badge/tests-2985%20passing-brightgreen.svg" alt="Tests">
 <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux%20%7C%20iOS%20%7C%20Android-lightgrey.svg" alt="Platform">
 
@@ -372,7 +372,9 @@ Trust is **domain-specific**. You might be at `moderate_autonomy` for email but 
 
 ## Project Status
 
-SkyTwin is in **active development** (v0.6.23.2). The core decision pipeline, twin model, policy engine, and swappable memory layer are functional. Gmail and Google Calendar connectors work with real OAuth. Desktop builds ship for all three platforms. The mobile app pairs via QR code and can capture voice. v0.5.0.0 brought the one-command installer and a non-technical-user UX overhaul; v0.5.1.0 through v0.5.4.0 closed the post-/review follow-ups; the v0.6 series added the embedded local LLM (#187), tier-aware memory retrieval (#251), per-Lifebook surfaces (#193), and the voice loop (mobile capture + Piper TTS).
+SkyTwin is in **Tier 1 launch polish** (see [`docs/launch-plan.md`](./docs/launch-plan.md)) — Tier 0 (bundled installer, in-app OAuth setup, Gmail wizard) shipped; Tier 1 (cold-load demo, signed binaries, mobile cut, safety + privacy debt) is the active pre-launch sprint tracked under epic [#357](https://github.com/jayzalowitz/skytwin/issues/357). The current shipped version is in the badge above and in [`CHANGELOG.md`](./CHANGELOG.md). Core decision pipeline, twin model, policy engine, and swappable memory layer are functional; Gmail and Google Calendar connectors run with real OAuth; desktop builds ship for all three platforms; the mobile app pairs via QR code and captures voice. v0.5.0.0 brought the one-command installer and a non-technical-user UX overhaul; the v0.6 series added the embedded local LLM (#187), tier-aware memory retrieval (#251), per-Lifebook surfaces (#193), the voice loop (mobile capture + Piper TTS), and Epic A's cold-load demo unblocker (#358).
+
+**Free and open-source forever for personal use.** Team and hosted tiers are planned for organizations that need shared policies, audit logs, or managed infrastructure — see [`docs/launch-plan.md`](./docs/launch-plan.md) for the split.
 
 **What works today:**
 - One-command install (`curl | bash`) on macOS, Linux, and WSL — installs every dependency, clones the repo, starts the services, opens the dashboard


### PR DESCRIPTION
## Summary

Closes #380. Two-line bug: README version badge was a literal `0.6.23.2`, 35 releases stale. Status paragraph repeated the same stale string. First impression for every cold-load was "this project is either sleepy or recently abandoned."

## Changes

- **Dynamic badge** — `img.shields.io/github/package-json/v/jayzalowitz/skytwin` reads `package.json` live on every render. Never goes stale again, zero scripts.
- **Status paragraph rewritten** — references `docs/launch-plan.md` and master epic #357 instead of duplicating a version literal inline. Past tense kept for v0.5/v0.6 highlights since those name shipped features that don't change.
- **Monetization sentence added** — exact text from the issue brief.
- **CI guard** — Test job in `build.yml` greps for `/badge/version-[0-9]` literals in README and fails the build if one slips back in. One line; cheap insurance.

## Verified locally

- `grep -E "/badge/version-[0-9]" README.md` → no match (guard passes)
- Badge URL renders against current `package.json` 0.6.58.0

## Test plan

- [ ] Visit README on GitHub — version badge shows current `package.json` version, not a literal
- [ ] Status paragraph reads as current (Tier 1 launch polish), not "active development (v0.6.23.2)"
- [ ] If you hardcode `version-0.7.0` into the badge URL and push, CI Test job fails with the README-badge error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)