### PR TITLE
chore(deps): zod 3→4 + the one z.record breaking-change fix (closes #438)

### DIFF
--- a/apps/twin-mcp-server/package.json
+++ b/apps/twin-mcp-server/package.json
@@ -21,7 +21,7 @@
     "@skytwin/shared-types": "workspace:*",
     "@skytwin/llm-client": "workspace:*",
     "express": "^5.2.1",
-    "zod": "^3.25.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",

--- a/apps/twin-mcp-server/src/server.ts
+++ b/apps/twin-mcp-server/src/server.ts
@@ -114,7 +114,7 @@ function buildMcpServer(tokenCtx: ExternalAgentToken): McpServer {
         action: z
           .object({
             type: z.string().describe('Action type identifier.'),
-            parameters: z.record(z.unknown()).describe('Action parameters.'),
+            parameters: z.record(z.string(), z.unknown()).describe('Action parameters.'),
             reasoning: z.string().describe('Why this action is being proposed.'),
           })
           .describe('The action to propose.'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,7 +225,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.4.3)
       '@skytwin/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -254,8 +254,8 @@ importers:
         specifier: ^5.2.1
         version: 5.2.1
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -665,7 +665,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.4.3)
       '@skytwin/core':
         specifier: workspace:*
         version: link:../core
@@ -5403,6 +5403,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zxing-wasm@3.0.3:
     resolution: {integrity: sha512-DdOn/G5F+qvZELWeO5ZFFwcN611TfMybxPV0LUUoutUmiH2t47MZSB7gLV9O9YLhvudBdnzQNAoFOu4Xz8eOrQ==}
     peerDependencies:
@@ -6640,7 +6643,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.18)
       ajv: 8.18.0
@@ -6657,8 +6660,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -10558,11 +10561,13 @@ snapshots:
       compress-commons: 4.1.2
       readable-stream: 3.6.2
 
-  zod-to-json-schema@3.25.2(zod@3.25.76):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zxing-wasm@3.0.3(@types/emscripten@1.41.5):
     dependencies:


### PR DESCRIPTION
## Summary

Dependabot **#438** (zod `^3.25` → `^4.4.3`) failed CI on a single zod-4 breaking change. This PR takes the upgrade and fixes it.

### The fix
zod 4 made `z.record(V)` require an explicit key schema:
```diff
- parameters: z.record(z.unknown()).describe('Action parameters.'),
+ parameters: z.record(z.string(), z.unknown()).describe('Action parameters.'),
```
`apps/twin-mcp-server/src/server.ts:117` — the **only** `z.record` call repo-wide. A grep for the other zod-4 breaking patterns (`.strict` / `.deepPartial` / `z.nativeEnum` / `.merge` / `z.function`) found none.

### Why it's safe
`@modelcontextprotocol/sdk@1.29.0` already declares `zod: "^3.25 || ^4.0"` — it consumes these tool schemas under zod 4 without issue.

## Verification (local)
- `@skytwin/twin-mcp-server` build (the package that failed CI) — **clean**
- `pnpm build` 35/35 · `pnpm test` 70/70 (exit 0) · `--frozen-lockfile` clean
- **runtime**: `z.record(z.string(), z.unknown())` accepts records and rejects non-records under zod 4.4.3

Closes #438.