### PR TITLE
docs: README leads with downloads (v0.6.58.0 published)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ All notable changes to SkyTwin will be documented in this file.
 
 ## [0.6.58.0] - 2026-05-23
 
+### Documentation
+
+- **README leads with downloads.** `## Quick Start` now opens with a "Download and install (no terminal)" section pointing at [the latest release](https://github.com/jayzalowitz/skytwin/releases/latest), a per-OS installer table (`.dmg` / `.exe` / `.AppImage` / `.deb` / `.rpm`), and the unsigned-build first-launch bypass (right-click → Open on macOS, More info → Run anyway on Windows). The `curl … | bash` one-command install moved down to "Build from source." Added a download badge linking to `/releases/latest`; removed the stale hardcoded "2985 tests passing" badge. v0.6.58.0 is the first build published with installer artifacts attached — the release pipeline that produces them was fixed across PRs #352–#356.
+
 ### Fixed (CI release pipeline + post-#350 Copilot review)
 
 - **`release.yml` pnpm-setup conflict.** All three release-matrix jobs (mac/win/linux) were failing at `pnpm/action-setup@v4 with version: 9` because v4 also reads the `packageManager` field from `package.json`, and seeing both inputs raises `ERR_PNPM_BAD_PM_VERSION`. Upgraded to `@v5` (matches `build.yml`'s usage — reads only the `packageManager` field). The v0.6.57.0 tag couldn't ship artifacts because of this; v0.6.58.0 + a tag re-push is the path to a working GitHub Release.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <a href="https://github.com/jayzalowitz/skytwin/actions/workflows/build.yml"><img src="https://github.com/jayzalowitz/skytwin/actions/workflows/build.yml/badge.svg" alt="Build"></a>
 <a href="https://github.com/jayzalowitz/skytwin/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
 <img src="https://img.shields.io/github/package-json/v/jayzalowitz/skytwin?color=brightgreen&label=version" alt="Version">
-<img src="https://img.shields.io/badge/tests-2985%20passing-brightgreen.svg" alt="Tests">
+<a href="https://github.com/jayzalowitz/skytwin/releases/latest"><img src="https://img.shields.io/github/v/release/jayzalowitz/skytwin?label=download&color=blue" alt="Download latest release"></a>
 <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux%20%7C%20iOS%20%7C%20Android-lightgrey.svg" alt="Platform">
 
 </div>
@@ -134,13 +134,31 @@ Every path produces an explanation. Every outcome feeds back into the twin. The 
 
 ## Quick Start
 
-### One-command install (macOS, Linux, WSL)
+### Download and install (no terminal)
+
+**[⬇ Download the latest release →](https://github.com/jayzalowitz/skytwin/releases/latest)**
+
+Grab the installer for your OS, double-click, and you're in. No terminal, no Docker, no Ollama, no `.env`. CockroachDB ships inside the bundle as a hash-verified native binary and an embedded llama.cpp model is the default LLM — nothing else to install.
+
+| OS | Installer on the release page |
+|----|-------------------------------|
+| **macOS** (Apple Silicon) | `SkyTwin-…-arm64.dmg` |
+| **Windows** | `SkyTwin.Setup.….exe` |
+| **Linux** | `SkyTwin-….AppImage`, `.deb`, or `.rpm` |
+
+> **⚠ Unsigned builds (for now).** Code-signing certs (Apple Developer + Windows EV) are a pending launch step, so your OS warns on first launch:
+> - **macOS:** right-click the app → **Open** → **Open** (clears Gatekeeper once).
+> - **Windows:** SmartScreen → **More info** → **Run anyway**.
+>
+> Signing lands before the public launch; until then this is the expected first-run experience.
+
+### Build from source (one-command, macOS / Linux / WSL)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/jayzalowitz/skytwin/main/install.sh | bash
 ```
 
-That's it. The installer detects your OS, installs anything missing (Homebrew on mac, Node 20+, pnpm), fetches the official CockroachDB single-node binary (hash-verified), clones the repo to `~/skytwin`, runs the bootstrap, starts the services, and opens the dashboard at `http://localhost:3200` once it's up. Re-running pulls latest and restarts.
+The installer detects your OS, installs anything missing (Homebrew on mac, Node 20+, pnpm), fetches the official CockroachDB single-node binary (hash-verified), clones the repo to `~/skytwin`, runs the bootstrap, starts the services, and opens the dashboard at `http://localhost:3200` once it's up. Re-running pulls latest and restarts.
 
 **No Docker required.** Before v0.6.56 the installer pulled Docker Desktop and ran CockroachDB inside a container — by far the heaviest dependency on the list, with its own EULA and a "open it once after install" gotcha. The default path now installs the CRDB binary directly into `~/.local/share/skytwin/bin/cockroach` and spawns it as a child process. Docker remains supported via `SKYTWIN_USE_DOCKER=true` for users who already have a Docker workflow.
 


### PR DESCRIPTION
## Summary

v0.6.58.0 is **published** with all five desktop installers attached (.dmg/.exe/.AppImage/.deb/.rpm — verified on the release page). This flips the README front door from "compile this codebase" to "download and double-click."

- New **Download and install (no terminal)** section at the top of Quick Start: prominent link to [`/releases/latest`](https://github.com/jayzalowitz/skytwin/releases/latest), a per-OS installer table, and the unsigned-build first-launch bypass (right-click→Open on macOS, More info→Run anyway on Windows) since code-signing certs are still a pending launch step.
- `curl … | bash` moved down to **Build from source** — still the contributor path, no longer the headline.
- Added a download badge → `/releases/latest`; removed the stale hardcoded "2985 tests passing" badge.

## Deliberate scope choices

- **Links point at the `/releases/latest` page, not direct `/latest/download/<file>` URLs.** Current assets are version-stamped (`SkyTwin-0.3.0-arm64.dmg`), so a fixed-name direct link would 404. Direct per-platform links need an electron-builder `artifactName` change to produce stable names first — that's a separate, **release-tested** PR. I deliberately did NOT bundle it here: an untested release-naming change is exactly how the release pipeline bit five times this week (PRs #352–#356). Page-link is robust and version-proof today.
- **No VERSION bump** — docs-only, keeps source aligned with the published 0.6.58.0 release.

## Test plan

- [x] Markdown renders (verified table + blockquote + badges locally).
- [x] `/releases/latest` resolves to v0.6.58.0 (confirmed via `gh api repos/.../releases/latest`).
- [x] Docs-only diff — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)