### PR TITLE
feat: Inbox-Intelligence epic — digest read layer, trust gates, UI (#484)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,281 @@
+# AGENTS.md -- Instructions for Codex Agents
+
+This file contains guidance for Codex agents working on the SkyTwin codebase.
+
+## Stack
+
+- **Language:** TypeScript (strict mode, ES2022 target, NodeNext modules)
+- **Package manager:** pnpm with workspaces
+- **Monorepo tooling:** Turborepo
+- **Database:** CockroachDB (PostgreSQL wire protocol)
+- **Runtime:** Node.js >= 20
+
+## How to Build, Test, and Run
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build all packages (respects dependency graph via Turbo)
+pnpm build
+
+# Run all tests
+pnpm test
+
+# Start development mode (all apps with hot reload)
+pnpm dev
+
+# Run database migrations
+pnpm db:migrate
+
+# Seed development data
+pnpm db:seed
+
+# Lint all packages
+pnpm lint
+```
+
+To work on a single package:
+
+```bash
+pnpm --filter @skytwin/decision-engine build
+pnpm --filter @skytwin/twin-model test
+```
+
+### Build gotcha: shared-types dist can go stale after rebases
+
+If `pnpm build` fails on `@skytwin/policy-engine` (or any other package) with `error TS2305: Module '"@skytwin/shared-types"' has no exported member '<NAME>'`, but the source clearly exports `<NAME>` in `packages/shared-types/src/index.ts`, the turbo cache is serving a stale `dist/`. Force-rebuild the package:
+
+```bash
+rm -rf packages/shared-types/dist packages/shared-types/tsconfig.tsbuildinfo \
+  && pnpm --filter @skytwin/shared-types build
+```
+
+Then verify the export landed in the dist:
+
+```bash
+grep '<NAME>' packages/shared-types/dist/index.js
+```
+
+This shows up most often after rebasing across changes to `packages/shared-types/src/index.ts`. CI is unaffected (fresh installs). Only the local worktree sees it.
+
+### Build gotcha: turbo parallel race on @skytwin/db dist
+
+If `pnpm build` fails on `@skytwin/api` with `Property 'X' does not exist on type {...}` for a method that's clearly in `packages/db/src/repositories/*.ts`, turbo's default parallel concurrency is racing on the `@skytwin/db` dist between dependent builds. Direct `pnpm --filter @skytwin/api build` succeeds because there's no race; full `pnpm build` fails because parallel writers stomp on each other's `.d.ts` output.
+
+Workaround:
+
+```bash
+pnpm build --concurrency=1   # serial build, ~10s slower but always correct
+```
+
+Or pre-build `@skytwin/db` to a stable state, then full build:
+
+```bash
+rm -rf packages/db/dist packages/db/tsconfig.tsbuildinfo \
+  && pnpm --filter @skytwin/db build \
+  && pnpm build
+```
+
+CI is unaffected (clean dist on every run).
+
+## Package Descriptions
+
+| Package | Purpose |
+|---------|---------|
+| `@skytwin/shared-types` | All TypeScript interfaces and type definitions. The dependency root. |
+| `@skytwin/config` | Environment variable loading, validation, and typed config objects. |
+| `@skytwin/core` | Shared utilities, error types, logging helpers. Includes retry with exponential backoff (`withRetry`) and circuit breaker (`CircuitBreaker`). |
+| `@skytwin/db` | CockroachDB client, migrations, query builders, and repository layer. |
+| `@skytwin/twin-model` | Twin profile CRUD, preference learning, confidence scoring. |
+| `@skytwin/decision-engine` | Event interpretation, candidate action generation, action selection. Pluggable strategy pattern: LLM strategies wrap `@skytwin/llm-client`, rule-based strategies are the fallback. |
+| `@skytwin/policy-engine` | Policy evaluation, trust tier enforcement, spend limit checks. |
+| `@skytwin/ironclaw-adapter` | HTTP adapter for the [IronClaw](https://github.com/nearai/ironclaw/) execution server. HMAC-SHA256 auth, retries, circuit breaker. Includes DirectExecutionAdapter fallback and mock for testing. |
+| `@skytwin/execution-router` | Adapter selection between IronClaw, OpenClaw, and Direct execution with trust-ranked fallback chains, risk modifiers, skill gap detection, and dynamic adapter discovery from plugin directories. |
+| `@skytwin/llm-client` | Unified LLM client with provider chain (Anthropic, OpenAI, Google, Ollama, embedded). Per-provider circuit breakers, SSRF-safe URL validation, prompt builder, response parser, and `estimateLlmCostCents()` helper (embedded/Ollama always return 0). No SDK dependencies. |
+| `@skytwin/embedded-llm` | Local-first LLM runtime: `llama.cpp` text backend, `whisper.cpp` STT backend (`/api/voice/transcribe`), and Piper TTS backend (`/api/voice/synthesize`). Spawn-based — each backend probes for its binary + model and falls back to a `Null*Port` when either is missing. Used by `llm-client` as the `embedded` provider and by `/api/voice/*` for the voice loop. |
+| `@skytwin/explanations` | Generates human-readable explanations for decisions and actions. |
+| `@skytwin/connectors` | Gmail, Google Calendar, and mock signal connectors with OAuth token management (DbTokenStore). Stamps every signal with an `AuthoringTier` (six tiers from `user_sent_originated` to `inbox_automated`) so retrieval can weight self-authored content above broadcast noise (#251 Layer 1). |
+| `@skytwin/mempalace` | Legacy memory system: spatial memory organization (wings/rooms/drawers), 4-layer retrieval stack, knowledge graph with temporal triples, episodic memory, AAAK compression. Selectable as a backend via `MEMORY_BACKEND=mempalace`; otherwise gbrain is the default. |
+| `@skytwin/memory-port` | Backend-agnostic `MemoryPort` interface + `SignalsRouter` polyfill engine + capability negotiation. The contract every memory backend implements (#196). |
+| `@skytwin/memory-gbrain` | Default memory backend (#197). `EmbeddedGbrainMemoryPort` runs in-process against the brain_* CRDB tables; vector + tsvector RRF for semantic and code-aware search. CLI-shellout `GbrainMemoryPort` kept for users with an external gbrain. |
+| `@skytwin/memory-gbrain-crdb-adapter` | CockroachDB-backed driver for the gbrain backend. Repository functions, embedding providers (hash-trick fallback + OpenAI-compatible HTTP), in-memory store for tests, RRF fold with tier-weighted scoring (#251 Layer 2) that ADDS per-tier bonuses to fused scores (additive, not multiplicative — the multiplicative cut had a structural leapfrog regression on real dense embedders, fixed in #260/#272). The bonus is gated by an opt-in `floorRatio` threshold (default 0.85; aligned with gbrain v0.35.6.0 `SearchOpts.floorRatio` after our PR #1091 was reworked and merged upstream as #1129) so weak-overlap candidates can't pick up the bonus and leapfrog a legitimate primary hit. Pin/hide controls (#270) and the authoring-tier backfill worker (#271) operate against the same `brain_pages.metadata.authoringTier` field. |
+| `@skytwin/memory-hybrid` | Composes any two `MemoryPort` impls. Reads route per-capability; writes dual-write best-effort. Exposes diagnostics counters. |
+| `@skytwin/memory-mempalace` | `MemPalaceMemoryPort` adapter — wraps the legacy `@skytwin/mempalace` classes against the `MemoryPort` contract. |
+| `@skytwin/assistant` | Stateless chat service that wraps `LlmClient` for text-only conversations with optional context enrichment (twin + memory) and action-intent routing (#135). |
+| `@skytwin/capability-engine` | Infers which user-facing apps the twin should learn capabilities for, from raw signals. Keyword matching in v1; LLM-verified service detection plus adaptive scoring landed in #202. |
+| `@skytwin/credential-vault` | Envelope encryption for OAuth tokens and other per-user secrets (AES-256-GCM with scrypt KDF) plus an in-process key cache (#212). Sits between the connectors and `db` so the encryption boundary is one obvious place. |
+| `@skytwin/idle-miner` | Filesystem scanner that runs during idle time, extracts project metadata, and emits signals that feed `capability-engine` (#201). Triggered by the desktop idle bridge (#239). |
+| `@skytwin/mcp-host` | Manages MCP servers (stdio / HTTP / SSE) — spawns, tool-call routing with per-server circuit breakers, telemetry, and Docker-isolated stdio servers when `zeroTrustMode` is on (#183 AC#4). |
+| `@skytwin/dxt` | Serializes / deserializes DXT artifacts — packed binary files that carry MCP server configs (with secrets redacted) so a twin can hand its tool set to another instance (#219). |
+| `@skytwin/observability` | In-memory metrics collection (latency, success rate, spend) with a ring-buffered rollup that powers the capability acquisition loop dashboards (#210). |
+| `@skytwin/policy-prompts` | Versioned LLM prompt templates with JSON-schema-validated outputs and deterministic fallbacks when no LLM is configured. Used by briefing prose, draft-email generation, and risk profiling (#200). |
+| `@skytwin/registry-client` | Loads the curated MCP registry, knows about each entry's OAuth quirks, and looks services up by keyword. Smithery-augmented when configured. |
+| `@skytwin/evals` | Evaluation framework for measuring decision quality over time. |
+
+### Apps
+
+| App | Purpose |
+|-----|---------|
+| `api` | HTTP API server exposing decision endpoints, user management, and webhooks. Includes liveness/readiness health checks and mDNS service advertisement. |
+| `web` | Web dashboard for reviewing decisions, managing preferences, and configuring policies. |
+| `worker` | Background job processor for async decision execution and feedback processing. Includes startup hang detection and graceful shutdown. |
+| `desktop` | Electron desktop app with electron-builder. Cross-platform builds for macOS (.dmg), Windows (.exe), and Linux (.AppImage/.deb). |
+| `mobile` | React Native mobile app (Expo SDK 55). QR code pairing, mDNS API discovery, SSE real-time streaming, push notifications, and voice capture (`VoiceScreen` records via `expo-audio`, base64-encodes via `expo-file-system`, and ships to the paired desktop's `/api/voice/transcribe` for on-device whisper.cpp transcription). |
+| `openclaw-bridge` | Lightweight bridge server connecting SkyTwin's OpenClaw adapter to a local Ollama instance for LLM reasoning. |
+| `twin-mcp-server` | MCP server exposing the twin's read-only surface (decisions, learnings, recent activity) to external MCP clients. |
+
+## Key Patterns
+
+### Adapter Pattern for IronClaw
+
+All IronClaw API access goes through `@skytwin/ironclaw-adapter`. Never call the IronClaw API directly from other packages. The adapter:
+- Normalizes IronClaw responses into SkyTwin types
+- Handles retries, timeouts, and error mapping
+- Provides a typed interface that can be mocked in tests
+
+### Typed Decision Objects
+
+Every decision flows through a structured pipeline:
+1. `DecisionObject` -- the raw event and interpreted situation
+2. `DecisionContext` -- enriched with twin profile, policies, behavioral patterns, cross-domain traits, and temporal profile
+3. `CandidateAction[]` -- possible actions with risk assessments, scored with pattern boosts and trait adjustments
+4. `DecisionOutcome` -- the selected action and whether it auto-executes or requires approval
+
+All of these types live in `@skytwin/shared-types`. Use them. Do not create ad-hoc objects for decision data.
+
+### CockroachDB as Source of Truth
+
+- All twin profiles, preferences, decision history, and policy state live in CockroachDB.
+- Use the repository layer in `@skytwin/db` for all database access.
+- CockroachDB supports serializable transactions -- use them for multi-step operations.
+- Twin profile updates are versioned. Every mutation creates a `TwinProfileVersion` record.
+
+### Explanation-First Design
+
+Every automated action must produce an `ExplanationRecord` that answers:
+- What happened?
+- What evidence was used?
+- What preferences were invoked?
+- Why this action over alternatives?
+- How can the user correct this if it's wrong?
+
+### Frontend Event Handling
+
+**No inline `onclick=`, `onkeydown=`, or any other inline event-handler attribute** in rendered HTML. The web dashboard renders a lot of HTML via template literals, and `escapeHtml` is HTML-context safe but the values often land in JS-string-literal context inside `onclick="handleX('${escapeHtml(value)}')"` — XSS-unsafe by construction even when current values (UUIDs, enums) happen to be safe today. Use `data-action="…"` attributes plus a delegated event listener.
+
+**Singleton delegators must be gated by `window.location.hash`, not by DOM containment.** The SPA in `apps/web/public/js/app.js` reuses one `#page-content` container element across all routes — only the `innerHTML` swaps. That means `container.contains(target)` returns true for clicks on every page, and `container.addEventListener` inside a `renderX(container, …)` function stacks one new listener per render. Fix:
+
+1. Hoist the delegator to a module-level function with a `_pageListenerWired` guard.
+2. Attach once on `document`.
+3. First check inside the handler: `if (window.location.hash.split('?')[0] !== '#/<route>') return;`
+
+Same-page rerenders (after a save, after an SSE event) won't accumulate listeners. Cross-page navigation won't fire the wrong page's handlers. See `apps/web/public/js/pages/{approvals,settings,decisions,dashboard-view}.js` for the pattern.
+
+**Read `getCurrentUserId()` inside the handler when it depends on the current user.** Closing over a `userId` argument from the render function leaves stale-userId listeners firing under the next user (relevant after the dev "Switch user" button changes localStorage).
+
+## Safety Invariants
+
+These are non-negotiable rules. Do not write code that violates them.
+
+1. **Never auto-execute without a policy check.** Every action must pass through the policy engine before execution. No exceptions, no shortcuts, no "just this once."
+
+2. **Always log explanations.** Every decision that results in an action (or a deliberate non-action) must produce an `ExplanationRecord`. If you can't explain it, don't do it.
+
+3. **Respect trust tiers.** A user's `TrustTier` determines what can be auto-executed. New users start at `'observer'` and must earn higher tiers through consistent feedback. Never bypass tier checks.
+
+4. **Spend limits are hard limits.** If an action's estimated cost exceeds the user's per-action or daily spend limit, it must be escalated. Do not approximate. Do not round down.
+
+5. **Reversibility matters.** Mark actions as `reversible: true` or `reversible: false` accurately. The system treats irreversible actions with higher scrutiny. Lying about reversibility is a bug.
+
+6. **Feedback flows back.** User approvals, rejections, edits, and undos must update the twin model. If feedback isn't being recorded, the system is broken.
+
+7. **Risk assessment is mandatory.** Every `CandidateAction` must include a `RiskAssessment` with reasoning. Skipping risk assessment is not a valid optimization.
+
+8. **Untrusted-origin actions never auto-execute destructive work.** Content the user did not author — inbound email, idle-crawl files, web pages, third-party calendar invites — is the documentary-poisoning attack surface. Every action carries an `ActionProvenance`; the injection guard (`evaluateInjectionGuard` in `packages/shared-types/src/action-safety.ts`, applied by `PolicyEvaluator.checkInjectionGuard` and backstopped by `ExecutionRouter`) escalates destructive-shaped or untrusted-origin actions to human confirmation — single-click, or two-click for extreme shapes (shell, filesystem, DB, account destruction). Provenance is the security boundary; never weaken it to a "default if absent" — absent provenance must fail safe to `untrusted_external`. The candidate generator does not get to set its own provenance.
+
+## Zero-trust mode runtime constraint
+
+When `McpServerConfig.zeroTrustMode` is `true`, the MCP server process is spawned inside `docker run --network=none` so it has no network access. This applies **only to stdio transport** — HTTP/SSE servers are remote processes and `--network=none` would sever the connection entirely. Requires Docker to be running on the host; if Docker is unavailable the server starts without isolation and `McpServerHandle.failedToIsolate` is set to `true`. MCP server packages must be pre-installed on the host via `npm install -g <package>` so the host global `node_modules` mount (resolved via `npm root -g`) makes them visible inside the container. See `packages/mcp-host/src/docker-spawn.ts` for implementation details.
+
+## Review Discipline
+
+### PR merge gate — non-negotiable
+
+Every PR MUST clear a three-step gate **before merge**. Skipping any step is grounds to revert the merge. Adapted from the gate Robot-Robot-and-Human (RRH) uses, which closed a class of "Copilot left dozens of unaddressed inline comments" misses that this codebase has accumulated.
+
+**NEVER push to main directly.** All changes — including doc-only typo fixes — go through a Pull Request. Feature branches only. If a commit lands on main by mistake, immediately revert and move the change to a feature branch.
+
+**Add Copilot as a reviewer on every PR.** Right after `gh pr create`, run `gh pr edit <PR> --add-reviewer @copilot`. This is the cheapest second pair of eyes available and it is the reviewer that catches the most things on this codebase. The pre-merge gate depends on Copilot having actually reviewed.
+
+**Pre-merge — all three required, in order:**
+
+1. **Run `/review`** against the PR diff. The skill catches SQL safety issues, LLM trust-boundary violations, conditional side effects, and structural problems that Copilot's automated review misses (and vice versa — they catch different classes of issue, which is why we run both). Treat its findings the same as Copilot's: address valid concerns, dismiss non-applicable ones with a one-line explanation in the PR comment thread.
+
+2. **Wait for Copilot review and address every comment.** After `gh pr edit <PR> --add-reviewer @copilot`, wait for the review to land. `gh pr view <PR> --json reviews` shows review summaries (state + author); for the actual inline comments use `gh api repos/:owner/:repo/pulls/<PR>/comments` (PR review comments) and `gh api repos/:owner/:repo/issues/<PR>/comments` (top-level conversation comments). For each: either push a fix (preferred — same reviewer often catches additional issues on the second pass) or dismiss with a one-line reason in a reply. **Do NOT merge until every comment is resolved or explicitly dismissed.** This is the gate the May 2026 epic week skipped, which led to ~70 REAL unresolved Copilot findings across 15 PRs and the multi-batch sweep PR (#226 → #232) to clean them up.
+
+3. **Run `/document-release`** against the PR diff. The skill cross-references the diff against `README.md`, `ARCHITECTURE.md` (if present), `CONTRIBUTING.md`, `CLAUDE.md`, this `AGENTS.md`, and `CHANGELOG.md`, updates them where they've drifted from what shipped, polishes CHANGELOG voice, and cleans up TODOs the PR superseded. Running this **pre-merge** keeps code + docs atomic — reviewers see proposed doc updates alongside the code, no drift window between merge and the doc-update commit, no follow-up "docs: sync with X" commits cluttering main. If review feedback in step 2 changes the code, re-run `/document-release` (it's idempotent).
+
+The order is non-negotiable: `/review` first (catches structural issues), Copilot second (catches what `/review` missed plus inline nits), `/document-release` third (docs reflect the final pre-merge state). Don't merge before step 3; the diff that ships includes the doc updates.
+
+### Habits that prevent "PR ships a regression of the bug it claims to fix"
+
+These have already prevented several bugs from landing on this codebase. Don't skip them — the merge gate above is necessary but not sufficient.
+
+- **`/review` and CI catch different things.** CI verifies code compiles and tests pass; it does not verify that the PR's stated intent landed correctly. Two of the highest-impact bugs caught on this codebase were "the loop walks the wrong direction" and "the verification curl produces no output" — both compiled, both passed tests, both would have shipped a regression of the original bug.
+- **When migrating event-handler patterns, trace re-render paths first.** Before adding any `addEventListener` inside a render function, write down what triggers a re-render of that container (route changes? SSE events? post-save mutations?). If anything other than a one-time mount triggers re-render, use a singleton wired via `_listenerWired` guard. See "Frontend Event Handling" above.
+- **Verify shared-types `dist/` has the export you're importing before declaring the build clean.** After changes to `packages/shared-types/src/index.ts`, run `grep <EXPORT> packages/shared-types/dist/index.js`. Catches the turbo-cache regression in two seconds.
+- **Write the unit test alongside any parse / validation / regex hardening.** "Falls back to safe default on garbage input" without a test is one rebase away from silently regressing. Five test cases for input validation are faster to write than to argue about whether you need them.
+- **Post-`/review` and post-Copilot fixes get their own commits inside the PR.** Don't squash them into the original change locally before pushing — separate commits give reviewers a clear "what was the first cut, what did review catch" diff. CHANGELOG can carry a `### Fixed (post-/review)` subsection for the same reason.
+- **Documentation that describes engine behavior must cite the source-of-truth file.** The trust-tier promotion criteria, spend-limit thresholds, and policy gates all live in code (`packages/shared-types/src/policy.ts`, `packages/policy-engine/`). When docs describe these, link to the file so future drift is visible. `docs/safety-model.md` does this; new docs should follow.
+
+## Code Style
+
+- Use named exports, not default exports.
+- Prefer `interface` over `type` for object shapes.
+- Use `unknown` instead of `any`. If you write `any`, justify it with a comment.
+- Error handling: use typed result objects (`{ success: true, data } | { success: false, error }`) rather than thrown exceptions for expected failure modes.
+- Tests go in `__tests__/` directories adjacent to source, or in files named `*.test.ts`.
+- Use vitest for all tests.
+
+## Skill routing
+
+When the user's request matches an available Codex skill, follow that skill's
+workflow before doing ad-hoc work. The skill has specialized workflows that
+produce better results than ad-hoc answers.
+
+Key routing rules:
+- Product ideas, "is this worth building", brainstorming → invoke office-hours
+- Bugs, errors, "why is this broken", 500 errors → invoke investigate
+- Ship, deploy, push, create PR → invoke ship
+- QA, test the site, find bugs → invoke qa
+- Code review, check my diff → invoke review
+- Update docs after shipping → invoke document-release
+- Weekly retro → invoke retro
+- Design system, brand → invoke design-consultation
+- Visual audit, design polish → invoke design-review
+- Architecture review → invoke plan-eng-review
+
+## Deploy Configuration (configured by /setup-deploy)
+- Platform: None (pre-deployment)
+- Production URL: Not configured
+- Deploy workflow: None
+- Deploy status command: None
+- Merge method: squash
+- Project type: Monorepo (API + web dashboard + worker), not yet deployed
+- Post-deploy health check: None
+
+### Custom deploy hooks
+- Pre-merge: none
+- Deploy trigger: none (merge to main only)
+- Deploy status: none
+- Health check: none
+
+## Design System
+Always read `DESIGN.md` before making any visual or UI decision. Font choices,
+color tokens (iris `#7C72E8` is the single accent and means "needs you / act"),
+spacing, the action-vs-awareness hierarchy, and the per-element state catalog all
+live there. Do not deviate without explicit user approval. In `/qa` and
+`/design-review`, flag any UI that doesn't match `DESIGN.md` — especially the
+"every state" rule (cold-start, scope-blocked, loading, error, prose-fallback must
+all be designed, not happy-path only).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,3 +270,12 @@ Key routing rules:
 - Deploy trigger: none (merge to main only)
 - Deploy status: none
 - Health check: none
+
+## Design System
+Always read `DESIGN.md` before making any visual or UI decision. Font choices,
+color tokens (iris `#7C72E8` is the single accent and means "needs you / act"),
+spacing, the action-vs-awareness hierarchy, and the per-element state catalog all
+live there. Do not deviate without explicit user approval. In `/qa` and
+`/design-review`, flag any UI that doesn't match `DESIGN.md` — especially the
+"every state" rule (cold-start, scope-blocked, loading, error, prose-fallback must
+all be designed, not happy-path only).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,193 @@
+# Design System — SkyTwin
+
+Source of truth for every visual and UI decision. Read this before touching UI.
+Created by /design-consultation, grounded in a full element-and-state inventory of
+the digest surfaces (web `twin-briefing.js` / `dashboard-view.js`, mobile
+`BriefingScreen.tsx`), the existing tokens in `apps/web/public/css/styles.css`, and
+the data shapes in `@skytwin/decision-engine` (`digest.ts`, `digest-detail.ts`,
+`source-coverage.ts`) + `@skytwin/shared-types` enums.
+
+## Product Context
+- **What this is:** a digital twin's daily briefing/digest. It reads your signals
+  (email, calendar, files, voice), splits what needs you from what's awareness, and
+  acts on your behalf under trust + policy gates.
+- **Who it's for:** two audiences at once. A non-technical default (calm, safe,
+  legible) and a power user who flips on depth (provenance, confidence, why).
+- **The memorable thing:** "careful software that quietly handled things for me."
+  Trust and calm over flash. Every choice serves that.
+
+## Aesthetic Direction
+- **Direction:** Calm command center. Premium, function-led. Restraint, generous
+  air, refined type, crisp edges. Not a dashboard, not a toy.
+- **Decoration level:** minimal. Type, spacing, and one accent do the work. Depth
+  comes from a single soft elevation shadow, not ornament.
+- **Function leads:** every element earns its place by serving a product purpose —
+  triage (what needs you), action (do it here), trust (where it came from, why).
+
+## Color — color is meaning, never decoration
+Cool-neutral dark base (refines the existing tokens; zero brown). Exactly ONE accent,
+and it means **"needs your attention / act here."** Reserve every other hue for a
+specific meaning.
+
+| Token | Value | Meaning / usage |
+|-------|-------|-----------------|
+| `--bg` | `#0E0F13` | App background (deep cool-neutral) |
+| `--surface` | `#16181F` | Cards, the digest |
+| `--elevated` | `#1D2029` | Raised panels, power-view detail, hover |
+| `--border` | `#272B38` | Hairline separators |
+| `--border-strong` | `#363B4C` | Focus ring, hover border |
+| `--text` | `#ECEDF1` | Primary text |
+| `--text-muted` | `#9CA0AE` | Secondary text, labels |
+| `--text-dim` | `#5E6374` | Tertiary, timestamps, refs |
+| `--accent` (iris) | `#7C72E8` | THE accent: needs-you, primary actions, deadline pill, to-do edge. Nothing else. |
+| `--accent-hover` | `#9A92F2` | Accent hover |
+| `--accent-soft` | `rgba(124,114,232,.16)` | Accent fill behind pills/primary chips |
+| `--danger` | `#F26D5B` | Security alerts + destructive only. Never decorative. |
+| `--danger-soft` | `rgba(242,109,91,.13)` | |
+| `--safe` | `#46C08A` | "Available" / "handled on my own" / safe status |
+| `--warning` | `#E7B14C` | "Partial" coverage only |
+
+Discipline that fixes the old chip-soup: **accent is rare.** If two things on a row
+are accent-colored, one is wrong. Provenance, source-type, and topics are all neutral.
+
+**Light mode:** invert surfaces (bg `#FAFAFB`, surface `#FFFFFF`, text `#1A1B20`),
+keep the same accent, drop accent/danger fills to ~10% alpha. Derive, do not redesign.
+
+## Typography
+- **Voice (display):** **Fraunces** (opsz on; weight 500). Used ONLY for the twin's
+  one-line opener ("Three things need you this morning."). The serif is the
+  signature: it separates the twin's words from your content and reads considered,
+  human, trustworthy. Never use it for UI chrome.
+- **Everything structural:** **Geist** (400/450/500/600). Headings, to-dos, labels,
+  buttons, body. Calm and legible at small sizes.
+- **Data / refs / confidence / IDs:** **Geist Mono** (400/500). The mono IS the
+  visual cue for the technical (power) layer.
+- **Loading:** Google Fonts (`Fraunces`, `Geist`, `Geist Mono`) or self-host under
+  `apps/web/public/fonts`. Preconnect; `display=swap`.
+- **Blacklist:** never Inter, Roboto, Space Grotesk, system-ui as display/body (the
+  convergence trap).
+- **Scale (px):** voice 25 / section-label 12 (600, uppercase, muted) / to-do 15 /
+  topic-item 13.5 / meta 12 / mono 11.5. Line-height 1.5 body, 1.28 voice.
+
+## Spacing
+- **Base unit:** 4px. **Density:** comfortable (the to-do is the hero; give it air).
+- **Scale:** 2xs(2) xs(4) sm(8) md(12) lg(16) xl(24) 2xl(32) 3xl(48) 4xl(64).
+- Row padding 13px vertical; section gap 18–24px; card padding 24–26px.
+
+## Layout
+- **Approach:** single focused reading column. A digest is read top to bottom, not
+  scanned as a grid. **Max width ~680px.**
+- **Hierarchy is the layout:** the To-dos block is the action zone (accent edge,
+  checkboxes, inline actions); Topics is the awareness zone (lighter, no edge, no
+  checkbox, smaller). The eye must know "act vs. catch up" without reading.
+- **Radius:** card 14, control/row 8, button 6, pill 999. Crisp, not bubbly.
+
+## Motion
+- **Approach:** minimal-functional. Only motion that aids comprehension.
+- **Duration:** micro 120ms (toggles, hover), short 180ms (expand/collapse,
+  check-off), avoid anything longer. **Easing:** ease-out for enter, ease-in for exit.
+- Row actions reveal on hover/focus (calm at rest). Reduced-motion: no transitions.
+
+---
+
+## Component & State Catalog
+Every element, what it binds to, and EVERY state it must handle. States marked
+**(GAP)** exist in the data/logic today but were never rendered. The system designs
+them now; do not ship the element without them.
+
+### Twin voice opener
+Binds: `briefing` summary. Fraunces, 25px. One line ("Three things need you this
+morning."). States: with-todos / all-quiet ("You're all caught up.") / cold-start
+("Connect a source and I'll start your briefing.").
+
+### Value line
+Binds: counts derived from outcomes. `✓ N handled on my own · M need you · K to catch
+up`. The `✓ handled` segment uses `--safe`. Proves the twin earned its keep. State:
+hide the "handled" segment when zero.
+
+### To-do row (action zone) — `DigestTodo`
+Left edge 2px `--accent` (`--danger` for security). Checkbox + provenance dot + text
++ optional deadline pill + inline actions (hover/focus reveal).
+- **default** / **hover-focus** (actions appear) / **checked → completing** (180ms,
+  accent check, row fades) / **with-deadline** (accent pill `in 2 days`) /
+  **overdue** (GAP — pill flips to `--danger`) /
+  **security/danger** (red edge, no checkbox, hint "open your provider directly,"
+  action `Verify in app`) /
+  **scope-blocked (GAP)** — when `detail.whyNotAutoExecuted` includes
+  `missing_write_scope`, the primary action becomes a quiet `Grant access` (not a
+  filled accent button; it's a request, not a one-click act) /
+  **provenance**: filled dot `--text-muted` = "from you", hollow dot `--text-dim` =
+  inbound. Provenance is NEVER accent-colored.
+
+### Inline row actions
+Binds: action types (`send_reply`, `respond_to_event`, escalate…). Primary = filled
+accent (`Draft reply`, `Accept`); secondary = outline (`Snooze`, `Propose new`).
+Security primary = filled `--danger`. At most one primary per row. Reveal on
+hover/focus; on touch, always visible.
+
+### Source-type indication — `sourceType`
+NOT a row of CAPS chips (that was the chip-soup). A single small monochrome glyph +
+accessible label (email, calendar, file, voice, app). One mark, neutral, never accent.
+Unknown type → neutral dot, never crashes.
+
+### Citation — `signalRefs[]`
+NOT repeated "source" buttons. A single quiet affordance per row (a small "·N
+sources" link or an icon) that opens the in-app signal/decision detail. NEVER a raw
+external URL (safety #8). Hover: `--text`.
+
+### Topic group (awareness zone) — `DigestTopic`
+Domain title (12px muted) + lighter item rows: no edge, no checkbox, smaller (13.5px),
+neutral. Visibly recedes from the to-do zone. State: empty → omit the group.
+
+### Power-view toggle
+Header, right. Persisted. `aria-pressed`. Off by default (clean view is the default;
+non-technical users never see depth unless they ask). On: all detail panels expand +
+coverage panel shows.
+
+### Per-item detail panel — `DigestItemDetail`
+`--elevated` panel, mono refs. Rows: origin (provenance label) / confidence (% — show
+as text + a thin accent bar) / urgency (the reason) / not-auto-run (humanized block
+reasons) / refs (mono) / why (explanation). States: collapsed (per-row toggle) /
+expanded / forced-open (power view) / absent (no detail → no expander).
+
+### Coverage panel — `SourceCoverage`
+Power view. Per capability: status dot (`--safe` available / `--warning` partial /
+`--text-dim` unavailable) + name + "connect X to unlock Y". 
+**Cold-start (GAP):** when `coverage.coldStart` is true (zero connectors), this is NOT
+a panel buried in power view — it's the PRIMARY surface: a designed "Connect a source
+to begin" state listing connectable providers. This is the new user's first moment;
+design it, don't fall through to "nothing yet."
+
+### Digest container — states (several are GAPs)
+- **loading (GAP):** skeleton rows (shimmer at reduced-motion-safe), not a bare
+  "Loading…".
+- **populated:** the digest.
+- **empty-quiet:** connected but nothing today → the voice line "You're all caught
+  up." + the value line. Calm, not blank.
+- **cold-start (GAP):** zero connectors → the coverage cold-start surface above.
+- **error / API-fail (GAP):** a contained, human error card with Retry. Never a
+  white void; never swallow.
+- **prose-fallback:** no `structured` payload → render `prose_markdown`. When
+  structured IS present, prose collapses under a "Full briefing" disclosure.
+
+### Dashboard briefing card (`dashboard-view.js`)
+Binds: `briefing.items[]`. Mirror the digest language: accent edge = needs-you, safe =
+handled. Summary headline. States: loading / empty (hide) / cold-start / error. Today
+it hides when empty — give it a cold-start nudge instead.
+
+### Mobile BriefingScreen (`BriefingScreen.tsx`)
+Same system, same hierarchy. Has loading/error/empty already; bring it to digest
+parity (to-dos with actions, source mark, the two-zone hierarchy). Touch: actions
+always visible (no hover).
+
+---
+
+## Decisions Log
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2026-06-07 | Calm command center; premium, function-led | Trust product + daily surface → restraint beats flash; serves both audiences via clean-default + power-view |
+| 2026-06-07 | Iris `#7C72E8` as the ONE accent = "needs you / act" | Premium, refines the existing `#6c7bff`, avoids the convergent generic blue; single-accent discipline kills the chip-soup |
+| 2026-06-07 | Rejected warm/brown base | Read as sepia sludge; the real app is cool-neutral — align to it, deepen for premium |
+| 2026-06-07 | Fraunces for the twin's voice only | A serif signature reads human/considered/trustworthy and separates the twin's words from content |
+| 2026-06-07 | To-dos are an action zone (checkbox + inline actions), Topics an awareness zone | The "it can act" thesis must be visible; hierarchy encodes act-vs-catch-up |
+| 2026-06-07 | Every state cataloged incl. cold-start, scope-blocked, loading, error | Boil the lake: design all states, not the happy path |

--- a/apps/api/src/__tests__/describe-preference.test.ts
+++ b/apps/api/src/__tests__/describe-preference.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { describePreference } from '../routes/twin.js';
+
+/**
+ * Render hardening: describePreference must never emit "[object Object]" for a
+ * structured preference value (the dashboard "What I've learned" summaries go
+ * straight to the user). Regression guard for the Home-page bug where a
+ * brand-preference object rendered as "[object Object]".
+ */
+describe('describePreference', () => {
+  it('renders an object value readably, never "[object Object]"', () => {
+    const out = describePreference('shopping', 'brand_preference', {
+      category: 'electronics',
+      preferred: ['Apple', 'Sony'],
+    });
+    expect(out).not.toContain('[object Object]');
+    expect(out).toContain('electronics');
+    expect(out).toContain('Apple');
+    expect(out).toContain('Sony');
+  });
+
+  it('renders an array value as a joined list', () => {
+    const out = describePreference('shopping', 'favorites', ['Apple', 'Sony']);
+    expect(out).not.toContain('[object Object]');
+    expect(out).toContain('Apple, Sony');
+  });
+
+  it('renders nested objects without "[object Object]"', () => {
+    const out = describePreference('travel', 'rules', { seat: { window: true } });
+    expect(out).not.toContain('[object Object]');
+  });
+
+  it('renders booleans as enabled/disabled', () => {
+    expect(describePreference('calendar', 'morning_person', true)).toContain('enabled');
+    expect(describePreference('calendar', 'morning_person', false)).toContain('disabled');
+  });
+
+  it('surfaces a free-form string preference directly', () => {
+    expect(describePreference('email', 'tone', 'concise')).toBe('Email: concise');
+  });
+
+  it('includes the key for a numeric preference', () => {
+    expect(describePreference('scheduling', 'meeting_buffer', 15)).toContain('15');
+    expect(describePreference('scheduling', 'meeting_buffer', 15)).toContain('meeting buffer');
+  });
+
+  it('returns null for null/undefined/empty values', () => {
+    expect(describePreference('email', 'x', null)).toBeNull();
+    expect(describePreference('email', 'x', undefined)).toBeNull();
+    expect(describePreference('email', 'x', '')).toBeNull();
+  });
+});

--- a/apps/api/src/__tests__/fake-user-e2e.test.ts
+++ b/apps/api/src/__tests__/fake-user-e2e.test.ts
@@ -232,6 +232,8 @@ class InMemoryLabelInferencePort implements LabelInferencePort {
 // ── Fake user: Bob Patel, founder/CEO at Series A startup ─────────────────
 
 const BOB_USER_ID = 'bob-patel-uuid-fixture-aaaabbbb';
+const GMAIL_SEND_SCOPE = 'https://www.googleapis.com/auth/gmail.send';
+const CALENDAR_EVENTS_SCOPE = 'https://www.googleapis.com/auth/calendar.events';
 
 function buildBobPreferences(): Preference[] {
   const now = new Date();
@@ -618,6 +620,7 @@ describe('full E2E — fake user driven through DecisionMaker', () => {
   it('board email → escalates to approval, never auto-execute', async () => {
     const decision = buildInbox().find((d) => d.id === 'd-board-001')!;
     const ctx = await buildContext(harness, decision, TrustTier.HIGH_AUTONOMY);
+    ctx.grantedScopes = [GMAIL_SEND_SCOPE];
     const outcome = await harness.decisionMaker.evaluate(ctx);
 
     // Even at HIGH_AUTONOMY a send_reply on a board thread is irreversible →
@@ -638,6 +641,7 @@ describe('full E2E — fake user driven through DecisionMaker', () => {
   it('CFO email requiring response → reply is irreversible → policy gates', async () => {
     const decision = buildInbox().find((d) => d.id === 'd-cfo-001')!;
     const ctx = await buildContext(harness, decision, TrustTier.MODERATE_AUTONOMY);
+    ctx.grantedScopes = [GMAIL_SEND_SCOPE];
     const outcome = await harness.decisionMaker.evaluate(ctx);
 
     // The reply candidate should exist (requiresResponse=true triggers it)
@@ -655,6 +659,7 @@ describe('full E2E — fake user driven through DecisionMaker', () => {
   it('calendar invite → produces accept/decline/propose-alternative candidates', async () => {
     const decision = buildInbox().find((d) => d.id === 'd-cal-001')!;
     const ctx = await buildContext(harness, decision, TrustTier.MODERATE_AUTONOMY);
+    ctx.grantedScopes = [CALENDAR_EVENTS_SCOPE];
     const outcome = await harness.decisionMaker.evaluate(ctx);
 
     const types = outcome.allCandidates.map((c) => c.actionType);

--- a/apps/api/src/__tests__/live-digest-helpers.test.ts
+++ b/apps/api/src/__tests__/live-digest-helpers.test.ts
@@ -83,7 +83,7 @@ describe('urgencyReasonFor', () => {
   });
 
   it('describes the urgency level for other situations', () => {
-    expect(urgencyReasonFor({ situation_type: 'email_triage', urgency: 'critical' })).toMatch(/critical/i);
+    expect(urgencyReasonFor({ situation_type: 'email_triage', urgency: 'critical' })).toMatch(/urgent/i);
     expect(urgencyReasonFor({ situation_type: 'email_triage', urgency: 'low' })).toMatch(/routine/i);
   });
 

--- a/apps/api/src/__tests__/live-digest-helpers.test.ts
+++ b/apps/api/src/__tests__/live-digest-helpers.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { needsYou, sourceLabel } from '../services/live-digest.js';
+
+/**
+ * The to-do/FYI split (spec 01) and source labels (spec 07) that drive the
+ * live digest. Pure logic — guarded here so the classification can't silently
+ * drift (e.g. a security alert quietly dropping out of the to-do bucket).
+ */
+describe('needsYou (to-do bucket classification)', () => {
+  const row = (over: Partial<Parameters<typeof needsYou>[0]>) => ({
+    requires_approval: false,
+    situation_type: 'email_triage',
+    urgency: 'low',
+    ...over,
+  });
+
+  it('is a to-do when the engine escalated it for approval', () => {
+    expect(needsYou(row({ requires_approval: true }))).toBe(true);
+  });
+
+  it('is a to-do for a security alert (escalate-only, spec 06)', () => {
+    expect(needsYou(row({ situation_type: 'security_alert' }))).toBe(true);
+  });
+
+  it('is a to-do for a new calendar invite (needs RSVP)', () => {
+    expect(needsYou(row({ situation_type: 'calendar_invite' }))).toBe(true);
+  });
+
+  it('is a to-do when urgency is high or critical', () => {
+    expect(needsYou(row({ urgency: 'high' }))).toBe(true);
+    expect(needsYou(row({ urgency: 'critical' }))).toBe(true);
+  });
+
+  it('is FYI (not a to-do) for routine low/medium items', () => {
+    expect(needsYou(row({}))).toBe(false);
+    expect(needsYou(row({ urgency: 'medium' }))).toBe(false);
+    expect(needsYou(row({ situation_type: 'calendar_update', urgency: 'medium' }))).toBe(false);
+  });
+
+  it('treats a null requires_approval as not-escalated', () => {
+    expect(needsYou(row({ requires_approval: null }))).toBe(false);
+  });
+});
+
+describe('sourceLabel', () => {
+  it('maps connector channels to digest source labels', () => {
+    expect(sourceLabel('gmail')).toBe('email');
+    expect(sourceLabel('email')).toBe('email');
+    expect(sourceLabel('google_calendar')).toBe('calendar');
+    expect(sourceLabel('calendar')).toBe('calendar');
+    expect(sourceLabel('filesystem')).toBe('file');
+    expect(sourceLabel('voice')).toBe('voice');
+  });
+
+  it('falls back to the raw source, or "app" when empty', () => {
+    expect(sourceLabel('slack')).toBe('slack');
+    expect(sourceLabel('')).toBe('app');
+  });
+});

--- a/apps/api/src/__tests__/live-digest-helpers.test.ts
+++ b/apps/api/src/__tests__/live-digest-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { needsYou, sourceLabel } from '../services/live-digest.js';
+import { needsYou, sourceLabel, normalizeUrgency, urgencyReasonFor } from '../services/live-digest.js';
 
 /**
  * The to-do/FYI split (spec 01) and source labels (spec 07) that drive the
@@ -55,5 +55,39 @@ describe('sourceLabel', () => {
   it('falls back to the raw source, or "app" when empty', () => {
     expect(sourceLabel('slack')).toBe('slack');
     expect(sourceLabel('')).toBe('app');
+  });
+});
+
+describe('normalizeUrgency', () => {
+  it("maps the DB default 'normal' to 'medium', not 'low'", () => {
+    expect(normalizeUrgency('normal')).toBe('medium');
+  });
+
+  it('passes through valid union values', () => {
+    expect(normalizeUrgency('low')).toBe('low');
+    expect(normalizeUrgency('medium')).toBe('medium');
+    expect(normalizeUrgency('high')).toBe('high');
+    expect(normalizeUrgency('critical')).toBe('critical');
+  });
+
+  it('falls back to low for null/unknown values', () => {
+    expect(normalizeUrgency(null)).toBe('low');
+    expect(normalizeUrgency('whatever')).toBe('low');
+  });
+});
+
+describe('urgencyReasonFor', () => {
+  it('gives the real driver for escalate-only / RSVP situations', () => {
+    expect(urgencyReasonFor({ situation_type: 'security_alert', urgency: 'high' })).toMatch(/security alert/i);
+    expect(urgencyReasonFor({ situation_type: 'calendar_invite', urgency: 'medium' })).toMatch(/rsvp/i);
+  });
+
+  it('describes the urgency level for other situations', () => {
+    expect(urgencyReasonFor({ situation_type: 'email_triage', urgency: 'critical' })).toMatch(/critical/i);
+    expect(urgencyReasonFor({ situation_type: 'email_triage', urgency: 'low' })).toMatch(/routine/i);
+  });
+
+  it('never returns the generic "Default for" placeholder', () => {
+    expect(urgencyReasonFor({ situation_type: 'email_triage', urgency: 'normal' })).not.toMatch(/default for/i);
   });
 });

--- a/apps/api/src/__tests__/live-digest.test.ts
+++ b/apps/api/src/__tests__/live-digest.test.ts
@@ -65,8 +65,10 @@ describe('buildLiveDigest', () => {
     expect(todo.detail?.sourceRefs[0]).toContain('no-reply@accounts.example');
     expect(todo.detail?.sourceRefs[0]).not.toMatch(/^email:\s*[0-9a-f]{8}$/);
     expect(todo.detail?.urgencyReason).toMatch(/security alert/i);
-    expect(todo.detail?.provenanceLabel).toMatch(/untrusted/i); // safety #8 fail-safe
-    expect(todo.detail?.whyNotAutoExecuted.join(' ')).toMatch(/untrusted/i);
+    // Plain-language provenance (no scary "untrusted" jargon), still fail-safe.
+    expect(todo.detail?.provenanceLabel).toBe('From someone else');
+    expect(todo.detail?.whyNotAutoExecuted.join(' ')).toMatch(/someone else/i);
+    expect(todo.detail?.whyNotAutoExecuted.join(' ')).not.toMatch(/untrusted/i);
     // Actionable, not system labels: the real snippet + a recommended step.
     expect(todo.body).toBe('A sign-in from a new device.');
     expect(todo.detail?.suggestedAction).toMatch(/security settings/i);

--- a/apps/api/src/__tests__/live-digest.test.ts
+++ b/apps/api/src/__tests__/live-digest.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock only @skytwin/db's query — the decision-engine fold (buildDigest,
+// toSignalText, buildDigestItemDetail, computeCoverage) stays REAL so this
+// exercises the actual mapper glue, not a stub of it.
+const mockQuery = vi.fn();
+vi.mock('@skytwin/db', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+import { buildLiveDigest } from '../services/live-digest.js';
+
+function decisionRow(over: Record<string, unknown> = {}) {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    raw_event: {
+      source: 'gmail',
+      type: 'message',
+      data: {
+        subject: 'Account notice',
+        from: 'no-reply@accounts.example',
+        snippet: 'A sign-in from a new device.',
+        authoringTier: 'inbox_automated',
+      },
+    },
+    summary: 'Account notice',
+    domain: 'security',
+    urgency: 'high',
+    situation_type: 'security_alert',
+    created_at: new Date('2026-06-01T00:00:00Z'),
+    requires_approval: true,
+    auto_executed: false,
+    escalation_reason: 'untrusted_origin',
+    confidence: 0.8,
+    ...over,
+  };
+}
+
+describe('buildLiveDigest', () => {
+  beforeEach(() => mockQuery.mockReset());
+
+  it('returns null when the user has no decisions (cold start)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    expect(await buildLiveDigest('u1')).toBeNull();
+  });
+
+  it('maps a security decision to a to-do with meaningful power-view detail', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [decisionRow()] }) // decisions+outcomes
+      .mockResolvedValueOnce({ rows: [] }); // connected_accounts
+
+    const d = await buildLiveDigest('u1');
+    expect(d).not.toBeNull();
+    expect(d!.todos).toHaveLength(1);
+
+    const todo = d!.todos[0]!;
+    // Title comes from toSignalText (the real subject), not the generic summary.
+    expect(todo.text).toBe('Account notice');
+    expect(todo.sourceType).toBe('email');
+    // Detail is meaningful: real confidence, the sender as the ref, a real
+    // urgency reason, inbound provenance — not "[id slice]" / "Default for X".
+    expect(todo.detail?.confidencePct).toBe(80);
+    expect(todo.detail?.sourceRefs[0]).toContain('no-reply@accounts.example');
+    expect(todo.detail?.sourceRefs[0]).not.toMatch(/^email:\s*[0-9a-f]{8}$/);
+    expect(todo.detail?.urgencyReason).toMatch(/security alert/i);
+    expect(todo.detail?.provenanceLabel).toMatch(/untrusted/i); // safety #8 fail-safe
+    expect(todo.detail?.whyNotAutoExecuted.join(' ')).toMatch(/untrusted/i);
+  });
+
+  it('puts routine inbound items in topics, not to-dos', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          decisionRow({
+            situation_type: 'email_triage',
+            domain: 'email',
+            urgency: 'low',
+            requires_approval: false,
+            escalation_reason: null,
+            summary: 'Weekly digest',
+            raw_event: {
+              source: 'gmail',
+              type: 'message',
+              data: { subject: 'Weekly digest', from: 'news@x.example' },
+            },
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const d = await buildLiveDigest('u1');
+    expect(d!.todos).toHaveLength(0);
+    const item = d!.topics.flatMap((t) => t.items)[0];
+    expect(item?.text).toBe('Weekly digest');
+    // No fabricated "not auto-run" reason for a non-escalated FYI item.
+    expect(item?.detail?.whyNotAutoExecuted).toEqual([]);
+  });
+
+  it('degrades a malformed raw_event to the summary without throwing', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          decisionRow({
+            raw_event: null,
+            summary: 'fallback summary',
+            situation_type: 'email_triage',
+            urgency: 'low',
+            requires_approval: false,
+            escalation_reason: null,
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const d = await buildLiveDigest('u1');
+    const item = d!.topics.flatMap((t) => t.items)[0];
+    expect(item?.text).toBe('fallback summary');
+  });
+
+  it('marks a user-authored signal as from-you provenance', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          decisionRow({
+            situation_type: 'email_triage',
+            urgency: 'low',
+            requires_approval: false,
+            escalation_reason: null,
+            raw_event: {
+              source: 'gmail',
+              type: 'message',
+              data: { subject: 'Re: vendor', authoringTier: 'user_sent_reply' },
+            },
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const d = await buildLiveDigest('u1');
+    const item = d!.topics.flatMap((t) => t.items)[0];
+    expect(item?.detail?.provenanceLabel).toMatch(/from you/i);
+  });
+
+  it('counts only auto_executed decisions in handledCount', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          decisionRow({ id: 'a', auto_executed: true, requires_approval: false, situation_type: 'email_triage', urgency: 'low', escalation_reason: null }),
+          decisionRow({ id: 'b', auto_executed: false, requires_approval: false, situation_type: 'email_triage', urgency: 'low', escalation_reason: null }),
+          decisionRow({ id: 'c', auto_executed: null, requires_approval: false, situation_type: 'email_triage', urgency: 'low', escalation_reason: null }),
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const d = await buildLiveDigest('u1');
+    expect(d!.handledCount).toBe(1);
+  });
+});

--- a/apps/api/src/__tests__/live-digest.test.ts
+++ b/apps/api/src/__tests__/live-digest.test.ts
@@ -32,6 +32,8 @@ function decisionRow(over: Record<string, unknown> = {}) {
     auto_executed: false,
     escalation_reason: 'untrusted_origin',
     confidence: 0.8,
+    selected_action_desc: null,
+    selected_action_type: null,
     ...over,
   };
 }
@@ -65,6 +67,39 @@ describe('buildLiveDigest', () => {
     expect(todo.detail?.urgencyReason).toMatch(/security alert/i);
     expect(todo.detail?.provenanceLabel).toMatch(/untrusted/i); // safety #8 fail-safe
     expect(todo.detail?.whyNotAutoExecuted.join(' ')).toMatch(/untrusted/i);
+    // Actionable, not system labels: the real snippet + a recommended step.
+    expect(todo.body).toBe('A sign-in from a new device.');
+    expect(todo.detail?.suggestedAction).toMatch(/security settings/i);
+  });
+
+  it('uses the pipeline-selected action as the suggested next step', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          decisionRow({
+            situation_type: 'calendar_invite',
+            domain: 'calendar',
+            urgency: 'medium',
+            requires_approval: false,
+            escalation_reason: null,
+            selected_action_desc: 'Accept this calendar invitation.',
+            selected_action_type: 'accept_invite',
+            raw_event: {
+              source: 'google_calendar',
+              type: 'event',
+              data: { title: 'Acme kickoff', description: 'Project kickoff with Acme.' },
+            },
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const d = await buildLiveDigest('u1');
+    // calendar_invite is a to-do (needs RSVP)
+    const todo = d!.todos[0]!;
+    expect(todo.text).toBe('Acme kickoff');
+    expect(todo.body).toBe('Project kickoff with Acme.');
+    expect(todo.detail?.suggestedAction).toBe('Accept this calendar invitation.');
   });
 
   it('puts routine inbound items in topics, not to-dos', async () => {

--- a/apps/api/src/__tests__/live-digest.test.ts
+++ b/apps/api/src/__tests__/live-digest.test.ts
@@ -72,7 +72,7 @@ describe('buildLiveDigest', () => {
     expect(todo.detail?.suggestedAction).toMatch(/security settings/i);
   });
 
-  it('uses the pipeline-selected action as the suggested next step', async () => {
+  it('derives a clean suggested step from the selected action TYPE', async () => {
     mockQuery
       .mockResolvedValueOnce({
         rows: [
@@ -82,6 +82,7 @@ describe('buildLiveDigest', () => {
             urgency: 'medium',
             requires_approval: false,
             escalation_reason: null,
+            // The engine's raw description is internal-y; we map the TYPE.
             selected_action_desc: 'Accept this calendar invitation.',
             selected_action_type: 'accept_invite',
             raw_event: {
@@ -99,7 +100,32 @@ describe('buildLiveDigest', () => {
     const todo = d!.todos[0]!;
     expect(todo.text).toBe('Acme kickoff');
     expect(todo.body).toBe('Project kickoff with Acme.');
-    expect(todo.detail?.suggestedAction).toBe('Accept this calendar invitation.');
+    expect(todo.detail?.suggestedAction).toMatch(/accept the invite/i);
+  });
+
+  it('cleans the engine\'s internal action text into a user-facing step', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          decisionRow({
+            situation_type: 'generic',
+            domain: 'general',
+            urgency: 'low',
+            requires_approval: false,
+            escalation_reason: null,
+            // Raw rule-based text that should NOT leak to the user.
+            selected_action_desc: 'Escalate to user: Decision needed regarding: transcript.',
+            selected_action_type: 'escalate_to_user',
+            raw_event: { source: 'voice', type: 'note', data: { transcript: 'Call Acme Monday.' } },
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const d = await buildLiveDigest('u1');
+    const item = d!.topics.flatMap((t) => t.items)[0];
+    expect(item?.detail?.suggestedAction).not.toMatch(/escalate to user|decision needed regarding/i);
+    expect(item?.detail?.suggestedAction).toMatch(/take a look/i);
   });
 
   it('puts routine inbound items in topics, not to-dos', async () => {

--- a/apps/api/src/__tests__/twin-briefings-sections-fold.test.ts
+++ b/apps/api/src/__tests__/twin-briefings-sections-fold.test.ts
@@ -38,6 +38,10 @@ vi.mock('@skytwin/db', () => ({
   lifebookRepository: {
     listVisible: mockListVisible,
   },
+  // buildLiveDigest (twin-briefings /latest) queries decisions; an empty
+  // result makes it return null so these tests exercise the prose/sections
+  // path without the live digest.
+  query: vi.fn().mockResolvedValue({ rows: [] }),
 }));
 
 import { createTwinBriefingsRouter } from '../routes/twin-briefings.js';

--- a/apps/api/src/routes/credential-vault.ts
+++ b/apps/api/src/routes/credential-vault.ts
@@ -130,8 +130,18 @@ function unpackEncrypted(packed: Buffer): { iv: Buffer; tag: Buffer; ciphertext:
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function getUserId(req: Request): string | undefined {
-  const asAny = req as unknown as { user?: { id?: string } };
-  return asAny.user?.id;
+  const asAny = req as unknown as {
+    user?: { id?: string };
+    query?: { userId?: string };
+    body?: { userId?: string };
+  };
+  // Session identity first (production); fall back to the explicit userId the
+  // client passes (the codebase's dev convention, e.g. twin-briefings) so the
+  // vault works under the localhost dev-auth bypass. Ownership is still gated
+  // by requireOwnership when a real session is present.
+  return asAny.user?.id
+    ?? (typeof asAny.query?.userId === 'string' ? asAny.query.userId : undefined)
+    ?? (typeof asAny.body?.userId === 'string' ? asAny.body.userId : undefined);
 }
 
 // ── Router ────────────────────────────────────────────────────────────────────

--- a/apps/api/src/routes/decisions.ts
+++ b/apps/api/src/routes/decisions.ts
@@ -31,6 +31,7 @@ export function createDecisionsRouter(): Router {
       const to = req.query['to'] ? new Date(req.query['to'] as string) : undefined;
       const situationType = req.query['situationType'] as string | undefined;
       const search = req.query['search'] as string | undefined;
+      const signalId = (req.query['signalId'] ?? req.query['signal']) as string | undefined;
 
       let decisions = await decisionRepository.findByUser(userId, {
         domain,
@@ -38,6 +39,7 @@ export function createDecisionsRouter(): Router {
         offset: search || situationType ? 0 : offset,
         from,
         to,
+        signalId,
       });
 
       // Server-side filter: situation type

--- a/apps/api/src/routes/decisions.ts
+++ b/apps/api/src/routes/decisions.ts
@@ -66,18 +66,22 @@ export function createDecisionsRouter(): Router {
         decisions.map((d) => d.id),
       );
       const outcomeMap = new Map(
-        outcomes.map((o) => [o.decision_id, o.auto_executed]),
+        outcomes.map((o) => [o.decision_id, o]),
       );
 
       res.json({
-        decisions: decisions.map((d) => ({
-          id: d.id,
-          situationType: d.situation_type,
-          domain: d.domain,
-          urgency: d.urgency,
-          autoExecuted: outcomeMap.has(d.id) ? outcomeMap.get(d.id) : null,
-          createdAt: d.created_at,
-        })),
+        decisions: decisions.map((d) => {
+          const outcome = outcomeMap.get(d.id);
+          return {
+            id: d.id,
+            situationType: d.situation_type,
+            domain: d.domain,
+            urgency: d.urgency,
+            autoExecuted: outcome ? outcome.auto_executed : null,
+            requiresApproval: outcome ? outcome.requires_approval === true : false,
+            createdAt: d.created_at,
+          };
+        }),
         total,
         limit,
         offset,

--- a/apps/api/src/routes/twin-briefings.ts
+++ b/apps/api/src/routes/twin-briefings.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { briefingRepository, lifebookRepository } from '@skytwin/db';
 import { createLogger } from '@skytwin/core';
 import { UUID_REGEX } from '../middleware/validate-uuid.js';
+import { buildLiveDigest } from '../services/live-digest.js';
 
 const log = createLogger('api:twin-briefings');
 
@@ -91,18 +92,41 @@ export function createTwinBriefingsRouter(): Router {
         })
         .filter((s): s is NonNullable<typeof s> => s !== null);
 
-      // Spec 08/01: expose the structured digest payload (todos/topics) when
-      // present so the UI can render the two-bucket source-aware view. Nullable
-      // and additive — old briefings (no structured_payload) return null and the
-      // UI falls back to the prose render. Forward-compatible: when the
-      // structured_payload column + generator write land, it flows through here.
-      const briefingWithStructured = briefing
-        ? {
-            ...briefing,
-            structured:
-              (briefing as { structured_payload?: unknown }).structured_payload ?? null,
-          }
-        : null;
+      // Spec 08/01: expose the structured digest payload (todos/topics) so the
+      // UI can render the two-bucket source-aware view. Resolution order:
+      //   1. a stored structured_payload (forward-compatible, set by the
+      //      worker's generator once that seam lands), else
+      //   2. a digest computed live from the user's recent decisions, so the
+      //      page renders real parity today.
+      // The live build is best-effort — any failure degrades to the prose
+      // render rather than 500ing the briefing endpoint.
+      const stored = (briefing as { structured_payload?: unknown } | null)
+        ?.structured_payload;
+      const liveDigest = stored
+        ? null
+        : await buildLiveDigest(userId).catch((e) => {
+            log.warn('live digest build failed', { userId, error: String(e) });
+            return null;
+          });
+      const structured = stored ?? liveDigest;
+
+      let briefingWithStructured: unknown = null;
+      if (briefing) {
+        briefingWithStructured = { ...briefing, structured: structured ?? null };
+      } else if (liveDigest && (liveDigest.todos.length || liveDigest.topics.length)) {
+        // No stored briefing row yet, but we can render live parity from
+        // decisions. Synthesize a minimal briefing envelope carrying the
+        // structured digest; prose is null so the UI renders the digest only.
+        briefingWithStructured = {
+          id: 'live',
+          user_id: userId,
+          cadence: cadence ?? 'daily',
+          prose_markdown: null,
+          generated_at: new Date().toISOString(),
+          read_at: null,
+          structured: liveDigest,
+        };
+      }
 
       res.json({ briefing: briefingWithStructured, sections });
     } catch (err) {

--- a/apps/api/src/routes/twin-briefings.ts
+++ b/apps/api/src/routes/twin-briefings.ts
@@ -91,7 +91,20 @@ export function createTwinBriefingsRouter(): Router {
         })
         .filter((s): s is NonNullable<typeof s> => s !== null);
 
-      res.json({ briefing: briefing ?? null, sections });
+      // Spec 08/01: expose the structured digest payload (todos/topics) when
+      // present so the UI can render the two-bucket source-aware view. Nullable
+      // and additive — old briefings (no structured_payload) return null and the
+      // UI falls back to the prose render. Forward-compatible: when the
+      // structured_payload column + generator write land, it flows through here.
+      const briefingWithStructured = briefing
+        ? {
+            ...briefing,
+            structured:
+              (briefing as { structured_payload?: unknown }).structured_payload ?? null,
+          }
+        : null;
+
+      res.json({ briefing: briefingWithStructured, sections });
     } catch (err) {
       next(err);
     }

--- a/apps/api/src/routes/twin.ts
+++ b/apps/api/src/routes/twin.ts
@@ -323,7 +323,7 @@ export function createTwinRouter(): Router {
   return router;
 }
 
-function describePreference(domain: string, key: string, value: unknown): string | null {
+export function describePreference(domain: string, key: string, value: unknown): string | null {
   const domainLabels: Record<string, string> = {
     email: 'Email',
     calendar: 'Calendar',
@@ -369,8 +369,41 @@ function describePreference(domain: string, key: string, value: unknown): string
     // like a config file ("find_travel_deals = i love travel deals").
     return `${domainLabel}: ${value.trim()}`;
   }
+  if (typeof value === 'number') {
+    return `${domainLabel}: ${humanKey} — ${value}`;
+  }
   if (value !== null && value !== undefined) {
-    return `${domainLabel}: ${humanKey} — ${String(value)}`;
+    // Objects/arrays: render a compact, human-readable summary instead of the
+    // useless "[object Object]" that String() produces on a structured value.
+    const rendered = renderStructuredPrefValue(value);
+    return rendered ? `${domainLabel}: ${humanKey} — ${rendered}` : null;
   }
   return null;
+}
+
+/**
+ * Turn a structured preference value (array or object) into a short,
+ * human-readable string. Never returns "[object Object]".
+ */
+function renderStructuredPrefValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => (v !== null && typeof v === 'object' ? JSON.stringify(v) : String(v)))
+      .filter((s) => s.length > 0)
+      .join(', ');
+  }
+  if (value !== null && typeof value === 'object') {
+    const parts: string[] = [];
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (v === null || v === undefined) continue;
+      const vs = Array.isArray(v)
+        ? v.join(', ')
+        : typeof v === 'object'
+          ? JSON.stringify(v)
+          : String(v);
+      if (vs.length > 0) parts.push(`${k.replace(/_/g, ' ')}: ${vs}`);
+    }
+    return parts.join('; ');
+  }
+  return String(value);
 }

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -16,9 +16,35 @@ const VALID_DOMAINS = [
 /**
  * Create the users management router.
  */
+/**
+ * Conservative autonomy defaults for a brand-new user (spec 10 Part A).
+ *
+ * Deliberately NO spend caps: the built-in `NO_SPEND_WITHOUT_LIMIT` policy
+ * blocks all spend until the user configures a budget, so omitting caps is the
+ * safe default (escalate, never silently auto-spend). The dashboard surfaces
+ * "set a budget to enable spend". Domain allow/block lists start empty.
+ */
+const DEFAULT_AUTONOMY_SETTINGS: Record<string, unknown> = {
+  allowedDomains: [],
+  blockedDomains: [],
+};
+
 export function createUsersRouter(): Router {
   const router = Router();
   const twinService = new TwinService(new TwinRepositoryAdapter(), new PatternRepositoryAdapter());
+
+  /**
+   * Provision the zero-content default state every real user starts from:
+   * an empty twin profile (eagerly, not lazily) + conservative autonomy
+   * settings. Idempotent (getOrCreateProfile no-ops if a profile exists) and
+   * only invoked on the genuinely-new-user path, so it never clobbers a
+   * configured user. Best-effort: getOrCreateProfile lazily backstops the
+   * profile elsewhere, so this is belt-and-suspenders, not a hard dependency.
+   */
+  async function provisionNewUser(userId: string): Promise<void> {
+    await twinService.getOrCreateProfile(userId);
+    await userRepository.updateAutonomySettings(userId, DEFAULT_AUTONOMY_SETTINGS);
+  }
 
   // Everything under /:userId is user-scoped and must be authenticated.
   router.use('/:userId', sessionAuth, requireOwnership);
@@ -99,15 +125,25 @@ export function createUsersRouter(): Router {
         return;
       }
 
-      // Trust tier is always 'suggest' for new users — must be earned, not declared.
-      // Callers cannot self-escalate via the creation endpoint.
-      const trustTier = 'suggest';
+      // Trust tier is always 'observer' for new users — must be earned, not declared
+      // (spec 10, LOCKED 2026-06-06). Matches the DB column default and CLAUDE.md;
+      // resolves the prior 3-way conflict where this line forced 'suggest'. Users
+      // climb observer -> suggest via the transparent, consensual promotion engine
+      // (10 consecutive approvals at >=80%, user-accepted). Callers cannot
+      // self-escalate via the creation endpoint.
+      const trustTier = 'observer';
 
       const user = await userRepository.create({
         email,
         name,
         trustTier,
       });
+
+      // Provision the zero-content default state every real user starts from:
+      // an empty twin profile + conservative autonomy settings. Idempotent and
+      // best-effort — getOrCreateProfile lazily backstops if this is skipped,
+      // so a provisioning hiccup never blocks user creation. (spec 10 Part A)
+      await provisionNewUser(user.id);
 
       res.status(201).json({ user, created: true });
     } catch (error) {

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -143,7 +143,15 @@ export function createUsersRouter(): Router {
       // an empty twin profile + conservative autonomy settings. Idempotent and
       // best-effort — getOrCreateProfile lazily backstops if this is skipped,
       // so a provisioning hiccup never blocks user creation. (spec 10 Part A)
-      await provisionNewUser(user.id);
+      try {
+        await provisionNewUser(user.id);
+      } catch (provisionErr) {
+        // Genuinely best-effort (review): the user row already exists, and
+        // getOrCreateProfile lazily backstops the profile later — so a
+        // provisioning hiccup must NOT turn into a 500 (which, on client retry,
+        // would then hit "email already exists"). Swallow and continue.
+        console.warn('[users] provisionNewUser failed (non-blocking):', provisionErr);
+      }
 
       res.status(201).json({ user, created: true });
     } catch (error) {

--- a/apps/api/src/services/live-digest.ts
+++ b/apps/api/src/services/live-digest.ts
@@ -25,6 +25,9 @@ import {
   type Digest,
 } from '@skytwin/decision-engine';
 
+/** Most-recent decisions scanned to assemble one digest (perf + relevance bound). */
+const RECENT_DECISIONS_WINDOW = 30;
+
 interface DecisionDigestRow {
   id: string;
   raw_event: unknown;
@@ -36,6 +39,7 @@ interface DecisionDigestRow {
   requires_approval: boolean | null;
   auto_executed: boolean | null;
   escalation_reason: string | null;
+  confidence: number | null;
 }
 
 interface AccountRow {
@@ -63,6 +67,49 @@ export function sourceLabel(source: string): string {
 }
 
 const VALID_URGENCY = new Set(['low', 'medium', 'high', 'critical']);
+
+/**
+ * Normalize a stored urgency to the DigestItem union. The decisions table
+ * defaults urgency to 'normal' (decisionRepository.create), which isn't in the
+ * union — map it to 'medium' rather than silently demoting it to 'low'.
+ */
+export function normalizeUrgency(u: string | null): NonNullable<DigestItem['urgency']> {
+  if (u === 'normal') return 'medium';
+  return (u && VALID_URGENCY.has(u) ? u : 'low') as NonNullable<DigestItem['urgency']>;
+}
+
+/**
+ * A human "why this urgency" line for the power view — the real driver, not a
+ * generic "Default for <domain>" placeholder.
+ */
+export function urgencyReasonFor(row: {
+  situation_type: string;
+  urgency: string | null;
+}): string {
+  if (row.situation_type === 'security_alert') {
+    return 'Security alert — always sent to you, never auto-handled';
+  }
+  if (row.situation_type === 'calendar_invite') return 'New invite — awaiting your RSVP';
+  switch (normalizeUrgency(row.urgency)) {
+    case 'critical':
+      return 'Critical — flagged for immediate attention';
+    case 'high':
+      return 'High urgency';
+    case 'medium':
+      return 'Normal priority';
+    default:
+      return 'Routine — no deadline detected';
+  }
+}
+
+/** First non-empty string field from a signal's data payload. */
+function senderRef(data: Record<string, unknown>): string | null {
+  for (const key of ['from', 'organizer', 'fileName', 'path']) {
+    const v = data[key];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return null;
+}
 
 /**
  * A decision belongs in the TO-DO bucket (needs you) when the engine escalated
@@ -96,13 +143,13 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
             d.raw_event,
             (d.interpreted_situation->>'summary') AS summary,
             d.domain, d.urgency, d.situation_type, d.created_at,
-            o.requires_approval, o.auto_executed, o.escalation_reason
+            o.requires_approval, o.auto_executed, o.escalation_reason, o.confidence
      FROM decisions d
      LEFT JOIN decision_outcomes o ON o.decision_id = d.id
      WHERE d.user_id = $1
      ORDER BY d.created_at DESC
-     LIMIT 30`,
-    [userId],
+     LIMIT $2`,
+    [userId, RECENT_DECISIONS_WINDOW],
   );
   if (decisions.rows.length === 0) return null;
 
@@ -118,14 +165,15 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
       type?: unknown;
       data?: unknown;
     };
+    const data: Record<string, unknown> =
+      raw.data && typeof raw.data === 'object'
+        ? (raw.data as Record<string, unknown>)
+        : {};
     const signalText = toSignalText({
       id: r.id,
       source: typeof raw.source === 'string' ? raw.source : 'unknown',
       type: typeof raw.type === 'string' ? raw.type : 'unknown',
-      data:
-        raw.data && typeof raw.data === 'object'
-          ? (raw.data as Record<string, unknown>)
-          : {},
+      data,
       timestamp: r.created_at instanceof Date ? r.created_at : new Date(r.created_at),
     });
     const text =
@@ -135,25 +183,33 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
       `${r.situation_type.replace(/_/g, ' ')} needs review`;
 
     const actionRequired = needsYou(r);
-    const urgency = (r.urgency && VALID_URGENCY.has(r.urgency)
-      ? r.urgency
-      : 'low') as DigestItem['urgency'];
-    const blockedReasons = actionRequired
-      ? [r.escalation_reason ?? 'trust_tier:observer']
-      : [];
+    const urgency = normalizeUrgency(r.urgency);
+    // Honest "why not auto-run": the engine's real escalation reason if it has
+    // one, else the trust-tier gate ONLY when it genuinely required approval.
+    // A to-do that's escalate-only by nature (security/RSVP) but wasn't
+    // approval-gated gets no fabricated reason ("Set aside for your review").
+    const blockedReasons = r.escalation_reason
+      ? [r.escalation_reason]
+      : r.requires_approval === true
+        ? ['trust_tier:observer']
+        : [];
 
     const sourceType = sourceLabel(signalText.source);
+    // Meaningful source ref: who/what it came from (sender, organizer, file),
+    // not an opaque internal id slice.
+    const sender = senderRef(data);
     detailByRef.set(
       r.id,
       buildDigestItemDetail({
         // Inbound/ingested content the user did not author is untrusted-origin
         // (safety #8); user-authored signals (spec 07) are trusted context.
         provenance: signalText.authoredByUser ? 'user_originated' : 'untrusted_external',
+        confidence: typeof r.confidence === 'number' ? r.confidence : undefined,
         domain: r.domain,
+        urgencyReason: urgencyReasonFor(r),
         requiresApproval: actionRequired,
         blockedReasons,
-        explanation: r.summary,
-        sourceRefs: [`${sourceType}:${r.id.slice(0, 8)}`],
+        sourceRefs: [sender ? `${sourceType}: ${sender}` : sourceType],
       }),
     );
 
@@ -181,7 +237,7 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
   );
 
   const handledCount = decisions.rows.filter((r) => r.auto_executed === true).length;
-  const digest = buildDigest(items, { maxTodos: 7 });
+  const digest = buildDigest(items); // maxTodos defaults to 7
 
   // Attach power-view detail (spec 14) to each surfaced todo/topic item by ref.
   for (const todo of digest.todos) {

--- a/apps/api/src/services/live-digest.ts
+++ b/apps/api/src/services/live-digest.ts
@@ -1,0 +1,197 @@
+/**
+ * Live digest: compute the structured to-do/FYI digest (spec 01/04) directly
+ * from the user's recent decisions, so the briefing page renders real parity
+ * even before the worker's structured-payload generation seam lands. This is
+ * the integration that makes the digest VISIBLE end-to-end.
+ *
+ *   decisions (+ outcomes + connected accounts)
+ *     -> SignalText (spec 07) -> DigestItem[]
+ *     -> buildDigest()  -> { todos, topics, coverage, handledCount }
+ *
+ * The digest TEXT comes from the underlying RawSignal via toSignalText (spec
+ * 07) — the same source-agnostic accessor the extractors use — not the generic
+ * rule-based decision summary. That gives real, human titles ("Account notice",
+ * "Trial ending soon", a calendar event title, a voice-note transcript line)
+ * across every source instead of "Email triage needed for an email from gmail".
+ */
+
+import { query } from '@skytwin/db';
+import {
+  buildDigest,
+  buildDigestItemDetail,
+  computeCoverage,
+  toSignalText,
+  type DigestItem,
+  type Digest,
+} from '@skytwin/decision-engine';
+
+interface DecisionDigestRow {
+  id: string;
+  raw_event: unknown;
+  summary: string | null;
+  domain: string | null;
+  urgency: string | null;
+  situation_type: string;
+  created_at: string | Date;
+  requires_approval: boolean | null;
+  auto_executed: boolean | null;
+  escalation_reason: string | null;
+}
+
+interface AccountRow {
+  provider: string;
+  scopes: string[] | null;
+  is_active: boolean;
+}
+
+/** Map a RawSignal source channel to the digest's source-type label. */
+export function sourceLabel(source: string): string {
+  switch (source) {
+    case 'gmail':
+    case 'email':
+      return 'email';
+    case 'google_calendar':
+    case 'calendar':
+      return 'calendar';
+    case 'filesystem':
+      return 'file';
+    case 'voice':
+      return 'voice';
+    default:
+      return source || 'app';
+  }
+}
+
+const VALID_URGENCY = new Set(['low', 'medium', 'high', 'critical']);
+
+/**
+ * A decision belongs in the TO-DO bucket (needs you) when the engine escalated
+ * it for approval, OR it is escalate-only by nature (a security alert, spec 06),
+ * OR a new calendar invite awaiting your RSVP, OR high/critical urgency.
+ * Everything else is awareness-only (FYI). Derived purely from real decision
+ * attributes — no hand-tuning per item.
+ */
+export function needsYou(row: {
+  requires_approval: boolean | null;
+  situation_type: string;
+  urgency: string | null;
+}): boolean {
+  if (row.requires_approval === true) return true;
+  if (row.situation_type === 'security_alert') return true; // escalate-only (spec 06)
+  if (row.situation_type === 'calendar_invite') return true; // needs an RSVP
+  return row.urgency === 'high' || row.urgency === 'critical';
+}
+
+export interface LiveDigest extends Digest {
+  handledCount: number;
+}
+
+/**
+ * Build the structured digest for a user from their recent decisions. Returns
+ * null when the user has no decisions (caller falls back to prose / empty).
+ */
+export async function buildLiveDigest(userId: string): Promise<LiveDigest | null> {
+  const decisions = await query<DecisionDigestRow>(
+    `SELECT d.id,
+            d.raw_event,
+            (d.interpreted_situation->>'summary') AS summary,
+            d.domain, d.urgency, d.situation_type, d.created_at,
+            o.requires_approval, o.auto_executed, o.escalation_reason
+     FROM decisions d
+     LEFT JOIN decision_outcomes o ON o.decision_id = d.id
+     WHERE d.user_id = $1
+     ORDER BY d.created_at DESC
+     LIMIT 30`,
+    [userId],
+  );
+  if (decisions.rows.length === 0) return null;
+
+  // Power-view detail (spec 14) is attached to each todo/topic by ref AFTER
+  // buildDigest (the generator's job — buildDigest itself leaves it unset).
+  const detailByRef = new Map<string, ReturnType<typeof buildDigestItemDetail>>();
+
+  const items: DigestItem[] = decisions.rows.map((r) => {
+    // Reconstruct the RawSignal the decision was made from and read its text
+    // through the spec-07 accessor (source-agnostic title/body/source).
+    const raw = (r.raw_event ?? {}) as {
+      source?: unknown;
+      type?: unknown;
+      data?: unknown;
+    };
+    const signalText = toSignalText({
+      id: r.id,
+      source: typeof raw.source === 'string' ? raw.source : 'unknown',
+      type: typeof raw.type === 'string' ? raw.type : 'unknown',
+      data:
+        raw.data && typeof raw.data === 'object'
+          ? (raw.data as Record<string, unknown>)
+          : {},
+      timestamp: r.created_at instanceof Date ? r.created_at : new Date(r.created_at),
+    });
+    const text =
+      signalText.title.trim() ||
+      signalText.body.trim() ||
+      r.summary ||
+      `${r.situation_type.replace(/_/g, ' ')} needs review`;
+
+    const actionRequired = needsYou(r);
+    const urgency = (r.urgency && VALID_URGENCY.has(r.urgency)
+      ? r.urgency
+      : 'low') as DigestItem['urgency'];
+    const blockedReasons = actionRequired
+      ? [r.escalation_reason ?? 'trust_tier:observer']
+      : [];
+
+    const sourceType = sourceLabel(signalText.source);
+    detailByRef.set(
+      r.id,
+      buildDigestItemDetail({
+        // Inbound/ingested content the user did not author is untrusted-origin
+        // (safety #8); user-authored signals (spec 07) are trusted context.
+        provenance: signalText.authoredByUser ? 'user_originated' : 'untrusted_external',
+        domain: r.domain,
+        requiresApproval: actionRequired,
+        blockedReasons,
+        explanation: r.summary,
+        sourceRefs: [`${sourceType}:${r.id.slice(0, 8)}`],
+      }),
+    );
+
+    return {
+      ref: r.id,
+      text,
+      actionRequired,
+      domain: r.domain,
+      sourceType,
+      urgency,
+    };
+  });
+
+  // Coverage for the power-view panel, from the user's connected accounts.
+  const accounts = await query<AccountRow>(
+    `SELECT provider, scopes, is_active FROM connected_accounts WHERE user_id = $1`,
+    [userId],
+  );
+  const coverage = computeCoverage(
+    accounts.rows.map((a) => ({
+      provider: a.provider,
+      scopes: a.scopes ?? [],
+      isActive: a.is_active,
+    })),
+  );
+
+  const handledCount = decisions.rows.filter((r) => r.auto_executed === true).length;
+  const digest = buildDigest(items, { maxTodos: 7 });
+
+  // Attach power-view detail (spec 14) to each surfaced todo/topic item by ref.
+  for (const todo of digest.todos) {
+    todo.detail = detailByRef.get(todo.ref);
+  }
+  for (const topic of digest.topics) {
+    for (const item of topic.items) {
+      item.detail = detailByRef.get(item.ref);
+    }
+  }
+
+  return { ...digest, coverage, handledCount };
+}

--- a/apps/api/src/services/live-digest.ts
+++ b/apps/api/src/services/live-digest.ts
@@ -105,24 +105,53 @@ export function urgencyReasonFor(row: {
 }
 
 /**
- * The twin's recommended next step for an item — the actual action the user
- * (or twin) would take, not a system label. Prefers the pipeline's selected
- * candidate-action description; falls back to a sensible default for the
- * situations that are escalate-only by nature.
+ * The twin's recommended next step for an item — phrased for the user, not the
+ * system. Driven by the pipeline's selected action TYPE (structured and
+ * reliable) mapped to a plain-English instruction, so every item gets a clean
+ * suggestion instead of the engine's raw internal text ("Apply appropriate
+ * labels to this email", "Escalate to user: Decision needed regarding: …").
  */
+const ACTION_SUGGESTIONS: Record<string, string> = {
+  accept_invite: 'Accept the invite, or decline / propose another time.',
+  tentative_accept: 'Tentatively accept, or decide later.',
+  decline_invite: 'Decline this invite.',
+  respond_to_event: 'Reply to the invite — accept, decline, or propose a time.',
+  archive_email: "Nothing needed — I'll archive it.",
+  label_email: "Nothing needed — I'll file it for you.",
+  draft_email: 'Review the draft reply I prepared.',
+  send_email: 'Review and send when you’re ready.',
+  acknowledge: 'Just an update — no reply needed.',
+  dismiss: 'Dismiss it once you’ve seen it.',
+  organize_file: "I'll file it where it belongs.",
+  summarize_document: 'Open it, or ask me for a summary.',
+  share_document: 'Share it with the right people.',
+  create_note: 'Saved as a note — open it when you need it.',
+  escalate_to_user: 'Take a look and tell me what to do.',
+};
+
 export function suggestedActionFor(row: {
-  selected_action_desc: string | null;
+  selected_action_type: string | null;
   situation_type: string;
 }): string | null {
-  const desc = row.selected_action_desc?.trim();
-  if (desc) return desc;
+  // Security alerts get a specific, safe instruction regardless of the engine's
+  // generic escalate action.
+  if (row.situation_type === 'security_alert') {
+    return "Open your account's security settings and confirm this sign-in — don't use links in the message.";
+  }
+  const byType = row.selected_action_type
+    ? ACTION_SUGGESTIONS[row.selected_action_type]
+    : undefined;
+  if (byType) return byType;
+  // No selected action: fall back on the situation.
   switch (row.situation_type) {
-    case 'security_alert':
-      return 'Open your account security settings and confirm this sign-in';
     case 'calendar_invite':
-      return 'Reply to the invite — accept, decline, or propose a new time';
+      return 'Reply to the invite — accept, decline, or propose a time.';
+    case 'calendar_update':
+      return 'Just an update — no reply needed.';
+    case 'document_management':
+      return "I'll file it; open it if you want to review.";
     default:
-      return null;
+      return 'Take a look and decide what to do.';
   }
 }
 

--- a/apps/api/src/services/live-digest.ts
+++ b/apps/api/src/services/live-digest.ts
@@ -94,13 +94,13 @@ export function urgencyReasonFor(row: {
   if (row.situation_type === 'calendar_invite') return 'New invite — awaiting your RSVP';
   switch (normalizeUrgency(row.urgency)) {
     case 'critical':
-      return 'Critical — flagged for immediate attention';
+      return 'Urgent — needs your attention now';
     case 'high':
-      return 'High urgency';
+      return 'Time-sensitive — worth a look soon';
     case 'medium':
-      return 'Normal priority';
+      return 'Not time-sensitive — just so you’re aware';
     default:
-      return 'Routine — no deadline detected';
+      return 'Routine — nothing time-sensitive, just keeping you in the loop';
   }
 }
 
@@ -283,6 +283,12 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
         domain: r.domain,
         urgencyReason: urgencyReasonFor(r),
         suggestedAction: suggestedActionFor(r) ?? undefined,
+        occurredAt:
+          r.created_at instanceof Date
+            ? r.created_at.toISOString()
+            : r.created_at
+              ? String(r.created_at)
+              : undefined,
         requiresApproval: actionRequired,
         blockedReasons,
         sourceRefs: [sender ?? SOURCE_FRIENDLY[sourceType] ?? sourceType],

--- a/apps/api/src/services/live-digest.ts
+++ b/apps/api/src/services/live-digest.ts
@@ -40,6 +40,8 @@ interface DecisionDigestRow {
   auto_executed: boolean | null;
   escalation_reason: string | null;
   confidence: number | null;
+  selected_action_desc: string | null;
+  selected_action_type: string | null;
 }
 
 interface AccountRow {
@@ -102,6 +104,28 @@ export function urgencyReasonFor(row: {
   }
 }
 
+/**
+ * The twin's recommended next step for an item — the actual action the user
+ * (or twin) would take, not a system label. Prefers the pipeline's selected
+ * candidate-action description; falls back to a sensible default for the
+ * situations that are escalate-only by nature.
+ */
+export function suggestedActionFor(row: {
+  selected_action_desc: string | null;
+  situation_type: string;
+}): string | null {
+  const desc = row.selected_action_desc?.trim();
+  if (desc) return desc;
+  switch (row.situation_type) {
+    case 'security_alert':
+      return 'Open your account security settings and confirm this sign-in';
+    case 'calendar_invite':
+      return 'Reply to the invite — accept, decline, or propose a new time';
+    default:
+      return null;
+  }
+}
+
 /** First non-empty string field from a signal's data payload. */
 function senderRef(data: Record<string, unknown>): string | null {
   for (const key of ['from', 'organizer', 'fileName', 'path']) {
@@ -143,9 +167,12 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
             d.raw_event,
             (d.interpreted_situation->>'summary') AS summary,
             d.domain, d.urgency, d.situation_type, d.created_at,
-            o.requires_approval, o.auto_executed, o.escalation_reason, o.confidence
+            o.requires_approval, o.auto_executed, o.escalation_reason, o.confidence,
+            sel.description AS selected_action_desc,
+            sel.action_type AS selected_action_type
      FROM decisions d
      LEFT JOIN decision_outcomes o ON o.decision_id = d.id
+     LEFT JOIN candidate_actions sel ON sel.id = o.selected_action_id
      WHERE d.user_id = $1
      ORDER BY d.created_at DESC
      LIMIT $2`,
@@ -181,6 +208,16 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
       signalText.body.trim() ||
       r.summary ||
       `${r.situation_type.replace(/_/g, ' ')} needs review`;
+    // The real content (what it actually says) — only when distinct from the
+    // title, so we don't echo the same line twice. Capped to keep the digest
+    // scannable.
+    const bodyText = signalText.body.trim();
+    const body =
+      bodyText && bodyText !== text
+        ? bodyText.length > 200
+          ? `${bodyText.slice(0, 199)}…`
+          : bodyText
+        : undefined;
 
     const actionRequired = needsYou(r);
     const urgency = normalizeUrgency(r.urgency);
@@ -207,6 +244,7 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
         confidence: typeof r.confidence === 'number' ? r.confidence : undefined,
         domain: r.domain,
         urgencyReason: urgencyReasonFor(r),
+        suggestedAction: suggestedActionFor(r) ?? undefined,
         requiresApproval: actionRequired,
         blockedReasons,
         sourceRefs: [sender ? `${sourceType}: ${sender}` : sourceType],
@@ -216,6 +254,7 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
     return {
       ref: r.id,
       text,
+      body,
       actionRequired,
       domain: r.domain,
       sourceType,

--- a/apps/api/src/services/live-digest.ts
+++ b/apps/api/src/services/live-digest.ts
@@ -155,14 +155,23 @@ export function suggestedActionFor(row: {
   }
 }
 
-/** First non-empty string field from a signal's data payload. */
+/** The actual sender of a signal (email from / event organizer), if any. */
 function senderRef(data: Record<string, unknown>): string | null {
-  for (const key of ['from', 'organizer', 'fileName', 'path']) {
+  for (const key of ['from', 'organizer']) {
     const v = data[key];
     if (typeof v === 'string' && v.trim()) return v.trim();
   }
   return null;
 }
+
+/** Friendly "where it's from" when there's no concrete sender. */
+const SOURCE_FRIENDLY: Record<string, string> = {
+  email: 'your inbox',
+  calendar: 'your calendar',
+  file: 'your files',
+  voice: 'a voice note',
+  app: 'an app',
+};
 
 /**
  * A decision belongs in the TO-DO bucket (needs you) when the engine escalated
@@ -276,7 +285,7 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
         suggestedAction: suggestedActionFor(r) ?? undefined,
         requiresApproval: actionRequired,
         blockedReasons,
-        sourceRefs: [sender ? `${sourceType}: ${sender}` : sourceType],
+        sourceRefs: [sender ?? SOURCE_FRIENDLY[sourceType] ?? sourceType],
       }),
     );
 

--- a/apps/web/public/css/styles.css
+++ b/apps/web/public/css/styles.css
@@ -1237,76 +1237,121 @@ textarea.form-input { resize: vertical; min-height: 60px; }
   .skeleton-pulse { animation: none; opacity: 0.55; }
 }
 
-/* ── Digest (spec 08, #481): two-bucket source-aware cited view ───────────── */
-.digest { margin-bottom: 1.25rem; }
-.digest-heading {
-  font-size: 0.95rem; font-weight: 600; margin: 1rem 0 0.5rem;
-  color: var(--text); border-bottom: 1px solid var(--border); padding-bottom: 0.25rem;
+/* ── Digest design system (DESIGN.md) ───────────────────────────────────────
+   Calm command center. Iris is the SINGLE accent = "needs you / act".
+   Action zone (to-dos) vs awareness zone (topics). Every state designed. */
+:root {
+  --iris: #7C72E8; --iris-hover: #9A92F2; --iris-soft: rgba(124,114,232,.16);
+  --safe: #46C08A;
+  --font-voice: 'Fraunces', Georgia, serif;
+  --font-ui: 'Geist', system-ui, sans-serif;
+  --font-data: 'Geist Mono', ui-monospace, monospace;
 }
-.digest-todos { list-style: none; padding: 0; margin: 0 0 0.5rem; }
-.digest-todo, .digest-topic-item {
-  display: flex; align-items: center; flex-wrap: wrap; gap: 0.4rem;
-  padding: 0.4rem 0; border-bottom: 1px solid var(--border-soft, var(--border));
-}
-.digest-todo-text { font-weight: 500; }
-.digest-deadline {
-  font-size: 0.72rem; color: var(--warning, #b45309);
-  background: var(--warning-soft, rgba(180,83,9,0.1)); padding: 0.1rem 0.4rem; border-radius: var(--radius-sm);
-}
-.digest-topic { margin-bottom: 0.75rem; }
-.digest-topic-title { font-size: 0.85rem; font-weight: 600; color: var(--text-muted); margin: 0.5rem 0 0.25rem; }
+.digest { max-width: 680px; font-family: var(--font-ui); margin-bottom: 1.25rem; }
+
+/* Twin voice + value line (the twin earned its keep) */
+.digest-voice { font-family: var(--font-voice); font-weight: 500; font-size: 1.5rem;
+  line-height: 1.3; letter-spacing: -0.01em; margin: 0 0 0.5rem; color: var(--text); }
+.digest-value { display: flex; flex-wrap: wrap; gap: 0.85rem; align-items: center;
+  color: var(--text-muted); font-size: 0.8rem; margin: 0 0 1.4rem; }
+.digest-value b { color: var(--text); font-weight: 600; }
+.digest-value .done { color: var(--safe); }
+.digest-value .sep { width: 1px; height: 0.8rem; background: var(--border); }
+
+.digest-heading { display: flex; align-items: center; gap: 0.4rem; font-family: var(--font-ui);
+  font-size: 0.72rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--text-muted); margin: 1.1rem 0 0.4rem; }
+.digest-heading .count { color: var(--text-dim); font-weight: 500; }
+
+.digest-toolbar { display: flex; justify-content: flex-end; margin-bottom: 0.25rem; }
+.digest-power-toggle { font-size: 0.75rem; color: var(--iris); background: var(--iris-soft);
+  border: 1px solid transparent; padding: 0.25rem 0.6rem; border-radius: var(--radius-sm); cursor: pointer; }
+
+/* ACTION zone: to-dos */
+.digest-todos { list-style: none; padding: 0; margin: 0; }
+.digest-todo { display: flex; align-items: flex-start; gap: 0.7rem; padding: 0.8rem 0.7rem;
+  position: relative; border-radius: var(--radius); }
+.digest-todo + .digest-todo { border-top: 1px solid var(--border); }
+.digest-todo::before { content: ""; position: absolute; left: 0; top: 0.6rem; bottom: 0.6rem;
+  width: 2px; border-radius: 2px; background: var(--iris); opacity: .85; }
+.digest-todo.is-security::before { background: var(--danger); }
+.digest-check { width: 17px; height: 17px; border: 1.5px solid var(--text-dim); border-radius: 5px;
+  flex: none; margin-top: 1px; cursor: pointer; background: none; transition: .15s; }
+.digest-check.is-on { background: var(--iris); border-color: var(--iris); }
+.digest-prov { width: 6px; height: 6px; border-radius: 50%; flex: none; margin-top: 6px; }
+.digest-prov.you { background: var(--text-muted); }
+.digest-prov.inbound { border: 1px solid var(--text-dim); }
+.digest-todo-body { flex: 1; min-width: 0; }
+.digest-todo-text { font-size: 0.95rem; font-weight: 450; color: var(--text); }
+.digest-todo-hint { font-size: 0.72rem; color: var(--text-dim); margin-top: 0.15rem; }
+.digest-deadline { font-size: 0.7rem; font-weight: 500; color: var(--iris); background: var(--iris-soft);
+  padding: 0.1rem 0.5rem; border-radius: 999px; margin-left: 0.4rem; white-space: nowrap; }
+.digest-deadline.is-overdue { color: var(--danger); background: var(--danger-soft); }
+/* Source mark — one small neutral glyph + label, not a chip row */
+.digest-source { font-size: 0.66rem; color: var(--text-dim); margin-left: 0.4rem; white-space: nowrap; }
+/* Single citation affordance (in-app, never external URL) */
+.digest-cite { font-family: var(--font-data); font-size: 0.68rem; color: var(--text-dim);
+  background: none; border: none; cursor: pointer; padding: 0; margin-left: 0.4rem; }
+.digest-cite:hover { color: var(--text); }
+/* Inline actions — reveal on hover/focus (calm at rest); always-on for touch */
+.digest-actions { display: flex; gap: 0.35rem; flex: none; opacity: 0; transition: opacity .12s; }
+.digest-todo:hover .digest-actions, .digest-todo:focus-within .digest-actions { opacity: 1; }
+@media (hover: none) { .digest-actions { opacity: 1; } }
+/* Security is important enough to never hide its action behind a hover. */
+.digest-todo.is-security .digest-actions { opacity: 1; }
+.digest-act { font-size: 0.75rem; color: var(--text-muted); border: 1px solid var(--border);
+  background: transparent; padding: 0.25rem 0.6rem; border-radius: var(--radius-sm); cursor: pointer; }
+.digest-act:hover { border-color: var(--text-dim); color: var(--text); }
+.digest-act.primary { color: #fff; background: var(--iris); border-color: var(--iris); }
+.digest-todo.is-security .digest-act.primary { background: var(--danger); border-color: var(--danger); }
+.digest-act.grant { color: var(--iris); border-color: var(--iris); }
+
+/* AWARENESS zone: topics (lighter, no edge, no checkbox) */
+.digest-topic { margin-top: 0.4rem; }
+.digest-topic-title { font-size: 0.74rem; font-weight: 600; color: var(--text-muted); margin: 0.8rem 0 0.1rem; }
 .digest-topic ul { list-style: none; padding: 0; margin: 0; }
-/* Source chip — text label, not icon-only (a11y). */
-.source-chip {
-  font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.03em;
-  padding: 0.1rem 0.4rem; border-radius: var(--radius-sm);
-  background: var(--bg-soft, rgba(127,127,127,0.12)); color: var(--text-muted);
-  border: 1px solid var(--border);
-}
-.source-chip-email { background: var(--info-soft, rgba(37,99,235,0.12)); }
-.source-chip-calendar { background: var(--success-soft, rgba(22,163,74,0.12)); }
-.source-chip-voice { background: var(--accent-soft, rgba(147,51,234,0.12)); }
-/* Citation chip — in-app link, never an external URL. */
-.citation-chip {
-  font-size: 0.68rem; padding: 0.1rem 0.45rem; border-radius: var(--radius-sm);
-  background: transparent; color: var(--primary, #2563eb);
-  border: 1px dashed var(--border); cursor: pointer;
-}
-.citation-chip:hover { background: var(--bg-soft, rgba(127,127,127,0.1)); }
+.digest-topic-item { display: flex; align-items: baseline; gap: 0.5rem; padding: 0.45rem 0.7rem;
+  font-size: 0.85rem; color: var(--text); font-weight: 400; }
+.digest-topic-item + .digest-topic-item { border-top: 1px solid var(--border); }
 
-/* Digest: long-form prose tucked under a disclosure when the structured view renders. */
-.briefing-prose-details { margin-top: 1rem; }
-.briefing-prose-details > summary {
-  cursor: pointer; font-size: 0.82rem; padding: 0.3rem 0;
-  list-style: revert;
-}
-.briefing-prose-details[open] > summary { margin-bottom: 0.5rem; }
-
-/* ── Power view (spec 14): inline technical depth, discoverable not buried ──── */
-.digest-toolbar { display: flex; justify-content: flex-end; margin-bottom: 0.5rem; }
-.digest-detail-toggle {
-  font-size: 0.68rem; background: none; border: none; color: var(--primary, #2563eb);
-  cursor: pointer; padding: 0; margin-left: 0.25rem;
-}
-.digest-detail {
-  display: none; width: 100%; margin: 0.3rem 0 0.2rem; padding: 0.4rem 0.6rem;
-  background: var(--bg-soft, rgba(127,127,127,0.08)); border-radius: var(--radius-sm);
-  font-size: 0.74rem; color: var(--text-muted);
-}
-.digest-detail > div { padding: 0.1rem 0; }
-.digest-detail .dd-k {
-  display: inline-block; min-width: 6rem; color: var(--text-dim);
-  text-transform: uppercase; font-size: 0.62rem; letter-spacing: 0.03em;
-}
-.digest-detail code { font-size: 0.72rem; }
-/* Show detail when the row is toggled open OR power view is on. */
-.digest-item.detail-open .digest-detail,
+/* Power-view detail panel */
+.digest-detail { display: none; width: 100%; margin: 0.4rem 0 0.1rem; padding: 0.5rem 0.7rem;
+  background: var(--bg-hover); border-radius: var(--radius-sm); font-size: 0.76rem; color: var(--text-muted); }
+.digest-detail > div { display: flex; gap: 0.6rem; padding: 0.1rem 0; }
+.digest-detail .dd-k { min-width: 6rem; color: var(--text-dim); text-transform: uppercase;
+  font-size: 0.62rem; letter-spacing: .04em; }
+.digest-detail code { font-family: var(--font-data); font-size: 0.72rem; }
+.digest-detail-toggle { font-size: 0.7rem; background: none; border: none; color: var(--iris);
+  cursor: pointer; padding: 0; margin-left: 0.4rem; }
+.digest-todo.detail-open .digest-detail, .digest-topic-item.detail-open .digest-detail,
 .digest--power .digest-detail { display: block; }
-/* In power view everything is expanded, so hide the per-row toggles. */
 .digest--power .digest-detail-toggle { display: none; }
-.digest-coverage { margin-top: 1rem; border-top: 1px solid var(--border); padding-top: 0.75rem; }
-.digest-coverage-list { list-style: none; padding: 0; margin: 0; font-size: 0.78rem; }
-.digest-coverage-list li { padding: 0.15rem 0; }
-.cov-available { color: var(--success, #16a34a); font-weight: 600; }
-.cov-partial { color: var(--warning, #b45309); font-weight: 600; }
-.cov-unavailable { color: var(--text-dim); font-weight: 600; }
+
+/* Coverage panel */
+.digest-coverage { margin-top: 1.1rem; border-top: 1px solid var(--border); padding-top: 0.8rem; }
+.digest-coverage-list { list-style: none; padding: 0; margin: 0; font-size: 0.8rem; }
+.digest-coverage-list li { padding: 0.18rem 0; display: flex; gap: 0.5rem; align-items: baseline; }
+.cov-dot { width: 7px; height: 7px; border-radius: 50%; flex: none; position: relative; top: 2px; }
+.cov-dot.cov-available { background: var(--safe); }
+.cov-dot.cov-partial { background: var(--warning); }
+.cov-dot.cov-unavailable { background: var(--text-dim); }
+
+/* Prose fallback under a disclosure */
+.briefing-prose-details { margin-top: 1rem; }
+.briefing-prose-details > summary { cursor: pointer; font-size: 0.82rem; color: var(--text-muted);
+  padding: 0.3rem 0; list-style: revert; }
+
+/* ── Gap states (DESIGN.md: design them, don't fall through) ─────────────── */
+.digest-skel { max-width: 680px; }
+.digest-skel .sk { height: 1rem; border-radius: 6px; margin: 0.7rem 0;
+  background: linear-gradient(90deg, var(--bg-card) 25%, var(--bg-hover) 37%, var(--bg-card) 63%);
+  background-size: 400% 100%; animation: digestShimmer 1.3s ease infinite; }
+.digest-skel .sk.voice { height: 1.6rem; width: 60%; }
+.digest-skel .sk.row { width: 90%; }
+@keyframes digestShimmer { 0% { background-position: 100% 0; } 100% { background-position: 0 0; } }
+@media (prefers-reduced-motion: reduce) { .digest-skel .sk { animation: none; opacity: .6; } }
+.digest-state { max-width: 680px; text-align: center; padding: 2.2rem 1.5rem; color: var(--text-muted); }
+.digest-state .digest-voice { text-align: center; }
+.digest-state .sub { font-size: 0.9rem; color: var(--text-muted); margin: 0.3rem 0 1rem; }
+.digest-coldstart-sources { display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; }
+.digest-coldstart-sources .digest-act.primary { text-decoration: none; }

--- a/apps/web/public/css/styles.css
+++ b/apps/web/public/css/styles.css
@@ -1321,6 +1321,16 @@ textarea.form-input { resize: vertical; min-height: 60px; }
 .digest-detail .dd-k { min-width: 6rem; color: var(--text-dim); text-transform: uppercase;
   font-size: 0.62rem; letter-spacing: .04em; }
 .digest-detail code { font-family: var(--font-data); font-size: 0.72rem; }
+/* The actionable "suggested next step" leads the detail panel — slightly
+   brighter than the trust metadata around it. */
+.digest-detail .dd-suggested { color: var(--text); }
+.digest-detail .dd-suggested .dd-k { color: var(--iris); }
+/* One-line preview of what the signal actually says, under the title. */
+.digest-body { font-size: 0.8rem; color: var(--text-muted); line-height: 1.45;
+  margin-top: 0.15rem; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical; }
+/* Home digest: the recommended next step, action-toned (iris). */
+.digest-suggested { font-size: 0.78rem; color: var(--iris); margin-top: 0.2rem; font-weight: 500; }
 .digest-detail-toggle { font-size: 0.7rem; background: none; border: none; color: var(--iris);
   cursor: pointer; padding: 0; margin-left: 0.4rem; }
 .digest-todo.detail-open .digest-detail, .digest-topic-item.detail-open .digest-detail,

--- a/apps/web/public/css/styles.css
+++ b/apps/web/public/css/styles.css
@@ -1236,3 +1236,40 @@ textarea.form-input { resize: vertical; min-height: 60px; }
 @media (prefers-reduced-motion: reduce) {
   .skeleton-pulse { animation: none; opacity: 0.55; }
 }
+
+/* ── Digest (spec 08, #481): two-bucket source-aware cited view ───────────── */
+.digest { margin-bottom: 1.25rem; }
+.digest-heading {
+  font-size: 0.95rem; font-weight: 600; margin: 1rem 0 0.5rem;
+  color: var(--text); border-bottom: 1px solid var(--border); padding-bottom: 0.25rem;
+}
+.digest-todos { list-style: none; padding: 0; margin: 0 0 0.5rem; }
+.digest-todo, .digest-topic-item {
+  display: flex; align-items: center; flex-wrap: wrap; gap: 0.4rem;
+  padding: 0.4rem 0; border-bottom: 1px solid var(--border-soft, var(--border));
+}
+.digest-todo-text { font-weight: 500; }
+.digest-deadline {
+  font-size: 0.72rem; color: var(--warning, #b45309);
+  background: var(--warning-soft, rgba(180,83,9,0.1)); padding: 0.1rem 0.4rem; border-radius: var(--radius-sm);
+}
+.digest-topic { margin-bottom: 0.75rem; }
+.digest-topic-title { font-size: 0.85rem; font-weight: 600; color: var(--text-muted); margin: 0.5rem 0 0.25rem; }
+.digest-topic ul { list-style: none; padding: 0; margin: 0; }
+/* Source chip — text label, not icon-only (a11y). */
+.source-chip {
+  font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.03em;
+  padding: 0.1rem 0.4rem; border-radius: var(--radius-sm);
+  background: var(--bg-soft, rgba(127,127,127,0.12)); color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+.source-chip-email { background: var(--info-soft, rgba(37,99,235,0.12)); }
+.source-chip-calendar { background: var(--success-soft, rgba(22,163,74,0.12)); }
+.source-chip-voice { background: var(--accent-soft, rgba(147,51,234,0.12)); }
+/* Citation chip — in-app link, never an external URL. */
+.citation-chip {
+  font-size: 0.68rem; padding: 0.1rem 0.45rem; border-radius: var(--radius-sm);
+  background: transparent; color: var(--primary, #2563eb);
+  border: 1px dashed var(--border); cursor: pointer;
+}
+.citation-chip:hover { background: var(--bg-soft, rgba(127,127,127,0.1)); }

--- a/apps/web/public/css/styles.css
+++ b/apps/web/public/css/styles.css
@@ -1281,3 +1281,32 @@ textarea.form-input { resize: vertical; min-height: 60px; }
   list-style: revert;
 }
 .briefing-prose-details[open] > summary { margin-bottom: 0.5rem; }
+
+/* ── Power view (spec 14): inline technical depth, discoverable not buried ──── */
+.digest-toolbar { display: flex; justify-content: flex-end; margin-bottom: 0.5rem; }
+.digest-detail-toggle {
+  font-size: 0.68rem; background: none; border: none; color: var(--primary, #2563eb);
+  cursor: pointer; padding: 0; margin-left: 0.25rem;
+}
+.digest-detail {
+  display: none; width: 100%; margin: 0.3rem 0 0.2rem; padding: 0.4rem 0.6rem;
+  background: var(--bg-soft, rgba(127,127,127,0.08)); border-radius: var(--radius-sm);
+  font-size: 0.74rem; color: var(--text-muted);
+}
+.digest-detail > div { padding: 0.1rem 0; }
+.digest-detail .dd-k {
+  display: inline-block; min-width: 6rem; color: var(--text-dim);
+  text-transform: uppercase; font-size: 0.62rem; letter-spacing: 0.03em;
+}
+.digest-detail code { font-size: 0.72rem; }
+/* Show detail when the row is toggled open OR power view is on. */
+.digest-item.detail-open .digest-detail,
+.digest--power .digest-detail { display: block; }
+/* In power view everything is expanded, so hide the per-row toggles. */
+.digest--power .digest-detail-toggle { display: none; }
+.digest-coverage { margin-top: 1rem; border-top: 1px solid var(--border); padding-top: 0.75rem; }
+.digest-coverage-list { list-style: none; padding: 0; margin: 0; font-size: 0.78rem; }
+.digest-coverage-list li { padding: 0.15rem 0; }
+.cov-available { color: var(--success, #16a34a); font-weight: 600; }
+.cov-partial { color: var(--warning, #b45309); font-weight: 600; }
+.cov-unavailable { color: var(--text-dim); font-weight: 600; }

--- a/apps/web/public/css/styles.css
+++ b/apps/web/public/css/styles.css
@@ -1273,3 +1273,11 @@ textarea.form-input { resize: vertical; min-height: 60px; }
   border: 1px dashed var(--border); cursor: pointer;
 }
 .citation-chip:hover { background: var(--bg-soft, rgba(127,127,127,0.1)); }
+
+/* Digest: long-form prose tucked under a disclosure when the structured view renders. */
+.briefing-prose-details { margin-top: 1rem; }
+.briefing-prose-details > summary {
+  cursor: pointer; font-size: 0.82rem; padding: 0.3rem 0;
+  list-style: revert;
+}
+.briefing-prose-details[open] > summary { margin-bottom: 0.5rem; }

--- a/apps/web/public/css/styles.css
+++ b/apps/web/public/css/styles.css
@@ -1321,15 +1321,12 @@ textarea.form-input { resize: vertical; min-height: 60px; }
 .digest-detail .dd-k { min-width: 6rem; color: var(--text-dim); text-transform: uppercase;
   font-size: 0.62rem; letter-spacing: .04em; }
 .digest-detail code { font-family: var(--font-data); font-size: 0.72rem; }
-/* The actionable "suggested next step" leads the detail panel — slightly
-   brighter than the trust metadata around it. */
-.digest-detail .dd-suggested { color: var(--text); }
-.digest-detail .dd-suggested .dd-k { color: var(--iris); }
 /* One-line preview of what the signal actually says, under the title. */
 .digest-body { font-size: 0.8rem; color: var(--text-muted); line-height: 1.45;
   margin-top: 0.15rem; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2;
   -webkit-box-orient: vertical; }
-/* Home digest: the recommended next step, action-toned (iris). */
+/* The recommended next step — action-toned (iris), shown in the row for every
+   item (to-do and topic) so the digest is actionable without the power view. */
 .digest-suggested { font-size: 0.78rem; color: var(--iris); margin-top: 0.2rem; font-weight: 500; }
 .digest-detail-toggle { font-size: 0.7rem; background: none; border: none; color: var(--iris);
   cursor: pointer; padding: 0; margin-left: 0.4rem; }

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -39,6 +39,7 @@
     </button>
     <ul class="nav-links" id="nav-links">
       <li><a href="#/" class="nav-link active" data-page="dashboard">Home</a></li>
+      <li><a href="#/briefing" class="nav-link" data-page="briefing">Briefing</a></li>
       <li><a href="#/assistant" class="nav-link" data-page="assistant">Chat</a></li>
       <li><a href="#/approvals" class="nav-link" data-page="approvals">
         Needs your OK

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SkyTwin — Your Personal AI Assistant</title>
+  <!-- Design system fonts (DESIGN.md): Fraunces = twin voice, Geist = UI, Geist Mono = data/refs -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500&family=Geist:wght@400;450;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
   <link rel="icon" id="favicon" type="image/svg+xml" href='data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="15" fill="%231976d2"/><text x="16" y="22" font-family="-apple-system,system-ui,sans-serif" font-size="18" font-weight="700" text-anchor="middle" fill="white">S</text></svg>'>
   <link rel="stylesheet" href="/css/styles.css">
   <link rel="stylesheet" href="/css/themes.css">

--- a/apps/web/public/js/app.js
+++ b/apps/web/public/js/app.js
@@ -853,7 +853,7 @@ function wireDxtDropAndOpen() {
   }
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('DOMContentLoaded', async () => {
   // Apply saved a11y preferences (text scale, reduced motion, voice-first)
   // before any render so users with prefs don't see a flash of base UI.
   initA11y();

--- a/apps/web/public/js/app.js
+++ b/apps/web/public/js/app.js
@@ -45,7 +45,7 @@ const routes = {
   '/capabilities': { title: 'Capabilities', render: renderCapabilities },
   '/capabilities/audit': { title: 'Capability Audit Trail', render: renderCapabilitiesAudit },
   '/about-me': { title: 'About me', render: renderAboutMe },
-  '/briefing': { title: 'Twin Briefing', render: renderTwinBriefing },
+  '/briefing': { title: 'Briefing', render: renderTwinBriefing },
   '/twin-server-tokens': { title: 'MCP Agent Tokens', render: renderTwinServerTokens },
   '/provenance': { title: 'Provenance Graph', render: renderProvenanceGraph },
   '/credential-vault': { title: 'Credential Vault', render: renderCredentialVault },

--- a/apps/web/public/js/pages/credential-vault.js
+++ b/apps/web/public/js/pages/credential-vault.js
@@ -52,7 +52,7 @@ function ensureCredentialVaultListener() {
       try {
         await fetchJSON(`/api/credential-vault/init`, {
           method: 'POST',
-          body: JSON.stringify({ passphrase }),
+          body: JSON.stringify({ passphrase, userId }),
         });
         showToast('Vault initialized and unlocked');
         const container = document.getElementById('page-content');
@@ -83,6 +83,7 @@ function ensureCredentialVaultListener() {
           body: JSON.stringify({
             currentPassphrase: current,
             newPassphrase: next,
+            userId,
           }),
         });
         showToast(
@@ -105,7 +106,7 @@ function ensureCredentialVaultListener() {
 
     if (action === 'vault-lock') {
       try {
-        await fetchJSON(`/api/credential-vault/lock`, { method: 'POST' });
+        await fetchJSON(`/api/credential-vault/lock`, { method: 'POST', body: JSON.stringify({ userId }) });
         showToast('Vault locked');
         const container = document.getElementById('page-content');
         if (container) await renderCredentialVault(container, userId);
@@ -124,7 +125,7 @@ function ensureCredentialVaultListener() {
       try {
         await fetchJSON(`/api/credential-vault/unlock`, {
           method: 'POST',
-          body: JSON.stringify({ passphrase }),
+          body: JSON.stringify({ passphrase, userId }),
         });
         showToast('Vault unlocked');
         const container = document.getElementById('page-content');

--- a/apps/web/public/js/pages/dashboard.js
+++ b/apps/web/public/js/pages/dashboard.js
@@ -209,6 +209,8 @@ function renderDashboardDigest(s, briefing) {
           ${t.deadline ? `<span class="digest-deadline">${escapeHtml(String(t.deadline))}</span>` : ''}
           ${sourceChip(t.sourceType)}
         </div>
+        ${t.body ? `<div class="digest-body">${escapeHtml(t.body)}</div>` : ''}
+        ${t.detail?.suggestedAction ? `<div class="digest-suggested">→ ${escapeHtml(t.detail.suggestedAction)}</div>` : ''}
       </div>
     </li>`).join('');
 

--- a/apps/web/public/js/pages/dashboard.js
+++ b/apps/web/public/js/pages/dashboard.js
@@ -201,7 +201,7 @@ function renderDashboardDigest(s, briefing) {
   };
 
   const todoRows = todos.map((t) => `
-    <li class="digest-todo${t.kind === 'security' ? ' is-security' : ''}">
+    <li class="digest-todo">
       ${provDot(t.detail)}
       <div class="digest-todo-body">
         <div>
@@ -545,8 +545,8 @@ export async function renderDashboard(container, userId) {
     ${sinceLastVisit && !tourMode ? renderSinceLastVisit(sinceLastVisit) : ''}
     ${showBrainPrompt ? renderBrainPrompt() : ''}
     ${renderTwinBriefingWidget(_twinBriefing)}
-    ${tourMode || hasAnyData ? '' : renderConnectGoogleHero({ googleConnected, googleSystemConfigured, userId })}
-    ${tourMode || hasAnyData ? '' : renderConnectGmailHero({ googleConnected, googleScopes: googleOAuth.status === 'fulfilled' ? (googleOAuth.value?.scopes ?? []) : [] })}
+    ${tourMode ? '' : renderConnectGoogleHero({ googleConnected, googleSystemConfigured, userId })}
+    ${tourMode ? '' : renderConnectGmailHero({ googleConnected, googleScopes: googleOAuth.status === 'fulfilled' ? (googleOAuth.value?.scopes ?? []) : [] })}
     ${renderAskTwinWidget({ userId, tourMode })}
     ${showBriefing ? renderBriefingCard({ items: briefingItems, createdAt: briefing.createdAt }) : ''}
     ${renderLifebooksCard(lifebooks)}

--- a/apps/web/public/js/pages/dashboard.js
+++ b/apps/web/public/js/pages/dashboard.js
@@ -167,18 +167,97 @@ export function invalidateDashboardCache(keyPrefix) {
   }
 }
 
+// Source-type → short label (mirror of the briefing page's SOURCE_LABELS).
+const DASH_SOURCE_LABELS = {
+  email: 'email', gmail: 'email', calendar: 'calendar', google_calendar: 'calendar',
+  filesystem: 'file', file: 'file', voice: 'voice', app: 'app',
+};
+
+/**
+ * Home digest hero (spec 01/08) — the to-do/FYI parity surface, the most
+ * important thing on the page (DESIGN.md: action zone first). This is a
+ * READ-ONLY, compact render: the fully interactive digest (snooze, power view,
+ * citations) lives on #/briefing, whose click handlers are hash-gated to that
+ * route, so Home links out to it rather than duplicating dead buttons.
+ *
+ * @param {object} s - the `structured` digest payload { todos, topics, handledCount }
+ * @param {object} briefing - the briefing envelope (for read state)
+ */
+function renderDashboardDigest(s, briefing) {
+  const todos = Array.isArray(s.todos) ? s.todos : [];
+  const topicCount = (Array.isArray(s.topics) ? s.topics : [])
+    .reduce((n, g) => n + (Array.isArray(g.items) ? g.items.length : 0), 0);
+  const handled = typeof s.handledCount === 'number' ? s.handledCount : null;
+  const need = todos.length;
+  const isUnread = !briefing.read_at;
+
+  const provDot = (detail) => {
+    const you = detail && /from you/i.test(detail.provenanceLabel || '');
+    return `<span class="digest-prov ${you ? 'you' : 'inbound'}" title="${you ? 'from you' : 'inbound'}"></span>`;
+  };
+  const sourceChip = (st) => {
+    const label = DASH_SOURCE_LABELS[st];
+    return label ? `<span class="digest-source">${escapeHtml(label)}</span>` : '';
+  };
+
+  const todoRows = todos.map((t) => `
+    <li class="digest-todo${t.kind === 'security' ? ' is-security' : ''}">
+      ${provDot(t.detail)}
+      <div class="digest-todo-body">
+        <div>
+          <span class="digest-todo-text">${escapeHtml(t.text || '')}</span>
+          ${t.deadline ? `<span class="digest-deadline">${escapeHtml(String(t.deadline))}</span>` : ''}
+          ${sourceChip(t.sourceType)}
+        </div>
+      </div>
+    </li>`).join('');
+
+  const voice = need === 0
+    ? "You're all caught up."
+    : need === 1 ? 'One thing needs you.' : `${need} things need you.`;
+
+  return `
+    <div class="card" style="border-left: 3px solid var(--accent);">
+      <div class="card-header">
+        <span class="card-title">
+          Your briefing
+          ${isUnread ? '<span class="badge badge-info" style="margin-left:0.35rem; font-size:0.7rem;">New</span>' : ''}
+        </span>
+        <a href="#/briefing" style="font-size: 0.78rem; color: var(--text-muted);">Open →</a>
+      </div>
+      <p class="digest-voice" style="font-size: 1.25rem; margin: 0.2rem 0 0.5rem;">${voice}</p>
+      <p class="digest-value">
+        ${handled !== null ? `<span class="done">✓ ${handled} handled on my own</span><span class="sep"></span>` : ''}
+        <span><b>${need}</b> need you</span><span class="sep"></span>
+        <span><b>${topicCount}</b> to catch up on</span>
+      </p>
+      ${need ? `<div class="digest-heading">To-dos <span class="count">· ${need}</span></div>
+        <ul class="digest-todos">${todoRows}</ul>` : ''}
+      <a href="#/briefing" class="btn btn-outline btn-sm" style="font-size: 0.8rem; margin-top: 0.75rem;">
+        Read full briefing →
+      </a>
+    </div>`;
+}
+
 /**
  * Twin Briefing widget for the dashboard (issue #177).
- * Shows the headline (first paragraph) of the latest daily twin briefing,
- * with a link to the full #/briefing page.
  *
- * Only renders when a briefing exists and has prose content.
- * Lightweight addition — does not refactor existing dashboard sections.
+ * Prefers the structured digest (spec 01/08) — the to-do/FYI parity surface —
+ * and falls back to the prose headline for legacy briefings that only carry
+ * prose. Returns '' when there is neither (new user; connect heroes show).
  *
  * @param {object|null} briefing - TwinBriefingRow from /api/twin-briefings/latest
  */
 function renderTwinBriefingWidget(briefing) {
-  if (!briefing || !briefing.prose_markdown) return '';
+  if (!briefing) return '';
+
+  // Structured digest takes priority — it is the product's primary surface.
+  const s = briefing.structured;
+  if (s && ((Array.isArray(s.todos) && s.todos.length) || (Array.isArray(s.topics) && s.topics.length))) {
+    return renderDashboardDigest(s, briefing);
+  }
+
+  if (!briefing.prose_markdown) return '';
 
   // Extract the first non-empty, non-heading paragraph as the headline.
   const lines = briefing.prose_markdown.split('\n');
@@ -465,11 +544,11 @@ export async function renderDashboard(container, userId) {
     ${renderJustConnectedCelebration({ justConnectedProvider, justConnectedAccount, recentDecisionsCount: recentDecisions.length, learnedCount: learn?.totalPreferences ?? 0 })}
     ${sinceLastVisit && !tourMode ? renderSinceLastVisit(sinceLastVisit) : ''}
     ${showBrainPrompt ? renderBrainPrompt() : ''}
-    ${tourMode ? '' : renderConnectGoogleHero({ googleConnected, googleSystemConfigured, userId })}
-    ${tourMode ? '' : renderConnectGmailHero({ googleConnected, googleScopes: googleOAuth.status === 'fulfilled' ? (googleOAuth.value?.scopes ?? []) : [] })}
+    ${renderTwinBriefingWidget(_twinBriefing)}
+    ${tourMode || hasAnyData ? '' : renderConnectGoogleHero({ googleConnected, googleSystemConfigured, userId })}
+    ${tourMode || hasAnyData ? '' : renderConnectGmailHero({ googleConnected, googleScopes: googleOAuth.status === 'fulfilled' ? (googleOAuth.value?.scopes ?? []) : [] })}
     ${renderAskTwinWidget({ userId, tourMode })}
     ${showBriefing ? renderBriefingCard({ items: briefingItems, createdAt: briefing.createdAt }) : ''}
-    ${renderTwinBriefingWidget(_twinBriefing)}
     ${renderLifebooksCard(lifebooks)}
     ${pending > 0 ? `<div class="card" style="border-left: 3px solid var(--warning); cursor: pointer;" data-action="goto" data-hash="#/approvals">
       <span style="font-weight: 600;">You have ${pending} pending approval${pending > 1 ? 's' : ''}</span>

--- a/apps/web/public/js/pages/decisions.js
+++ b/apps/web/public/js/pages/decisions.js
@@ -13,6 +13,8 @@ let _decisionsListenerWired = false;
 export async function renderDecisions(container, userId) {
   currentUserId = userId;
   ensureDecisionsListener();
+  const routeParams = new URLSearchParams((window.location.hash || '').split('?')[1] || '');
+  const signalId = routeParams.get('signalId') || routeParams.get('signal') || '';
 
   container.innerHTML = `
     <div class="decisions-page">
@@ -89,6 +91,7 @@ export async function renderDecisions(container, userId) {
       if (from) params.from = from;
       if (to) params.to = to;
       if (search) params.search = search;
+      if (signalId) params.signalId = signalId;
 
       const result = await fetchDecisions(userId, params);
       const decisions = result.decisions ?? [];
@@ -97,7 +100,7 @@ export async function renderDecisions(container, userId) {
         `${result.total} decision${result.total !== 1 ? 's' : ''} found`;
 
       if (decisions.length === 0) {
-        const hasFilters = !!(domain || from || to || search);
+        const hasFilters = !!(domain || from || to || search || signalId);
         listEl.innerHTML = hasFilters
           ? `
             <div class="empty-state">

--- a/apps/web/public/js/pages/decisions.js
+++ b/apps/web/public/js/pages/decisions.js
@@ -162,9 +162,11 @@ export async function renderDecisions(container, userId) {
                     <td><span class="badge badge-${urgencyBadge(d.urgency)}">${escapeHtml(d.urgency || '--')}</span></td>
                     <td>${d.autoExecuted === true
                       ? '<span class="badge badge-accent" title="Your twin handled this automatically">Auto</span>'
-                      : d.autoExecuted === false
-                        ? '<span class="badge badge-success" title="You approved this action">You OK\'d</span>'
-                        : '<span class="badge badge-muted" title="Decision pending">Pending</span>'
+                      : d.requiresApproval === true
+                        ? '<span class="badge badge-warning" title="Waiting for your OK">Needs you</span>'
+                        : d.autoExecuted === false
+                          ? '<span class="badge badge-success" title="You approved this action">You OK\'d</span>'
+                          : '<span class="badge badge-muted" title="Decision pending">Pending</span>'
                     }</td>
                     <td>
                       <button class="btn btn-sm btn-outline undo-btn" data-action="show-undo" data-decision-id="${escapeHtml(d.id)}">

--- a/apps/web/public/js/pages/setup.js
+++ b/apps/web/public/js/pages/setup.js
@@ -438,9 +438,16 @@ function renderDynamicIntegrations(integrations, credLookup) {
 
 function buildSyncLookup(ironclawSync) {
   const lookup = {};
-  for (const row of ironclawSync?.credentials ?? []) {
-    if (!lookup[row.service]) lookup[row.service] = [];
-    lookup[row.service].push(row);
+  // IronClaw credential-sync only applies when a real, reachable IronClaw is
+  // configured. When it's unreachable (the common case: no IronClaw, the local
+  // mock, or a remote that's down) syncing is impossible — surface nothing
+  // rather than a misleading "Not fully synced to IronClaw" + a "Sync to
+  // IronClaw" button that can only fail with a connection error.
+  if (ironclawSync?.reachable) {
+    for (const row of ironclawSync.credentials ?? []) {
+      if (!lookup[row.service]) lookup[row.service] = [];
+      lookup[row.service].push(row);
+    }
   }
   _syncLookup = lookup;
   return lookup;

--- a/apps/web/public/js/pages/setup.js
+++ b/apps/web/public/js/pages/setup.js
@@ -274,9 +274,9 @@ export async function renderSetup(container, _userId) {
 
         <div style="margin-bottom: 1.25rem;">
           <div style="font-weight: 600; font-size: 0.9rem; margin-bottom: 0.5rem;">Live status</div>
-          ${renderAdapterStatus('Sandboxed execution server (IronClaw)', ironclaw, 'Highest trust — actions are sandboxed, audited, and reversible. Auto-detects on localhost:4000.')}
+          ${renderAdapterStatus('Sandboxed execution server (IronClaw)', ironclaw, 'Highest trust — actions are sandboxed, audited, and reversible. Auto-detects on localhost:4000.', true)}
           ${renderAdapterStatus('Built-in handlers', direct, 'Native handlers for email, calendar, finance, and more. Always available.')}
-          ${renderAdapterStatus('Local-AI execution (OpenClaw)', openclaw, 'Community engine that uses a local LLM for broader skills. Optional.')}
+          ${renderAdapterStatus('Local-AI execution (OpenClaw)', openclaw, 'Community engine that uses a local LLM for broader skills. Optional.', true)}
           <div style="margin-top: 0.5rem; font-size: 0.8rem; color: var(--text-muted);">
             Your twin automatically picks the most trusted engine that's available and falls back if one is down.
           </div>
@@ -472,7 +472,7 @@ function renderIronClawSyncSummary(service, syncLookup) {
   `;
 }
 
-function renderAdapterStatus(name, adapter, description) {
+function renderAdapterStatus(name, adapter, description, optional = false) {
   const dot = adapter.registered && adapter.healthy
     ? '<span style="display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--success); margin-right: 0.5rem;"></span>'
     : adapter.registered
@@ -483,7 +483,11 @@ function renderAdapterStatus(name, adapter, description) {
     ? '<span style="color: var(--success); font-size: 0.8rem;">Running</span>'
     : adapter.registered
       ? '<span style="color: var(--warning, #e6a700); font-size: 0.8rem;">Registered but unreachable</span>'
-      : '<span style="color: var(--text-muted); font-size: 0.8rem;">Not detected</span>';
+      // An optional adapter that simply isn't set up is not a failure — say so
+      // plainly instead of "Not detected" (which reads like something's wrong).
+      : optional
+        ? '<span style="color: var(--text-muted); font-size: 0.8rem;">Optional — not connected</span>'
+        : '<span style="color: var(--text-muted); font-size: 0.8rem;">Not detected</span>';
 
   const urlText = adapter.url && adapter.url !== 'local'
     ? `<span style="color: var(--text-muted); font-size: 0.75rem; margin-left: 0.5rem;">${escapeHtml(adapter.url)}</span>`

--- a/apps/web/public/js/pages/twin-briefing.js
+++ b/apps/web/public/js/pages/twin-briefing.js
@@ -153,23 +153,36 @@ function isPowerView() {
 function detailToggle(detail) {
   return detail ? `<button type="button" class="digest-detail-toggle" data-action="toggle-item-detail">Details</button>` : '';
 }
+// Qualitative word for a confidence %, so the number has a human meaning.
+function sureWord(p) {
+  if (p >= 85) return 'very sure';
+  if (p >= 65) return 'fairly sure';
+  if (p >= 40) return 'somewhat sure';
+  return 'not very sure';
+}
+
 function detailPanel(detail) {
   if (!detail) return '';
-  // Plain-language "why" behind the item, for anyone who wants it. The
-  // actionable step is already in the row. Labels read like a person would
-  // ask, not like the system names things internally.
+  // Every row must earn its place — concrete facts that help the user decide.
+  // The actionable step is already in the row above this panel.
   const rows = [];
   if (Array.isArray(detail.sourceRefs) && detail.sourceRefs.length)
     rows.push(`<div><span class="dd-k">where it's from</span> ${escapeHtml(detail.sourceRefs.join(', '))}</div>`);
-  if (detail.provenanceLabel)
-    rows.push(`<div><span class="dd-k">written by</span> ${escapeHtml(detail.provenanceLabel.replace(/^From /, ''))}</div>`);
-  if (typeof detail.confidencePct === 'number')
-    rows.push(`<div><span class="dd-k">how sure I am</span> ${detail.confidencePct}%</div>`);
+  if (detail.occurredAt) {
+    const when = formatTime(new Date(detail.occurredAt));
+    if (when) rows.push(`<div><span class="dd-k">when</span> ${escapeHtml(when)}</div>`);
+  }
   if (detail.urgencyReason)
     rows.push(`<div><span class="dd-k">why now</span> ${escapeHtml(detail.urgencyReason)}</div>`);
+  if (typeof detail.confidencePct === 'number')
+    rows.push(`<div><span class="dd-k">how sure I am</span> ${escapeHtml(sureWord(detail.confidencePct))} (${detail.confidencePct}%)</div>`);
   if (Array.isArray(detail.whyNotAutoExecuted) && detail.whyNotAutoExecuted.length)
     rows.push(`<div><span class="dd-k">why I'm asking you</span> ${detail.whyNotAutoExecuted.map((r) => escapeHtml(String(r))).join('; ')}</div>`);
-  return `<div class="digest-detail">${rows.join('')}</div>`;
+  // "Written by" only when YOU wrote it (notable). For inbound items the sender
+  // already shows it came from someone else — no redundant row.
+  if (detail.provenanceLabel && /from you/i.test(detail.provenanceLabel))
+    rows.push(`<div><span class="dd-k">written by</span> you</div>`);
+  return rows.length ? `<div class="digest-detail">${rows.join('')}</div>` : '';
 }
 
 // Inline action zone (the "it can act" thesis). Primary actions come from the
@@ -440,8 +453,8 @@ export async function renderTwinBriefing(container) {
   container.innerHTML = `
     <section class="twin-briefing-page">
       <header style="margin-bottom: 1.5rem;">
-        <h1>Twin Briefing</h1>
-        <p class="subtle">Your twin's periodic summary of what it's been up to.</p>
+        <h1>Your briefing</h1>
+        <p class="subtle">What I've handled, and what needs you.</p>
       </header>
 
       <div class="briefing-tabs" style="display: flex; gap: 0.5rem; margin-bottom: 1rem;">

--- a/apps/web/public/js/pages/twin-briefing.js
+++ b/apps/web/public/js/pages/twin-briefing.js
@@ -141,7 +141,7 @@ function renderCite(signalRefs) {
 // Provenance dot: filled (neutral) = from you, hollow = inbound. Never accent-colored.
 function provDot(detail) {
   const you = detail && /from you/i.test(detail.provenanceLabel || '');
-  return `<span class="digest-prov ${you ? 'you' : 'inbound'}" title="${you ? 'from you' : 'inbound'}"></span>`;
+  return `<span class="digest-prov ${you ? 'you' : 'inbound'}" title="${you ? 'you wrote this' : 'someone else sent this'}"></span>`;
 }
 
 // Power view (spec 14): persisted, defaults OFF (clean view is the default).
@@ -155,16 +155,20 @@ function detailToggle(detail) {
 }
 function detailPanel(detail) {
   if (!detail) return '';
-  // The actionable "suggested" step is shown in the row itself; this power-view
-  // panel is the trust/technical metadata behind the decision.
-  const rows = [`<div><span class="dd-k">origin</span> ${escapeHtml(detail.provenanceLabel || '')}</div>`];
-  if (typeof detail.confidencePct === 'number') rows.push(`<div><span class="dd-k">confidence</span> ${detail.confidencePct}%</div>`);
-  if (detail.urgencyReason) rows.push(`<div><span class="dd-k">urgency</span> ${escapeHtml(detail.urgencyReason)}</div>`);
-  if (Array.isArray(detail.whyNotAutoExecuted) && detail.whyNotAutoExecuted.length)
-    rows.push(`<div><span class="dd-k">not auto-run</span> ${detail.whyNotAutoExecuted.map((r) => escapeHtml(String(r))).join('; ')}</div>`);
+  // Plain-language "why" behind the item, for anyone who wants it. The
+  // actionable step is already in the row. Labels read like a person would
+  // ask, not like the system names things internally.
+  const rows = [];
   if (Array.isArray(detail.sourceRefs) && detail.sourceRefs.length)
-    rows.push(`<div><span class="dd-k">refs</span> <code>${detail.sourceRefs.map((r) => escapeHtml(String(r))).join(', ')}</code></div>`);
-  if (detail.explanation) rows.push(`<div><span class="dd-k">why</span> ${escapeHtml(detail.explanation)}</div>`);
+    rows.push(`<div><span class="dd-k">where it's from</span> ${escapeHtml(detail.sourceRefs.join(', '))}</div>`);
+  if (detail.provenanceLabel)
+    rows.push(`<div><span class="dd-k">written by</span> ${escapeHtml(detail.provenanceLabel.replace(/^From /, ''))}</div>`);
+  if (typeof detail.confidencePct === 'number')
+    rows.push(`<div><span class="dd-k">how sure I am</span> ${detail.confidencePct}%</div>`);
+  if (detail.urgencyReason)
+    rows.push(`<div><span class="dd-k">why now</span> ${escapeHtml(detail.urgencyReason)}</div>`);
+  if (Array.isArray(detail.whyNotAutoExecuted) && detail.whyNotAutoExecuted.length)
+    rows.push(`<div><span class="dd-k">why I'm asking you</span> ${detail.whyNotAutoExecuted.map((r) => escapeHtml(String(r))).join('; ')}</div>`);
   return `<div class="digest-detail">${rows.join('')}</div>`;
 }
 

--- a/apps/web/public/js/pages/twin-briefing.js
+++ b/apps/web/public/js/pages/twin-briefing.js
@@ -58,6 +58,11 @@ function handleBriefingClick(e) {
   } else if (action === 'briefing-history-item') {
     const id = target.dataset.briefingId;
     if (id) handleShowHistoryItem(id, userId);
+  } else if (action === 'open-signal') {
+    // Citation chip → in-app signal/decision detail (spec 08). Never an
+    // external URL. Routes to the decisions page filtered to the signal ref.
+    const ref = target.dataset.signalRef;
+    if (ref) window.location.hash = `#/decisions?signal=${encodeURIComponent(ref)}`;
   }
 }
 
@@ -81,6 +86,89 @@ async function handleShowHistoryItem(briefingId, userId) {
   renderProseSection(target);
 }
 
+// Source-type → accessible label for the digest source chip (spec 08, #481).
+// Text labels (not icon-only) for a11y; unknown types fall back to a neutral chip.
+const SOURCE_CHIP_LABELS = {
+  email: 'email',
+  gmail: 'email',
+  calendar: 'calendar',
+  google_calendar: 'calendar',
+  filesystem: 'file',
+  file: 'file',
+  voice: 'voice',
+  app: 'app',
+};
+
+function sourceChip(sourceType) {
+  const label = SOURCE_CHIP_LABELS[sourceType] || 'source';
+  return `<span class="source-chip source-chip-${escapeHtml(label)}">${escapeHtml(label)}</span>`;
+}
+
+function citationChips(signalRefs) {
+  if (!Array.isArray(signalRefs) || signalRefs.length === 0) return '';
+  // Each chip links to the in-app signal/decision detail — NEVER a raw external
+  // URL (spec 06 / safety invariant #8). data-action delegated, no inline handler.
+  return signalRefs
+    .map(
+      (ref) =>
+        `<button type="button" class="citation-chip" data-action="open-signal" data-signal-ref="${escapeHtml(
+          String(ref),
+        )}" aria-label="source: ${escapeHtml(String(ref))}">source</button>`,
+    )
+    .join(' ');
+}
+
+/**
+ * Render the structured digest (spec 01/08): To-dos bucket above Topics, each row
+ * source-aware + cited. Returns '' when there's no structured payload (caller
+ * falls back to prose — back-compat for old briefings).
+ */
+function renderDigestSection(structured) {
+  if (!structured || (!structured.todos?.length && !structured.topics?.length)) return '';
+
+  const todos = (structured.todos || [])
+    .map(
+      (t) => `
+      <li class="digest-todo">
+        ${sourceChip(t.sourceType)}
+        <span class="digest-todo-text">${escapeHtml(t.text || '')}</span>
+        ${t.deadline ? `<span class="digest-deadline">${escapeHtml(String(t.deadline))}</span>` : ''}
+        ${citationChips(t.signalRefs)}
+      </li>`,
+    )
+    .join('');
+
+  const topics = (structured.topics || [])
+    .map(
+      (group) => `
+      <div class="digest-topic">
+        <h4 class="digest-topic-title">${escapeHtml(group.title || group.domain || 'Topic')}</h4>
+        <ul>
+          ${(group.items || [])
+            .map(
+              (it) => `
+            <li class="digest-topic-item">
+              ${sourceChip(it.sourceType)}
+              <span>${escapeHtml(it.text || '')}</span>
+              ${citationChips(it.signalRefs)}
+            </li>`,
+            )
+            .join('')}
+        </ul>
+      </div>`,
+    )
+    .join('');
+
+  return `
+    <section class="digest" aria-label="Digest">
+      <h3 class="digest-heading">To-dos</h3>
+      ${todos ? `<ul class="digest-todos">${todos}</ul>` : '<p class="muted">Nothing needs you right now.</p>'}
+      <h3 class="digest-heading">Topics to catch up on</h3>
+      ${topics || '<p class="muted">No topics today.</p>'}
+    </section>
+  `;
+}
+
 function renderProseSection(briefing) {
   const el = document.getElementById('briefing-prose');
   if (!el) return;
@@ -88,6 +176,9 @@ function renderProseSection(briefing) {
   const prose = briefing ? briefing.prose_markdown || '' : '';
   const generated = briefing ? new Date(briefing.generated_at) : null;
   const isRead = !!briefing?.read_at;
+  // Spec 08: render the structured two-bucket digest when present; the prose
+  // block stays as a fallback / long-form view.
+  const digestHtml = renderDigestSection(briefing?.structured);
 
   el.innerHTML = `
     <div class="briefing-meta" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; font-size: 0.82rem; color: var(--text-dim);">
@@ -104,6 +195,7 @@ function renderProseSection(briefing) {
               style="font-size: 0.78rem;">Mark as read</button>`
         : ''}
     </div>
+    ${digestHtml}
     <div class="briefing-prose-content" style="white-space: pre-wrap; line-height: 1.7;">
       ${prose ? escapeHtml(prose) : '<em class="muted">No briefing content yet.</em>'}
     </div>

--- a/apps/web/public/js/pages/twin-briefing.js
+++ b/apps/web/public/js/pages/twin-briefing.js
@@ -155,10 +155,9 @@ function detailToggle(detail) {
 }
 function detailPanel(detail) {
   if (!detail) return '';
-  // Lead with the actionable next step; the trust metadata follows.
-  const rows = [];
-  if (detail.suggestedAction) rows.push(`<div class="dd-suggested"><span class="dd-k">suggested</span> ${escapeHtml(detail.suggestedAction)}</div>`);
-  rows.push(`<div><span class="dd-k">origin</span> ${escapeHtml(detail.provenanceLabel || '')}</div>`);
+  // The actionable "suggested" step is shown in the row itself; this power-view
+  // panel is the trust/technical metadata behind the decision.
+  const rows = [`<div><span class="dd-k">origin</span> ${escapeHtml(detail.provenanceLabel || '')}</div>`];
   if (typeof detail.confidencePct === 'number') rows.push(`<div><span class="dd-k">confidence</span> ${detail.confidencePct}%</div>`);
   if (detail.urgencyReason) rows.push(`<div><span class="dd-k">urgency</span> ${escapeHtml(detail.urgencyReason)}</div>`);
   if (Array.isArray(detail.whyNotAutoExecuted) && detail.whyNotAutoExecuted.length)
@@ -205,6 +204,7 @@ function renderTodoRow(t) {
           ${detailToggle(t.detail)}
         </div>
         ${t.body ? `<div class="digest-body">${escapeHtml(t.body)}</div>` : ''}
+        ${t.detail?.suggestedAction ? `<div class="digest-suggested">→ ${escapeHtml(t.detail.suggestedAction)}</div>` : ''}
         ${isSec ? `<div class="digest-todo-hint">Open your provider directly — don't trust links in the message.</div>` : ''}
         ${detailPanel(t.detail)}
       </div>
@@ -219,6 +219,7 @@ function renderTopicItem(it) {
       <div class="digest-todo-body">
         <div>${escapeHtml(it.text || '')} ${renderSource(it.sourceType)} ${renderCite(it.signalRefs)} ${detailToggle(it.detail)}</div>
         ${it.body ? `<div class="digest-body">${escapeHtml(it.body)}</div>` : ''}
+        ${it.detail?.suggestedAction ? `<div class="digest-suggested">→ ${escapeHtml(it.detail.suggestedAction)}</div>` : ''}
         ${detailPanel(it.detail)}
       </div>
     </li>`;

--- a/apps/web/public/js/pages/twin-briefing.js
+++ b/apps/web/public/js/pages/twin-briefing.js
@@ -196,9 +196,21 @@ function renderProseSection(briefing) {
         : ''}
     </div>
     ${digestHtml}
-    <div class="briefing-prose-content" style="white-space: pre-wrap; line-height: 1.7;">
-      ${prose ? escapeHtml(prose) : '<em class="muted">No briefing content yet.</em>'}
-    </div>
+    ${
+      digestHtml
+        ? // When the structured digest renders, the prose is redundant — tuck it
+          // under a disclosure as the long-form view (design-review: avoid
+          // showing the same briefing twice).
+          `<details class="briefing-prose-details">
+             <summary class="muted">Full briefing</summary>
+             <div class="briefing-prose-content" style="white-space: pre-wrap; line-height: 1.7;">
+               ${prose ? escapeHtml(prose) : '<em class="muted">No briefing content yet.</em>'}
+             </div>
+           </details>`
+        : `<div class="briefing-prose-content" style="white-space: pre-wrap; line-height: 1.7;">
+             ${prose ? escapeHtml(prose) : '<em class="muted">No briefing content yet.</em>'}
+           </div>`
+    }
   `;
 }
 

--- a/apps/web/public/js/pages/twin-briefing.js
+++ b/apps/web/public/js/pages/twin-briefing.js
@@ -305,6 +305,9 @@ function renderProseSection(briefing) {
   const prose = briefing ? briefing.prose_markdown || '' : '';
   const generated = briefing ? new Date(briefing.generated_at) : null;
   const isRead = !!briefing?.read_at;
+  // The live-computed digest (no stored row) carries the sentinel id 'live';
+  // read-state controls only apply to a persisted briefing.
+  const isPersisted = !!briefing && briefing.id !== 'live';
   // Spec 08: render the structured two-bucket digest when present; the prose
   // block stays as a fallback / long-form view.
   const digestHtml = renderDigestSection(briefing?.structured);
@@ -313,11 +316,11 @@ function renderProseSection(briefing) {
     <div class="briefing-meta" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; font-size: 0.82rem; color: var(--text-dim);">
       <span>
         ${generated ? `Generated ${formatTime(generated)}` : ''}
-        ${!isRead && briefing
+        ${!isRead && isPersisted
           ? `<span class="badge badge-info briefing-unread-badge" data-briefing-id="${escapeHtml(briefing.id)}" style="margin-left: 0.5rem;">New</span>`
           : ''}
       </span>
-      ${!isRead && briefing
+      ${!isRead && isPersisted
         ? `<button class="btn btn-sm btn-outline"
               data-action="mark-briefing-read"
               data-briefing-id="${escapeHtml(briefing.id)}"

--- a/apps/web/public/js/pages/twin-briefing.js
+++ b/apps/web/public/js/pages/twin-briefing.js
@@ -73,8 +73,24 @@ function handleBriefingClick(e) {
     renderBriefingTab(userId, _activeCadence);
   } else if (action === 'toggle-item-detail') {
     // Spec 14: per-item inline detail expand (no re-render).
-    const item = target.closest('.digest-item');
+    const item = target.closest('.digest-todo, .digest-topic-item');
     if (item) item.classList.toggle('detail-open');
+  } else if (action === 'toggle-check') {
+    // Mark a to-do done (visual). Persistence rides with the act layer.
+    target.classList.toggle('is-on');
+    const row = target.closest('.digest-todo');
+    if (row) row.classList.toggle('is-done');
+  } else if (action === 'row-action') {
+    // Inline action zone (DESIGN.md). The act layer (draft/snooze/verify) wires
+    // these to real execution; until then, route or acknowledge honestly.
+    const act = target.dataset.act;
+    if (act === 'grant') {
+      window.location.hash = '#/settings';
+    } else {
+      showToast(`"${act}" runs through the act layer — wiring lands with that work.`, { kind: 'info', durationMs: 2600 });
+    }
+  } else if (action === 'connect-source') {
+    window.location.hash = '#/settings';
   }
 }
 
@@ -98,163 +114,184 @@ async function handleShowHistoryItem(briefingId, userId) {
   renderProseSection(target);
 }
 
-// Source-type → accessible label for the digest source chip (spec 08, #481).
-// Text labels (not icon-only) for a11y; unknown types fall back to a neutral chip.
-const SOURCE_CHIP_LABELS = {
-  email: 'email',
-  gmail: 'email',
-  calendar: 'calendar',
-  google_calendar: 'calendar',
-  filesystem: 'file',
-  file: 'file',
-  voice: 'voice',
-  app: 'app',
+// ── Digest render (DESIGN.md) ───────────────────────────────────────────────
+// Calm command center: iris accent = "needs you / act"; action zone (to-dos) vs
+// awareness zone (topics); source as a small neutral mark (not a chip), one
+// citation affordance, provenance as a dot, power-view depth on demand.
+
+const SOURCE_LABELS = {
+  email: 'email', gmail: 'email', calendar: 'calendar', google_calendar: 'calendar',
+  filesystem: 'file', file: 'file', voice: 'voice', app: 'app',
 };
-
-function sourceChip(sourceType) {
-  const label = SOURCE_CHIP_LABELS[sourceType] || 'source';
-  return `<span class="source-chip source-chip-${escapeHtml(label)}">${escapeHtml(label)}</span>`;
+function renderSource(sourceType) {
+  const label = SOURCE_LABELS[sourceType];
+  return label ? `<span class="digest-source">${escapeHtml(label)}</span>` : '';
 }
 
-function citationChips(signalRefs) {
+// One quiet citation affordance per row → opens the in-app signal/decision detail.
+// NEVER a raw external URL (safety #8).
+function renderCite(signalRefs) {
   if (!Array.isArray(signalRefs) || signalRefs.length === 0) return '';
-  // Each chip links to the in-app signal/decision detail — NEVER a raw external
-  // URL (spec 06 / safety invariant #8). data-action delegated, no inline handler.
-  return signalRefs
-    .map(
-      (ref) =>
-        `<button type="button" class="citation-chip" data-action="open-signal" data-signal-ref="${escapeHtml(
-          String(ref),
-        )}" aria-label="source: ${escapeHtml(String(ref))}">source</button>`,
-    )
-    .join(' ');
+  const n = signalRefs.length;
+  return `<button type="button" class="digest-cite" data-action="open-signal" data-signal-ref="${escapeHtml(
+    String(signalRefs[0]),
+  )}" aria-label="view ${n} source${n > 1 ? 's' : ''}">·${n} source${n > 1 ? 's' : ''}</button>`;
 }
 
-// Power view (spec 14): one digest, two depths. Persisted client-side so a power
-// user keeps technical depth on by default. Discoverable via the header toggle —
-// NOT buried in settings. Defaults OFF so the clean view stays default.
+// Provenance dot: filled (neutral) = from you, hollow = inbound. Never accent-colored.
+function provDot(detail) {
+  const you = detail && /from you/i.test(detail.provenanceLabel || '');
+  return `<span class="digest-prov ${you ? 'you' : 'inbound'}" title="${you ? 'from you' : 'inbound'}"></span>`;
+}
+
+// Power view (spec 14): persisted, defaults OFF (clean view is the default).
 const POWER_VIEW_KEY = 'skytwin.digest.powerView';
 function isPowerView() {
-  try {
-    return localStorage.getItem(POWER_VIEW_KEY) === '1';
-  } catch {
-    return false;
-  }
+  try { return localStorage.getItem(POWER_VIEW_KEY) === '1'; } catch { return false; }
 }
 
-// Inline technical-depth panel for a row (spec 14). `detail` is the server-built
-// DigestItemDetail (buildDigestItemDetail); absent → no expander.
-function renderItemDetail(detail) {
+function detailToggle(detail) {
+  return detail ? `<button type="button" class="digest-detail-toggle" data-action="toggle-item-detail">Details</button>` : '';
+}
+function detailPanel(detail) {
   if (!detail) return '';
-  const rows = [];
-  rows.push(`<div><span class="dd-k">origin</span> ${escapeHtml(detail.provenanceLabel || '')}</div>`);
-  if (typeof detail.confidencePct === 'number') {
-    rows.push(`<div><span class="dd-k">confidence</span> ${detail.confidencePct}%</div>`);
-  }
-  if (detail.urgencyReason) {
-    rows.push(`<div><span class="dd-k">urgency</span> ${escapeHtml(detail.urgencyReason)}</div>`);
-  }
-  if (Array.isArray(detail.whyNotAutoExecuted) && detail.whyNotAutoExecuted.length) {
-    rows.push(
-      `<div><span class="dd-k">not auto-run</span> ${detail.whyNotAutoExecuted
-        .map((r) => escapeHtml(String(r)))
-        .join('; ')}</div>`,
-    );
-  }
-  if (Array.isArray(detail.sourceRefs) && detail.sourceRefs.length) {
-    rows.push(
-      `<div><span class="dd-k">refs</span> <code>${detail.sourceRefs
-        .map((r) => escapeHtml(String(r)))
-        .join(', ')}</code></div>`,
-    );
-  }
-  if (detail.explanation) {
-    rows.push(`<div><span class="dd-k">why</span> ${escapeHtml(detail.explanation)}</div>`);
-  }
-  return `
-    <button type="button" class="digest-detail-toggle" data-action="toggle-item-detail">Details</button>
-    <div class="digest-detail">${rows.join('')}</div>`;
+  const rows = [`<div><span class="dd-k">origin</span> ${escapeHtml(detail.provenanceLabel || '')}</div>`];
+  if (typeof detail.confidencePct === 'number') rows.push(`<div><span class="dd-k">confidence</span> ${detail.confidencePct}%</div>`);
+  if (detail.urgencyReason) rows.push(`<div><span class="dd-k">urgency</span> ${escapeHtml(detail.urgencyReason)}</div>`);
+  if (Array.isArray(detail.whyNotAutoExecuted) && detail.whyNotAutoExecuted.length)
+    rows.push(`<div><span class="dd-k">not auto-run</span> ${detail.whyNotAutoExecuted.map((r) => escapeHtml(String(r))).join('; ')}</div>`);
+  if (Array.isArray(detail.sourceRefs) && detail.sourceRefs.length)
+    rows.push(`<div><span class="dd-k">refs</span> <code>${detail.sourceRefs.map((r) => escapeHtml(String(r))).join(', ')}</code></div>`);
+  if (detail.explanation) rows.push(`<div><span class="dd-k">why</span> ${escapeHtml(detail.explanation)}</div>`);
+  return `<div class="digest-detail">${rows.join('')}</div>`;
 }
 
-// Coverage panel (spec 13 data) — shown in power view: what the twin can/can't see
-// and how to unlock more. Also doubles as cold-start guidance.
+// Inline action zone (the "it can act" thesis). Primary actions come from the
+// payload (item.actions) when the act layer is wired; security + scope-blocked
+// states derive from what we know today; Snooze is the universal default.
+function renderActions(t) {
+  const d = t.detail;
+  const scopeBlocked = d && Array.isArray(d.whyNotAutoExecuted) && d.whyNotAutoExecuted.some((r) => /permission|scope/i.test(r));
+  const acts = [];
+  if (t.kind === 'security') {
+    acts.push(`<button class="digest-act primary" data-action="row-action" data-act="verify">Verify in app</button>`);
+  } else {
+    if (Array.isArray(t.actions)) {
+      for (const a of t.actions) acts.push(`<button class="digest-act primary" data-action="row-action" data-act="${escapeHtml(a.id || '')}">${escapeHtml(a.label || '')}</button>`);
+    } else if (scopeBlocked) {
+      acts.push(`<button class="digest-act grant" data-action="row-action" data-act="grant">Grant access</button>`);
+    }
+    acts.push(`<button class="digest-act" data-action="row-action" data-act="snooze">Snooze</button>`);
+  }
+  return `<div class="digest-actions">${acts.join('')}</div>`;
+}
+
+function renderTodoRow(t) {
+  const isSec = t.kind === 'security';
+  const open = isPowerView() ? '' : '';
+  return `
+    <li class="digest-todo${isSec ? ' is-security' : ''}${open}">
+      ${isSec ? '' : `<button type="button" class="digest-check" data-action="toggle-check" aria-label="mark done"></button>`}
+      ${provDot(t.detail)}
+      <div class="digest-todo-body">
+        <div>
+          <span class="digest-todo-text">${escapeHtml(t.text || '')}</span>
+          ${t.deadline ? `<span class="digest-deadline">${escapeHtml(String(t.deadline))}</span>` : ''}
+          ${renderSource(t.sourceType)}
+          ${renderCite(t.signalRefs)}
+          ${detailToggle(t.detail)}
+        </div>
+        ${isSec ? `<div class="digest-todo-hint">Open your provider directly — don't trust links in the message.</div>` : ''}
+        ${detailPanel(t.detail)}
+      </div>
+      ${renderActions(t)}
+    </li>`;
+}
+
+function renderTopicItem(it) {
+  return `
+    <li class="digest-topic-item">
+      ${provDot(it.detail)}
+      <div class="digest-todo-body">
+        <div>${escapeHtml(it.text || '')} ${renderSource(it.sourceType)} ${renderCite(it.signalRefs)} ${detailToggle(it.detail)}</div>
+        ${detailPanel(it.detail)}
+      </div>
+    </li>`;
+}
+
 function renderCoveragePanel(coverage) {
-  if (!coverage) return '';
-  const status = (coverage.capabilityStatus || [])
+  if (!coverage || !Array.isArray(coverage.capabilityStatus)) return '';
+  const status = coverage.capabilityStatus
     .map(
       (c) =>
-        `<li><span class="cov-${escapeHtml(c.status)}">${escapeHtml(c.status)}</span> ${escapeHtml(
-          c.capability,
-        )}${
+        `<li><span class="cov-dot cov-${escapeHtml(c.status)}"></span>${escapeHtml(c.capability)}${
           c.status !== 'available' && c.unlockedBy?.length
             ? ` <span class="muted">— connect ${escapeHtml(c.unlockedBy.join(', '))}</span>`
             : ''
         }</li>`,
     )
     .join('');
+  return `<div class="digest-coverage"><h4 class="digest-topic-title">What I can see</h4><ul class="digest-coverage-list">${status}</ul></div>`;
+}
+
+// Cold-start: zero connectors → the PRIMARY surface, not a buried panel (DESIGN.md).
+function renderColdStart(coverage) {
+  const sources = ['Gmail', 'Calendar', 'Files'];
   return `
-    <div class="digest-coverage">
-      <h4 class="digest-topic-title">What I can see</h4>
-      <ul class="digest-coverage-list">${status}</ul>
+    <div class="digest-state">
+      <p class="digest-voice">Connect a source and I'll start your briefing.</p>
+      <p class="sub">I read your signals, surface what needs you, and handle the rest under your rules.</p>
+      <div class="digest-coldstart-sources">
+        ${sources.map((s) => `<button class="digest-act primary" data-action="connect-source" data-source="${escapeHtml(s)}">Connect ${escapeHtml(s)}</button>`).join('')}
+      </div>
     </div>`;
 }
 
 /**
- * Render the structured digest (spec 01/08 + power view spec 14): To-dos above
- * Topics, source-aware + cited; power view adds inline per-item technical detail
- * and the coverage panel. Returns '' when there's no structured payload (caller
- * falls back to prose).
+ * Render the structured digest (DESIGN.md). Returns '' when there's no structured
+ * payload (caller falls back to prose). Handles cold-start + empty-quiet states.
  */
 function renderDigestSection(structured) {
-  if (!structured || (!structured.todos?.length && !structured.topics?.length)) return '';
+  if (!structured) return '';
+  if (structured.coverage?.coldStart) return renderColdStart(structured.coverage);
+
+  const todoList = structured.todos || [];
+  const topicList = structured.topics || [];
+  if (!todoList.length && !topicList.length) {
+    return `<section class="digest"><p class="digest-voice">You're all caught up.</p><p class="muted">Nothing needs you right now.</p></section>`;
+  }
   const powerOn = isPowerView();
 
-  const todos = (structured.todos || [])
-    .map(
-      (t) => `
-      <li class="digest-item digest-todo">
-        ${sourceChip(t.sourceType)}
-        <span class="digest-todo-text">${escapeHtml(t.text || '')}</span>
-        ${t.deadline ? `<span class="digest-deadline">${escapeHtml(String(t.deadline))}</span>` : ''}
-        ${citationChips(t.signalRefs)}
-        ${renderItemDetail(t.detail)}
-      </li>`,
-    )
-    .join('');
+  // Value line: the twin earned its keep.
+  const needYou = todoList.length;
+  const catchUp = topicList.reduce((n, g) => n + (g.items?.length || 0), 0);
+  const handled = typeof structured.handledCount === 'number' ? structured.handledCount : null;
+  const valueLine = `
+    <p class="digest-value">
+      ${handled !== null ? `<span class="done">✓ ${handled} handled on my own</span><span class="sep"></span>` : ''}
+      <span><b>${needYou}</b> need you</span><span class="sep"></span>
+      <span><b>${catchUp}</b> to catch up on</span>
+    </p>`;
 
-  const topics = (structured.topics || [])
+  const todos = todoList.map(renderTodoRow).join('');
+  const topics = topicList
     .map(
-      (group) => `
-      <div class="digest-topic">
-        <h4 class="digest-topic-title">${escapeHtml(group.title || group.domain || 'Topic')}</h4>
-        <ul>
-          ${(group.items || [])
-            .map(
-              (it) => `
-            <li class="digest-item digest-topic-item">
-              ${sourceChip(it.sourceType)}
-              <span>${escapeHtml(it.text || '')}</span>
-              ${citationChips(it.signalRefs)}
-              ${renderItemDetail(it.detail)}
-            </li>`,
-            )
-            .join('')}
-        </ul>
-      </div>`,
+      (g) => `<div class="digest-topic"><h4 class="digest-topic-title">${escapeHtml(g.title || g.domain || 'Topic')}</h4><ul>${(g.items || []).map(renderTopicItem).join('')}</ul></div>`,
     )
     .join('');
 
   return `
     <section class="digest ${powerOn ? 'digest--power' : ''}" aria-label="Digest">
       <div class="digest-toolbar">
-        <button type="button" class="btn btn-sm btn-outline" data-action="toggle-power-view"
-          aria-pressed="${powerOn ? 'true' : 'false'}">
+        <button type="button" class="digest-power-toggle" data-action="toggle-power-view" aria-pressed="${powerOn ? 'true' : 'false'}">
           ${powerOn ? 'Power view: on' : 'Power view'}
         </button>
       </div>
-      <h3 class="digest-heading">To-dos</h3>
+      <p class="digest-voice">${needYou === 1 ? 'One thing needs you.' : `${needYou} things need you.`}</p>
+      ${valueLine}
+      <div class="digest-heading">To-dos <span class="count">· ${needYou}</span></div>
       ${todos ? `<ul class="digest-todos">${todos}</ul>` : '<p class="muted">Nothing needs you right now.</p>'}
-      <h3 class="digest-heading">Topics to catch up on</h3>
+      <div class="digest-heading">Topics to catch up on <span class="count">· ${catchUp}</span></div>
       ${topics || '<p class="muted">No topics today.</p>'}
       ${powerOn ? renderCoveragePanel(structured.coverage) : ''}
     </section>
@@ -315,7 +352,12 @@ async function renderBriefingTab(userId, cadence) {
     t.classList.toggle('is-active', t.dataset.cadence === cadence);
   });
 
-  tabContent.innerHTML = `<p class="muted">Loading…</p>`;
+  // Loading skeleton (DESIGN.md gap state) instead of bare "Loading…".
+  tabContent.innerHTML = `
+    <div class="digest-skel" aria-busy="true" aria-label="Loading briefing">
+      <div class="sk voice"></div>
+      <div class="sk row"></div><div class="sk row"></div><div class="sk row"></div>
+    </div>`;
 
   try {
     const data = await fetchLatestTwinBriefing(userId, cadence);

--- a/apps/web/public/js/pages/twin-briefing.js
+++ b/apps/web/public/js/pages/twin-briefing.js
@@ -62,7 +62,7 @@ function handleBriefingClick(e) {
     // Citation chip → in-app signal/decision detail (spec 08). Never an
     // external URL. Routes to the decisions page filtered to the signal ref.
     const ref = target.dataset.signalRef;
-    if (ref) window.location.hash = `#/decisions?signal=${encodeURIComponent(ref)}`;
+    if (ref) window.location.hash = `#/decisions?signalId=${encodeURIComponent(ref)}`;
   } else if (action === 'toggle-power-view') {
     // Spec 14: flip the persisted power-view preference and re-render the tab.
     try {

--- a/apps/web/public/js/pages/twin-briefing.js
+++ b/apps/web/public/js/pages/twin-briefing.js
@@ -155,7 +155,10 @@ function detailToggle(detail) {
 }
 function detailPanel(detail) {
   if (!detail) return '';
-  const rows = [`<div><span class="dd-k">origin</span> ${escapeHtml(detail.provenanceLabel || '')}</div>`];
+  // Lead with the actionable next step; the trust metadata follows.
+  const rows = [];
+  if (detail.suggestedAction) rows.push(`<div class="dd-suggested"><span class="dd-k">suggested</span> ${escapeHtml(detail.suggestedAction)}</div>`);
+  rows.push(`<div><span class="dd-k">origin</span> ${escapeHtml(detail.provenanceLabel || '')}</div>`);
   if (typeof detail.confidencePct === 'number') rows.push(`<div><span class="dd-k">confidence</span> ${detail.confidencePct}%</div>`);
   if (detail.urgencyReason) rows.push(`<div><span class="dd-k">urgency</span> ${escapeHtml(detail.urgencyReason)}</div>`);
   if (Array.isArray(detail.whyNotAutoExecuted) && detail.whyNotAutoExecuted.length)
@@ -201,6 +204,7 @@ function renderTodoRow(t) {
           ${renderCite(t.signalRefs)}
           ${detailToggle(t.detail)}
         </div>
+        ${t.body ? `<div class="digest-body">${escapeHtml(t.body)}</div>` : ''}
         ${isSec ? `<div class="digest-todo-hint">Open your provider directly — don't trust links in the message.</div>` : ''}
         ${detailPanel(t.detail)}
       </div>
@@ -214,6 +218,7 @@ function renderTopicItem(it) {
       ${provDot(it.detail)}
       <div class="digest-todo-body">
         <div>${escapeHtml(it.text || '')} ${renderSource(it.sourceType)} ${renderCite(it.signalRefs)} ${detailToggle(it.detail)}</div>
+        ${it.body ? `<div class="digest-body">${escapeHtml(it.body)}</div>` : ''}
         ${detailPanel(it.detail)}
       </div>
     </li>`;

--- a/apps/web/public/js/pages/twin-briefing.js
+++ b/apps/web/public/js/pages/twin-briefing.js
@@ -63,6 +63,18 @@ function handleBriefingClick(e) {
     // external URL. Routes to the decisions page filtered to the signal ref.
     const ref = target.dataset.signalRef;
     if (ref) window.location.hash = `#/decisions?signal=${encodeURIComponent(ref)}`;
+  } else if (action === 'toggle-power-view') {
+    // Spec 14: flip the persisted power-view preference and re-render the tab.
+    try {
+      localStorage.setItem(POWER_VIEW_KEY, isPowerView() ? '0' : '1');
+    } catch {
+      /* localStorage unavailable — non-fatal */
+    }
+    renderBriefingTab(userId, _activeCadence);
+  } else if (action === 'toggle-item-detail') {
+    // Spec 14: per-item inline detail expand (no re-render).
+    const item = target.closest('.digest-item');
+    if (item) item.classList.toggle('detail-open');
   }
 }
 
@@ -118,22 +130,94 @@ function citationChips(signalRefs) {
     .join(' ');
 }
 
+// Power view (spec 14): one digest, two depths. Persisted client-side so a power
+// user keeps technical depth on by default. Discoverable via the header toggle —
+// NOT buried in settings. Defaults OFF so the clean view stays default.
+const POWER_VIEW_KEY = 'skytwin.digest.powerView';
+function isPowerView() {
+  try {
+    return localStorage.getItem(POWER_VIEW_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+// Inline technical-depth panel for a row (spec 14). `detail` is the server-built
+// DigestItemDetail (buildDigestItemDetail); absent → no expander.
+function renderItemDetail(detail) {
+  if (!detail) return '';
+  const rows = [];
+  rows.push(`<div><span class="dd-k">origin</span> ${escapeHtml(detail.provenanceLabel || '')}</div>`);
+  if (typeof detail.confidencePct === 'number') {
+    rows.push(`<div><span class="dd-k">confidence</span> ${detail.confidencePct}%</div>`);
+  }
+  if (detail.urgencyReason) {
+    rows.push(`<div><span class="dd-k">urgency</span> ${escapeHtml(detail.urgencyReason)}</div>`);
+  }
+  if (Array.isArray(detail.whyNotAutoExecuted) && detail.whyNotAutoExecuted.length) {
+    rows.push(
+      `<div><span class="dd-k">not auto-run</span> ${detail.whyNotAutoExecuted
+        .map((r) => escapeHtml(String(r)))
+        .join('; ')}</div>`,
+    );
+  }
+  if (Array.isArray(detail.sourceRefs) && detail.sourceRefs.length) {
+    rows.push(
+      `<div><span class="dd-k">refs</span> <code>${detail.sourceRefs
+        .map((r) => escapeHtml(String(r)))
+        .join(', ')}</code></div>`,
+    );
+  }
+  if (detail.explanation) {
+    rows.push(`<div><span class="dd-k">why</span> ${escapeHtml(detail.explanation)}</div>`);
+  }
+  return `
+    <button type="button" class="digest-detail-toggle" data-action="toggle-item-detail">Details</button>
+    <div class="digest-detail">${rows.join('')}</div>`;
+}
+
+// Coverage panel (spec 13 data) — shown in power view: what the twin can/can't see
+// and how to unlock more. Also doubles as cold-start guidance.
+function renderCoveragePanel(coverage) {
+  if (!coverage) return '';
+  const status = (coverage.capabilityStatus || [])
+    .map(
+      (c) =>
+        `<li><span class="cov-${escapeHtml(c.status)}">${escapeHtml(c.status)}</span> ${escapeHtml(
+          c.capability,
+        )}${
+          c.status !== 'available' && c.unlockedBy?.length
+            ? ` <span class="muted">— connect ${escapeHtml(c.unlockedBy.join(', '))}</span>`
+            : ''
+        }</li>`,
+    )
+    .join('');
+  return `
+    <div class="digest-coverage">
+      <h4 class="digest-topic-title">What I can see</h4>
+      <ul class="digest-coverage-list">${status}</ul>
+    </div>`;
+}
+
 /**
- * Render the structured digest (spec 01/08): To-dos bucket above Topics, each row
- * source-aware + cited. Returns '' when there's no structured payload (caller
- * falls back to prose — back-compat for old briefings).
+ * Render the structured digest (spec 01/08 + power view spec 14): To-dos above
+ * Topics, source-aware + cited; power view adds inline per-item technical detail
+ * and the coverage panel. Returns '' when there's no structured payload (caller
+ * falls back to prose).
  */
 function renderDigestSection(structured) {
   if (!structured || (!structured.todos?.length && !structured.topics?.length)) return '';
+  const powerOn = isPowerView();
 
   const todos = (structured.todos || [])
     .map(
       (t) => `
-      <li class="digest-todo">
+      <li class="digest-item digest-todo">
         ${sourceChip(t.sourceType)}
         <span class="digest-todo-text">${escapeHtml(t.text || '')}</span>
         ${t.deadline ? `<span class="digest-deadline">${escapeHtml(String(t.deadline))}</span>` : ''}
         ${citationChips(t.signalRefs)}
+        ${renderItemDetail(t.detail)}
       </li>`,
     )
     .join('');
@@ -147,10 +231,11 @@ function renderDigestSection(structured) {
           ${(group.items || [])
             .map(
               (it) => `
-            <li class="digest-topic-item">
+            <li class="digest-item digest-topic-item">
               ${sourceChip(it.sourceType)}
               <span>${escapeHtml(it.text || '')}</span>
               ${citationChips(it.signalRefs)}
+              ${renderItemDetail(it.detail)}
             </li>`,
             )
             .join('')}
@@ -160,11 +245,18 @@ function renderDigestSection(structured) {
     .join('');
 
   return `
-    <section class="digest" aria-label="Digest">
+    <section class="digest ${powerOn ? 'digest--power' : ''}" aria-label="Digest">
+      <div class="digest-toolbar">
+        <button type="button" class="btn btn-sm btn-outline" data-action="toggle-power-view"
+          aria-pressed="${powerOn ? 'true' : 'false'}">
+          ${powerOn ? 'Power view: on' : 'Power view'}
+        </button>
+      </div>
       <h3 class="digest-heading">To-dos</h3>
       ${todos ? `<ul class="digest-todos">${todos}</ul>` : '<p class="muted">Nothing needs you right now.</p>'}
       <h3 class="digest-heading">Topics to catch up on</h3>
       ${topics || '<p class="muted">No topics today.</p>'}
+      ${powerOn ? renderCoveragePanel(structured.coverage) : ''}
     </section>
   `;
 }

--- a/apps/worker/src/__tests__/briefing-generator-adaptive.test.ts
+++ b/apps/worker/src/__tests__/briefing-generator-adaptive.test.ts
@@ -10,11 +10,16 @@ const {
   mockBriefingRepository,
   mockAppSuggestionRepository,
   mockMcpServerRepository,
+  mockUserRepository,
   mockQuery,
 } = vi.hoisted(() => ({
   mockBriefingRepository: { create: vi.fn() },
   mockAppSuggestionRepository: { getPendingForUser: vi.fn() },
   mockMcpServerRepository: { listForUser: vi.fn() },
+  // spec 12: briefing-generator reads the user's locale before runPrompt. Without
+  // this the call threw and the generator silently fell back to the templated
+  // path, leaving the LLM-prose path untested (review #13).
+  mockUserRepository: { getLocale: vi.fn().mockResolvedValue({ language: null, timezone: null }) },
   mockQuery: vi.fn().mockResolvedValue({ rows: [] }),
 }));
 
@@ -22,6 +27,7 @@ vi.mock('@skytwin/db', () => ({
   briefingRepository: mockBriefingRepository,
   appSuggestionRepository: mockAppSuggestionRepository,
   mcpServerRepository: mockMcpServerRepository,
+  userRepository: mockUserRepository,
   query: mockQuery,
 }));
 

--- a/apps/worker/src/__tests__/promotion-eligibility-check.test.ts
+++ b/apps/worker/src/__tests__/promotion-eligibility-check.test.ts
@@ -3,10 +3,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockListActive = vi.fn();
 const mockCreateIfPending = vi.fn();
 const mockQuery = vi.fn();
+// Soak-floor source (spec 10 Part C): default to a value comfortably past the
+// observer floor (24h) so existing promotion-eligibility cases behave as before;
+// individual tests can override to assert the floor blocks early promotion.
+const mockHoursInCurrentTier = vi.fn().mockResolvedValue(72);
 
 vi.mock('@skytwin/db', () => ({
   mcpServerRepository: { listActive: mockListActive },
   promotionOffersRepository: { createIfPending: mockCreateIfPending },
+  trustTierAuditRepository: { hoursInCurrentTier: mockHoursInCurrentTier },
   query: mockQuery,
 }));
 
@@ -87,6 +92,23 @@ describe('runPromotionEligibilityCheckJob (#310)', () => {
       decisionsObservedCount: 20,
       approvedCount: 18,
     });
+  });
+
+  it('passes hoursInCurrentTier from the audit repo into the engine (soak-floor wiring, spec 10 Part C)', async () => {
+    mockListActive.mockResolvedValue([makeServer()]);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '20', approved: '18' }] })
+      .mockResolvedValueOnce({ rows: Array(10).fill({ payload: { approved: true } }) });
+    mockHoursInCurrentTier.mockResolvedValueOnce(5); // below the 24h observer floor
+    mockEvaluateProgression.mockReturnValue({ shouldChange: false, currentTier: 'observer', reason: 'soak' });
+
+    await runPromotionEligibilityCheckJob();
+
+    expect(mockHoursInCurrentTier).toHaveBeenCalledWith('u-1');
+    expect(mockEvaluateProgression).toHaveBeenCalledWith(
+      'observer',
+      expect.objectContaining({ hoursInCurrentTier: 5 }),
+    );
   });
 
   it('counts alreadyPending when createIfPending returns null (idempotency)', async () => {

--- a/apps/worker/src/jobs/briefing-generator.ts
+++ b/apps/worker/src/jobs/briefing-generator.ts
@@ -346,6 +346,11 @@ async function generateBriefingProse(
       // `{{#if domain}}` block scopes the prose accordingly.
       const result = await runPrompt<{ briefing: string; highlight_count?: number }>({
         promptName: 'briefing-prose',
+        // Pinned to v1 (prose-only) until the generator consumes v2's structured
+        // todos/topics (spec 01/08 integration). Without the pin, loadPrompt
+        // auto-selects v2, which would request + discard the structured arrays
+        // (wasted tokens) — review #6b.
+        version: 1,
         inputs: {
           date: new Date().toISOString().slice(0, 10),
           events,

--- a/apps/worker/src/jobs/briefing-generator.ts
+++ b/apps/worker/src/jobs/briefing-generator.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@skytwin/core';
-import { briefingRepository, appSuggestionRepository, lifebookRepository, mcpServerRepository, query } from '@skytwin/db';
+import { briefingRepository, appSuggestionRepository, lifebookRepository, mcpServerRepository, userRepository, query } from '@skytwin/db';
 import { runPrompt } from '@skytwin/policy-prompts';
 import type { LlmClient } from '@skytwin/llm-client';
 
@@ -335,6 +335,12 @@ async function generateBriefingProse(
         reason: s.reason_summary ?? '',
       }));
 
+      // Briefing prose locale from the user's profile (spec 12, #486), no longer
+      // hardcoded 'en'. Falls back to 'en' when unset.
+      const userLocale = await userRepository.getLocale(userId);
+      const briefingLanguage =
+        userLocale.language && userLocale.language.trim() ? userLocale.language.trim() : 'en';
+
       // Output type matches the prompt's documented schema: { briefing: string }.
       // `domain` is set only for per-Lifebook briefings — the template's
       // `{{#if domain}}` block scopes the prose accordingly.
@@ -343,7 +349,7 @@ async function generateBriefingProse(
         inputs: {
           date: new Date().toISOString().slice(0, 10),
           events,
-          language: 'en',
+          language: briefingLanguage,
           pending_tasks: pendingTasks,
           risk_profile: '',
           domain: scope?.domainName ?? '',

--- a/apps/worker/src/jobs/promotion-eligibility-check.ts
+++ b/apps/worker/src/jobs/promotion-eligibility-check.ts
@@ -1,5 +1,10 @@
 import { createLogger } from '@skytwin/core';
-import { mcpServerRepository, promotionOffersRepository, query } from '@skytwin/db';
+import {
+  mcpServerRepository,
+  promotionOffersRepository,
+  trustTierAuditRepository,
+  query,
+} from '@skytwin/db';
 import { TrustTierEngine } from '@skytwin/policy-engine';
 import { PROMOTION_THRESHOLDS } from '@skytwin/shared-types';
 import type { TrustTier } from '@skytwin/shared-types';
@@ -99,6 +104,14 @@ export async function runPromotionEligibilityCheckJob(): Promise<PromotionEligib
       // block and never incremented this counter.
       evaluated++;
 
+      // Soak floor (spec 10 Part C, #483): populate hoursInCurrentTier so the
+      // engine actually enforces minDurationInTierHours. Previously omitted, so
+      // a user could be offered observer->suggest within one session. Measured
+      // from the last tier change or account creation (fail-safe 0 = blocked).
+      const hoursInCurrentTier = await trustTierAuditRepository.hoursInCurrentTier(
+        server.user_id,
+      );
+
       const evaluation = engine.evaluateProgression(currentTier, {
         totalApprovals: approvedActions,
         totalRejections: totalActions - approvedActions,
@@ -107,6 +120,7 @@ export async function runPromotionEligibilityCheckJob(): Promise<PromotionEligib
         recentRejections: 0,
         hasCriticalUndo: false,
         approvalRatio,
+        hoursInCurrentTier,
       });
 
       if (evaluation.shouldChange && evaluation.recommendedTier) {

--- a/bin/skytwin-test-execution-stack
+++ b/bin/skytwin-test-execution-stack
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# skytwin-test-execution-stack — safe, repeatable end-to-end test of the
+# execution stack (events ingest → decision → policy/spend/risk gate → approval
+# → execution router → adapter → result + feedback), with ZERO real-world side
+# effects.
+#
+# Two independent safety layers guarantee nothing real is ever touched:
+#   1. ISOLATED, TOKENLESS test user — the Direct adapter's Gmail/Calendar
+#      handlers call resolveAccessToken() FIRST and throw before any network
+#      fetch, so a user with no OAuth token physically cannot reach Google.
+#   2. USE_MOCK_IRONCLAW=true — execution routes to the simulated IronClaw
+#      adapter (no HTTP at all).
+#
+# It spins up its own mock-mode API on a test port (default 3120), so it never
+# touches a running demo/prod API. Re-runnable: it resets the test user's
+# decision tree on each run.
+#
+# Usage:
+#   bin/skytwin-test-execution-stack
+#   API_PORT=3130 DATABASE_URL=postgres://… bin/skytwin-test-execution-stack
+#
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+API_PORT="${API_PORT:-3120}"
+API="http://localhost:${API_PORT}/api"
+DBURL="${DATABASE_URL:-postgresql://root@127.0.0.1:26257/skytwin?sslmode=disable}"
+U="dddddddd-0000-4000-8000-000000000001"   # reserved isolated test user
+LOG="$(mktemp -t skytwin-exec-test-XXXX.log)"
+psql_q() { psql "$DBURL" -At -c "$1" 2>/dev/null | grep -iv '^time:'; }
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+echo "[1/6] reset isolated tokenless test user (no OAuth token => cannot reach Google)"
+psql "$DBURL" -q >/dev/null 2>&1 <<SQL
+DELETE FROM execution_results WHERE plan_id IN (SELECT id FROM execution_plans WHERE decision_id IN (SELECT id FROM decisions WHERE user_id='$U'));
+DELETE FROM execution_plans   WHERE decision_id IN (SELECT id FROM decisions WHERE user_id='$U');
+DELETE FROM approval_requests WHERE user_id='$U';
+DELETE FROM decision_outcomes WHERE decision_id IN (SELECT id FROM decisions WHERE user_id='$U');
+DELETE FROM candidate_actions WHERE decision_id IN (SELECT id FROM decisions WHERE user_id='$U');
+DELETE FROM decisions WHERE user_id='$U';
+DELETE FROM oauth_tokens WHERE user_id='$U';
+INSERT INTO users (id, email, name, trust_tier, is_demo) VALUES ('$U','exec-test@local.test','Exec Test','observer',false)
+  ON CONFLICT (id) DO UPDATE SET trust_tier='observer';
+INSERT INTO twin_profiles (user_id, version) VALUES ('$U', 1) ON CONFLICT (user_id) DO NOTHING;
+SQL
+[ "$(psql_q "SELECT count(*) FROM oauth_tokens WHERE user_id='$U'")" = "0" ] || fail "test user must be tokenless"
+
+echo "[2/6] start mock-adapter API on :$API_PORT (USE_MOCK_IRONCLAW=true)"
+SKYTWIN_DEV_AUTH_BYPASS=true NODE_ENV=development USE_MOCK_IRONCLAW=true API_PORT="$API_PORT" \
+  DATABASE_URL="$DBURL" node apps/api/dist/index.js >"$LOG" 2>&1 &
+API_PID=$!
+trap 'kill "$API_PID" 2>/dev/null; rm -f "$LOG"' EXIT
+for _ in $(seq 1 20); do
+  [ "$(curl -s -o /dev/null -w '%{http_code}' "$API/health" 2>/dev/null)" = "200" ] && break; sleep 0.5
+done
+grep -q "Registered Mock IronClaw adapter" "$LOG" || fail "mock adapter not registered (see $LOG)"
+
+echo "[3/6] ingest a FAKE email (synthetic, untrusted origin)"
+curl -s -X POST "$API/events/ingest" -H 'content-type: application/json' -d '{
+  "userId":"'"$U"'","source":"gmail","type":"message",
+  "data":{"subject":"FAKE TEST — execution-stack harness","snippet":"Synthetic. Not a real email.","from":"harness@fake.test","id":"FAKE_HARNESS_MSG","authoringTier":"inbox_automated"}
+}' -o /dev/null -w '' || fail "ingest failed"
+sleep 1
+
+echo "[4/6] find the pending approval the pipeline created"
+AID="$(curl -s "$API/approvals/$U/pending" | python3 -c 'import sys,json;a=json.load(sys.stdin).get("approvals",[]);print(a[0]["id"] if a else "")')"
+[ -n "$AID" ] || fail "no approval created (pipeline did not escalate)"
+
+echo "[5/6] approve -> gate + execution router + (mock) adapter"
+RESP="$(curl -s -X POST "$API/approvals/$AID/respond" -H 'content-type: application/json' -d '{"action":"approve","userId":"'"$U"'"}')"
+echo "$RESP" | python3 -c 'import sys,json;d=json.load(sys.stdin);e=d.get("execution") or {};print("    execution:",e.get("status"),"via",e.get("adapterUsed"))' \
+  || fail "approve did not execute (response: $RESP)"
+
+echo "[6/6] verify the stack executed and recorded a result"
+# Assert a result ROW exists (router → adapter → persisted result), not that it
+# succeeded: the mock IronClaw adapter simulates a ~5% failure rate by design,
+# so a recorded result (success OR simulated failure) is the proof the whole
+# chain ran to completion. Also confirm the approval reached a terminal state.
+N="$(psql_q "SELECT count(*) FROM execution_plans ep JOIN execution_results er ON er.plan_id=ep.id WHERE ep.decision_id IN (SELECT id FROM decisions WHERE user_id='$U')")"
+[ "${N:-0}" -ge 1 ] || fail "execution ran but no execution_result was recorded"
+SUCC="$(psql_q "SELECT er.success FROM execution_plans ep JOIN execution_results er ON er.plan_id=ep.id WHERE ep.decision_id IN (SELECT id FROM decisions WHERE user_id='$U') ORDER BY er.completed_at DESC LIMIT 1")"
+ST="$(psql_q "SELECT status FROM approval_requests WHERE id='$AID'")"
+echo "    approval=$ST  execution_result.success=$SUCC  (success=t completed; success=f = mock's simulated failure path — both prove the stack ran)"
+[ "$ST" = "approved" ] || fail "approval did not reach 'approved' (got: '$ST')"
+
+echo "PASS — execution stack ran end-to-end via the mock adapter; no real side effects."

--- a/docs/testing-openclaw.md
+++ b/docs/testing-openclaw.md
@@ -1,0 +1,140 @@
+# Testing the OpenClaw execution adapter (safely)
+
+How to exercise SkyTwin's OpenClaw execution adapter end-to-end without any real
+external side effects (no real Gmail/Calendar, no touching a running demo API).
+
+## What OpenClaw is, in this repo
+
+- `@skytwin/execution-router` exposes `OpenClawAdapter`
+  (`packages/execution-router/src/openclaw-adapter.ts`). It implements the
+  `IronClawAdapter` interface and talks to an OpenClaw **server** over HTTP:
+  `POST {apiUrl}/execute`, `POST {apiUrl}/rollback`, `GET {apiUrl}/health`,
+  `GET {apiUrl}/status/{planId}`.
+- `apps/openclaw-bridge/server.mjs` is a tiny reference OpenClaw server. It
+  bridges those endpoints to a **local Ollama** instance — it asks the model to
+  *reason about* an action and returns a simulated result. It never sends a real
+  email, books a real event, etc. That makes it the safe target for live tests.
+- The adapter makes **real HTTP calls** to whatever `apiUrl` you give it. Point
+  it at the bridge (local Ollama) and nothing real is touched. There is **no
+  built-in mock/dry-run** for OpenClaw — with no `apiUrl`, `execute()` *throws*
+  and `healthCheck()` reports unhealthy (by design — never silently succeeds).
+  Contrast IronClaw, which has `USE_MOCK_IRONCLAW=true`.
+
+## Config wiring (exact)
+
+`packages/config/src/index.ts`:
+
+- `OPENCLAW_API_URL` -> `config.openclawApiUrl` (default `''`)
+- `OPENCLAW_API_KEY` -> `config.openclawApiKey` (default `''`, optional; sent as
+  `Authorization: Bearer <key>` when present)
+
+`apps/api/src/execution-setup.ts` (`resolveOpenClawConfig` + `createExecutionRouter`):
+
+- The DB `serviceCredentialRepository` row for service `openclaw`
+  (`api_url`, `api_key`) **overrides** the env values.
+- OpenClaw is registered **only if** a non-empty `apiUrl` resolves. Otherwise you
+  get the log line: `OpenClaw not configured (no URL) — skipping`.
+- The bridge's default port is **3456** (`server.mjs`, `package.json` dev/start
+  scripts). `bin/skytwin-dev` and the root `package.json dev` script both default
+  `OPENCLAW_API_URL=http://localhost:3456`, i.e. the API expects the bridge there.
+  (Note: the comment header in `server.mjs` mentions a 4100 default — stale; the
+  code default is 3456.)
+
+Bridge env (`apps/openclaw-bridge/server.mjs`):
+
+- `OLLAMA_HOST` (default `http://localhost:11434`)
+- `OLLAMA_MODEL` (default `gemma4:latest`)
+- `BRIDGE_PORT` (code default `3456`)
+
+## Router selection — important nuance
+
+`packages/execution-router/src/execution-router.ts`:
+
+```
+const BUILTIN_TRUST_RANKING = ['ironclaw', 'direct', 'openclaw'];
+```
+
+OpenClaw is **last**. The `direct` adapter is registered with **no skill set**, so
+`AdapterRegistry.canHandle('direct', anyAction)` returns `true` for everything.
+Result: for any standard action type, the router selects `direct` (or `ironclaw`
+if configured) as **primary**, and OpenClaw is only a **fallback** that runs when
+the higher-trust adapter *throws* before/at execution.
+
+So to actually see OpenClaw do the work, do one of:
+
+1. **Isolated adapter test (cleanest):** instantiate `OpenClawAdapter` directly and
+   call `buildPlan()` + `execute()` against the bridge. No router, no DB.
+2. **Router with only OpenClaw registered:** build an `AdapterRegistry`, register
+   just `openclaw` with `OPENCLAW_TRUST_PROFILE` + `OPENCLAW_SKILLS`, and route.
+3. **Force fallback:** register a primary adapter whose `buildPlan`/`execute`
+   throws for the chosen action type, so the router falls through to OpenClaw.
+
+`OPENCLAW_TRUST_PROFILE`: `reversibilityGuarantee: 'none'`, `authModel: 'api_key'`,
+`riskModifier: 1` (so irreversible actions get a +1 risk-tier bump under OpenClaw).
+
+## Safe live-test steps (verified working on this machine)
+
+Prereqs (already true here): Ollama installed (`/usr/local/bin/ollama`), running on
+`:11434`, with `gemma4:latest` pulled.
+
+```bash
+# 0. (only if needed) install + start Ollama and pull a model
+#    brew install ollama && ollama serve &  # or: open -a Ollama
+#    ollama pull gemma4:latest
+
+# 1. Start the bridge on an ISOLATED port (4199), away from the demo API and
+#    away from the default 3456 so it can't be picked up by anything by accident.
+cd apps/openclaw-bridge
+BRIDGE_PORT=4199 OLLAMA_MODEL=gemma4:latest node server.mjs &
+# wait for it to bind, then:
+curl -s http://localhost:4199/health        # -> {"status":"ok",...,"modelAvailable":true}
+
+# 2. Fire a FAKE action at /execute (mirrors the exact shape OpenClawAdapter
+#    POSTs). Nothing real is touched — the bridge only asks Ollama to reason.
+curl -s http://localhost:4199/execute -H 'Content-Type: application/json' -d '{
+  "planId": "test_plan_safe_001",
+  "decisionId": "test_decision_safe_001",
+  "action": {
+    "type": "archive_email",
+    "description": "Archive a newsletter from test@example.invalid",
+    "parameters": { "messageId": "FAKE-MSG-DOES-NOT-EXIST", "userId": "test-user-no-tokens" },
+    "domain": "email"
+  },
+  "steps": [
+    { "id": "step_1", "type": "archive_email", "description": "Archive the message",
+      "parameters": { "messageId": "FAKE-MSG-DOES-NOT-EXIST" } }
+  ]
+}'
+# -> {"status":"completed","adapter":"openclaw-bridge","model":"gemma4:latest",...,"latencyMs":~19000}
+
+# 3. Rollback (always simulated in bridge mode):
+curl -s http://localhost:4199/rollback -H 'Content-Type: application/json' \
+  -d '{"planId":"test_plan_safe_001"}'
+# -> {"status":"rolled_back",...}
+
+# 4. Clean up
+kill %1   # or kill the bridge PID
+```
+
+### Optional: full router path against the bridge, via the API
+
+Only do this against a **non-production API instance** (do NOT restart the demo API
+on :3110). Start a *separate* API with OpenClaw pointed at the bridge:
+
+```bash
+OPENCLAW_API_URL=http://localhost:4199 API_PORT=3120 \
+  node apps/api/dist/index.js
+```
+
+Then trigger an action through the decision/approval flow for an **isolated,
+tokenless test user**. Because `direct` outranks `openclaw`, pick an action type
+the direct handlers reject (so the router falls back to OpenClaw), or assert on the
+adapter in an isolated unit test (option 1/2 above) instead.
+
+## Safety notes
+
+- The bridge only reaches **local Ollama**. No outbound internet, no Gmail/Calendar.
+- Use a **tokenless test user** + **fake message/event IDs** so even the `direct`
+  path (if it ever runs) has nothing real to act on.
+- Don't reuse the demo API's port (3110) or DB-stored `openclaw` credentials.
+- Keep the bridge on an isolated port; tear it down when finished.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint": "turbo run lint",
     "db:migrate": "pnpm --filter @skytwin/db migrate",
     "db:seed": "pnpm --filter @skytwin/db seed",
+    "demo:fixture": "pnpm --filter @skytwin/db demo:fixture",
     "desktop": "pnpm --filter skytwin-desktop start",
     "desktop:dev": "pnpm --filter skytwin-desktop dev",
     "desktop:build:mac": "pnpm build && pnpm --filter skytwin-desktop package:mac",

--- a/packages/connectors/src/authoring-tier.ts
+++ b/packages/connectors/src/authoring-tier.ts
@@ -17,6 +17,14 @@
 export type AuthoringTier =
   | 'user_sent_originated'
   | 'user_sent_reply'
+  // Non-email authored/received tiers (#251 channel-agnostic extension, spec 07).
+  // `authored_originated` = the user created this doc/event/voice note;
+  // `received_shared` = someone shared it with the user. These let downstream
+  // capabilities (e.g. commitment extraction) treat self-authored non-email
+  // content the same as `user_sent_*` mail. Mapped via `isAuthoredByUser` in
+  // `@skytwin/decision-engine` (signal-text.ts).
+  | 'authored_originated'
+  | 'received_shared'
   | 'inbox_personal'
   | 'inbox_broadcast'
   | 'inbox_newsletter'

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,6 +16,7 @@
     "dev": "tsc --watch",
     "migrate": "tsx src/migrations/001-initial.ts",
     "seed": "tsx src/seeds/seed.ts",
+    "demo:fixture": "tsx src/seeds/demo-fixture.ts",
     "generate": "tsc --declaration --emitDeclarationOnly",
     "test": "vitest run",
     "lint": "tsc --noEmit"

--- a/packages/db/src/__tests__/demo-guard.test.ts
+++ b/packages/db/src/__tests__/demo-guard.test.ts
@@ -59,6 +59,12 @@ describe('isLocalDbTarget', () => {
     expect(isLocalDbTarget('postgresql://db.example.com/skytwin')).toBe(false);
     expect(isLocalDbTarget('10.0.0.5')).toBe(false);
   });
+
+  it('is not fooled by hosts that merely CONTAIN localhost/127.0.0.1 (review #8)', () => {
+    expect(isLocalDbTarget('postgresql://user:pass@localhost-fake.evil.com/db')).toBe(false);
+    expect(isLocalDbTarget('postgresql://evil.com/db?host=localhost')).toBe(false);
+    expect(isLocalDbTarget('postgresql://127.0.0.1.evil.com/db')).toBe(false);
+  });
 });
 
 describe('assertDemoUser — identity isolation (GATE 3)', () => {

--- a/packages/db/src/__tests__/demo-guard.test.ts
+++ b/packages/db/src/__tests__/demo-guard.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  assertDemoSafe,
+  assertDemoUser,
+  isLocalDbTarget,
+  REQUIRED_OVERRIDE_TOKEN,
+} from '../seeds/demo-guard.js';
+
+const local = { nodeEnv: 'development', dbTarget: 'postgresql://localhost:26257/skytwin', explicitOptIn: true };
+
+describe('assertDemoSafe — three-gate guard (spec 09 invariant #0)', () => {
+  it('passes for an explicitly-requested local dev run', () => {
+    expect(assertDemoSafe(local).ok).toBe(true);
+  });
+
+  it('GATE 1: refuses when not explicitly requested (never implicit / never for new users)', () => {
+    const r = assertDemoSafe({ ...local, explicitOptIn: false });
+    expect(r.ok).toBe(false);
+  });
+
+  it('GATE 2: hard-blocks production even WITH the override token', () => {
+    const r = assertDemoSafe({
+      nodeEnv: 'production',
+      dbTarget: 'postgresql://localhost/skytwin',
+      explicitOptIn: true,
+      overrideToken: REQUIRED_OVERRIDE_TOKEN,
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('GATE 2: refuses a non-local DB without the override token', () => {
+    const r = assertDemoSafe({
+      nodeEnv: 'development',
+      dbTarget: 'postgresql://prod-db.example.com:26257/skytwin',
+      explicitOptIn: true,
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('GATE 2: allows a non-local DB only WITH the correct override token (non-prod)', () => {
+    const r = assertDemoSafe({
+      nodeEnv: 'development',
+      dbTarget: 'postgresql://staging-db.example.com/skytwin',
+      explicitOptIn: true,
+      overrideToken: REQUIRED_OVERRIDE_TOKEN,
+    });
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('isLocalDbTarget', () => {
+  it('treats localhost / 127.0.0.1 / ::1 / unset as local', () => {
+    expect(isLocalDbTarget('postgresql://localhost:26257')).toBe(true);
+    expect(isLocalDbTarget('127.0.0.1')).toBe(true);
+    expect(isLocalDbTarget(undefined)).toBe(true);
+    expect(isLocalDbTarget('')).toBe(true);
+  });
+  it('treats remote hosts as non-local', () => {
+    expect(isLocalDbTarget('postgresql://db.example.com/skytwin')).toBe(false);
+    expect(isLocalDbTarget('10.0.0.5')).toBe(false);
+  });
+});
+
+describe('assertDemoUser — identity isolation (GATE 3)', () => {
+  it('throws when asked to write to a non-demo (real) user', () => {
+    expect(() => assertDemoUser('real-user', false)).toThrow(/non-demo user/);
+  });
+  it('allows writes to a demo-flagged user', () => {
+    expect(() => assertDemoUser('demo-user', true)).not.toThrow();
+  });
+});

--- a/packages/db/src/__tests__/upsert.test.ts
+++ b/packages/db/src/__tests__/upsert.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildUpsertSql, seedUpsert, type Queryable } from '../seeds/upsert.js';
+
+describe('buildUpsertSql (spec 10 Part B)', () => {
+  it('builds a parameterized INSERT ... ON CONFLICT DO UPDATE (default mode)', () => {
+    const { text, values } = buildUpsertSql({
+      table: 'users',
+      row: { id: 'u1', email: 'a@x.com', name: 'A' },
+      conflict: ['id'],
+    });
+    expect(text).toBe(
+      'INSERT INTO "users" ("id", "email", "name") VALUES ($1, $2, $3) ' +
+        'ON CONFLICT ("id") DO UPDATE SET "email" = EXCLUDED."email", "name" = EXCLUDED."name"',
+    );
+    expect(values).toEqual(['u1', 'a@x.com', 'A']);
+  });
+
+  it('supports DO NOTHING', () => {
+    const { text } = buildUpsertSql({
+      table: 'twin_profiles',
+      row: { user_id: 'u1', version: 1 },
+      conflict: ['user_id'],
+      update: 'nothing',
+    });
+    expect(text).toContain('ON CONFLICT ("user_id") DO NOTHING');
+    expect(text).not.toContain('DO UPDATE');
+  });
+
+  it('supports an explicit update-column subset', () => {
+    const { text } = buildUpsertSql({
+      table: 't',
+      row: { id: 1, a: 2, b: 3, c: 4 },
+      conflict: ['id'],
+      update: ['a', 'c'],
+    });
+    expect(text).toContain('DO UPDATE SET "a" = EXCLUDED."a", "c" = EXCLUDED."c"');
+    expect(text).not.toContain('"b" = EXCLUDED."b"');
+  });
+
+  it('degrades to DO NOTHING when every column is a conflict key', () => {
+    const { text } = buildUpsertSql({
+      table: 'link',
+      row: { left_id: 'l', right_id: 'r' },
+      conflict: ['left_id', 'right_id'],
+    });
+    expect(text).toContain('DO NOTHING');
+  });
+
+  it('quotes identifiers and escapes embedded quotes (injection-resistant identifiers)', () => {
+    const { text } = buildUpsertSql({
+      table: 'we"ird',
+      row: { 'co"l': 1 },
+      conflict: ['co"l'],
+    });
+    expect(text).toContain('"we""ird"');
+    expect(text).toContain('"co""l"');
+  });
+
+  it('throws on empty row or empty conflict set', () => {
+    expect(() => buildUpsertSql({ table: 't', row: {}, conflict: ['id'] })).toThrow();
+    expect(() => buildUpsertSql({ table: 't', row: { id: 1 }, conflict: [] })).toThrow();
+  });
+});
+
+describe('seedUpsert execution', () => {
+  it('executes the built SQL against the client with bound values', async () => {
+    const client: Queryable = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    await seedUpsert(client, {
+      table: 'users',
+      row: { id: 'u1', email: 'a@x.com' },
+      conflict: ['id'],
+    });
+    expect(client.query).toHaveBeenCalledTimes(1);
+    const call = (client.query as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(call[0] as string).toContain('INSERT INTO "users"');
+    expect(call[1]).toEqual(['u1', 'a@x.com']);
+  });
+
+  it('is safe to call repeatedly with the same row (idempotent by construction)', async () => {
+    const client: Queryable = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    const spec = { table: 'users', row: { id: 'u1' }, conflict: ['id'], update: 'nothing' as const };
+    await seedUpsert(client, spec);
+    await seedUpsert(client, spec);
+    const calls = (client.query as ReturnType<typeof vi.fn>).mock.calls;
+    const sql0 = calls[0]![0] as string;
+    const sql1 = calls[1]![0] as string;
+    expect(sql0).toBe(sql1); // identical idempotent statement
+    expect(sql0).toContain('DO NOTHING');
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -8,6 +8,10 @@
 export { getPool, query, withTransaction, healthCheck, closePool, getPoolStats } from './connection.js';
 export type { DatabaseConfig } from './connection.js';
 
+// Idempotent seed/provision helper (spec 10 Part B) — shared by the launch
+// demo fixture (spec 09) and any re-runnable seed path.
+export { seedUpsert, buildUpsertSql, type UpsertSpec, type Queryable } from './seeds/upsert.js';
+
 // Row types
 export type {
   OAuthTokenRowWithEncrypted,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -12,6 +12,18 @@ export type { DatabaseConfig } from './connection.js';
 // demo fixture (spec 09) and any re-runnable seed path.
 export { seedUpsert, buildUpsertSql, type UpsertSpec, type Queryable } from './seeds/upsert.js';
 
+// Launch demo-fixture safety guard (spec 09 invariant #0) — never runs for a
+// real or new user.
+export {
+  assertDemoSafe,
+  assertDemoUser,
+  isLocalDbTarget,
+  REQUIRED_OVERRIDE_TOKEN,
+  DEMO_USER_ID,
+  type DemoGuardEnv,
+  type DemoGuardResult,
+} from './seeds/demo-guard.js';
+
 // Row types
 export type {
   OAuthTokenRowWithEncrypted,

--- a/packages/db/src/migrations/063-user-locale-timezone.sql
+++ b/packages/db/src/migrations/063-user-locale-timezone.sql
@@ -1,0 +1,15 @@
+-- 063-user-locale-timezone.sql
+-- Per-user language + timezone (spec 12, #486).
+--
+-- `language` drives the daily-briefing prose locale (was hardcoded 'en' in
+-- briefing-generator.ts) and lets the extraction layer route non-English
+-- content to the LLM path instead of the English-only rule fallbacks.
+-- `timezone` resolves relative deadlines (spec 03 — "by Friday", "end of day")
+-- to the user's clock instead of UTC.
+--
+-- Both nullable: populated from the connector identity (Google profile locale,
+-- primary-calendar timezone) when available, with safe fallbacks resolved in
+-- code (language -> 'en', timezone -> 'UTC' with a logged warning). Existing
+-- rows backfill NULL and fall back at read time — no data migration needed.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS language STRING;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS timezone STRING;

--- a/packages/db/src/migrations/064-users-is-demo.sql
+++ b/packages/db/src/migrations/064-users-is-demo.sql
@@ -1,0 +1,9 @@
+-- 064-users-is-demo.sql
+-- Identity-isolation marker for the launch demo fixture (spec 09, #482).
+--
+-- The demo fixture (opt-in, local-only) writes synthetic data ONLY under users
+-- flagged is_demo = true; its guard refuses to touch any is_demo = false (real)
+-- user, and --reset deletes only is_demo = true rows. Real users default false,
+-- so a brand-new user ("grandma") can never be mistaken for a demo user even if
+-- the fixture is mis-invoked. Additive + nullable-safe (DEFAULT false).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS is_demo BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/src/repositories/decision-repository.ts
+++ b/packages/db/src/repositories/decision-repository.ts
@@ -179,6 +179,12 @@ export const decisionRepository = {
       paramIndex++;
     }
 
+    if (opts.signalId) {
+      conditions.push(`signal_id = $${paramIndex}`);
+      values.push(opts.signalId);
+      paramIndex++;
+    }
+
     if (opts.from) {
       conditions.push(`created_at >= $${paramIndex}`);
       values.push(opts.from);

--- a/packages/db/src/repositories/decision-repository.ts
+++ b/packages/db/src/repositories/decision-repository.ts
@@ -350,10 +350,10 @@ export const decisionRepository = {
   /**
    * Batch-fetch outcomes for multiple decisions in a single query.
    */
-  async getOutcomesForDecisions(decisionIds: string[]): Promise<Pick<DecisionOutcomeRow, 'decision_id' | 'auto_executed'>[]> {
+  async getOutcomesForDecisions(decisionIds: string[]): Promise<Pick<DecisionOutcomeRow, 'decision_id' | 'auto_executed' | 'requires_approval'>[]> {
     if (decisionIds.length === 0) return [];
-    const result = await query<Pick<DecisionOutcomeRow, 'decision_id' | 'auto_executed'>>(
-      'SELECT decision_id, auto_executed FROM decision_outcomes WHERE decision_id = ANY($1)',
+    const result = await query<Pick<DecisionOutcomeRow, 'decision_id' | 'auto_executed' | 'requires_approval'>>(
+      'SELECT decision_id, auto_executed, requires_approval FROM decision_outcomes WHERE decision_id = ANY($1)',
       [decisionIds],
     );
     return result.rows;

--- a/packages/db/src/repositories/trust-tier-audit-repository.ts
+++ b/packages/db/src/repositories/trust-tier-audit-repository.ts
@@ -82,4 +82,26 @@ export const trustTierAuditRepository = {
     );
     return parseInt(result.rows[0]?.count ?? '0', 10);
   },
+
+  /**
+   * Hours the user has spent in their current tier — measured from the most
+   * recent tier change, or from account creation when they've never changed
+   * tier (e.g. a new user still at the initial `observer` tier). Feeds the
+   * promotion soak-floor (spec 10 Part C, #483): without it the daily
+   * promotion-eligibility job omits `hoursInCurrentTier`, so the engine skips
+   * the `minDurationInTierHours` floor entirely (documented gap,
+   * docs/safety-model.md). Fail-safe: returns 0 when the time can't be
+   * determined, which keeps a promotion BLOCKED rather than granted early.
+   */
+  async hoursInCurrentTier(userId: string): Promise<number> {
+    const result = await query<{ hours: string | null }>(
+      `SELECT EXTRACT(EPOCH FROM (now() - COALESCE(
+          (SELECT created_at FROM trust_tier_audit WHERE user_id = $1 ORDER BY created_at DESC LIMIT 1),
+          (SELECT created_at FROM users WHERE id = $1)
+        ))) / 3600.0 AS hours`,
+      [userId],
+    );
+    const hours = result.rows[0]?.hours;
+    return hours == null ? 0 : Math.max(0, parseFloat(hours));
+  },
 };

--- a/packages/db/src/repositories/user-repository.ts
+++ b/packages/db/src/repositories/user-repository.ts
@@ -126,6 +126,18 @@ export const userRepository = {
   },
 
   /**
+   * Read a user's language + timezone (spec 12, #486). Returns nulls when
+   * unset; callers resolve safe fallbacks via resolveLanguage/resolveTimezone.
+   */
+  async getLocale(id: string): Promise<{ language: string | null; timezone: string | null }> {
+    const result = await query<{ language: string | null; timezone: string | null }>(
+      `SELECT language, timezone FROM users WHERE id = $1`,
+      [id],
+    );
+    return result.rows[0] ?? { language: null, timezone: null };
+  },
+
+  /**
    * Update a user's trust tier.
    */
   async updateTrustTier(

--- a/packages/db/src/seeds/demo-fixture.ts
+++ b/packages/db/src/seeds/demo-fixture.ts
@@ -1,0 +1,126 @@
+/**
+ * Launch demo fixture (spec 09, #482) — opt-in, isolated, idempotent.
+ *
+ * Populates a reserved demo user with a rich, synthetic, source-varied signal
+ * set so every digest surface can be exercised and screenshotted. Runs ONLY via
+ * this command (never wired into bin/skytwin-dev or any startup path), guards
+ * with assertDemoSafe before writing anything, and isolates every write to the
+ * demo user (is_demo = true). See demo-guard.ts for invariant #0.
+ *
+ *   pnpm demo:fixture                 # populate (local dev only)
+ *   pnpm demo:fixture --reset         # delete demo data only
+ *   pnpm demo:fixture --i-understand-this-writes-demo-data   # allow non-local DB
+ */
+
+import { getPool, withTransaction, closePool } from '../connection.js';
+import { seedUpsert } from './upsert.js';
+import {
+  assertDemoSafe,
+  REQUIRED_OVERRIDE_TOKEN,
+  DEMO_USER_ID,
+  type DemoGuardEnv,
+} from './demo-guard.js';
+import { DEMO_SIGNALS } from './demo-fixtures/signals.js';
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const reset = argv.includes('--reset');
+  const overrideToken = argv.includes(`--${REQUIRED_OVERRIDE_TOKEN}`)
+    ? REQUIRED_OVERRIDE_TOKEN
+    : undefined;
+
+  // Gate 1+2: explicit (this command IS the opt-in) + environment safety.
+  const env: DemoGuardEnv = {
+    nodeEnv: process.env.NODE_ENV,
+    dbTarget: process.env.DATABASE_URL,
+    explicitOptIn: true,
+    overrideToken,
+  };
+  const guard = assertDemoSafe(env);
+  if (!guard.ok) {
+    console.error(`[demo:fixture] REFUSED — ${guard.reason}`);
+    process.exit(1);
+    return;
+  }
+
+  getPool();
+
+  if (reset) {
+    // Gate 3 by predicate: only is_demo rows are touched. Owned rows cascade.
+    await withTransaction(async (client) => {
+      await client.query(`DELETE FROM users WHERE is_demo = true`);
+    });
+    console.log('[demo:fixture] reset complete — removed is_demo users only.');
+    await closePool();
+    return;
+  }
+
+  // Upsert the reserved demo user (is_demo = true) + an empty profile.
+  await withTransaction(async (client) => {
+    await seedUpsert(client, {
+      table: 'users',
+      row: {
+        id: DEMO_USER_ID,
+        email: 'demo@local.demo',
+        name: 'Demo User',
+        trust_tier: 'moderate_autonomy',
+        autonomy_settings: JSON.stringify({ maxAutoSpend: 5000 }),
+        is_demo: true,
+      },
+      conflict: ['id'],
+      update: 'all',
+    });
+    await seedUpsert(client, {
+      table: 'twin_profiles',
+      row: { user_id: DEMO_USER_ID, version: 1 },
+      conflict: ['user_id'],
+      update: 'nothing',
+    });
+  });
+
+  // Ingest synthetic signals through the real pipeline (spec's preferred path),
+  // so the digest reflects true system output. Requires the local API to be up
+  // (./bin/skytwin-dev). Best-effort: log guidance if it isn't.
+  const apiUrl = process.env.SKYTWIN_API_URL ?? 'http://localhost:3100';
+  let ingested = 0;
+  for (const sig of DEMO_SIGNALS) {
+    try {
+      const res = await fetch(`${apiUrl}/api/events/ingest`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          userId: DEMO_USER_ID,
+          source: sig.source,
+          type: sig.type,
+          data: sig.data,
+        }),
+      });
+      if (res.ok) ingested++;
+    } catch {
+      // API not running — fall through to guidance below.
+      break;
+    }
+  }
+
+  if (ingested === DEMO_SIGNALS.length) {
+    console.log(
+      `[demo:fixture] done — demo user provisioned, ${ingested} synthetic signals ingested.\n` +
+        'Trigger the worker briefing (or wait for its cycle), then screenshot:\n' +
+        '  • /briefing — to-dos vs topics, source chips, citations\n' +
+        '  • dashboard — trust-tier progress, recent activity\n' +
+        '  • mobile BriefingScreen',
+    );
+  } else {
+    console.log(
+      `[demo:fixture] demo user provisioned; ingested ${ingested}/${DEMO_SIGNALS.length} signals.\n` +
+        `Start the local stack (./bin/skytwin-dev) so ${apiUrl}/api/events/ingest is reachable, then re-run.`,
+    );
+  }
+
+  await closePool();
+}
+
+main().catch((err) => {
+  console.error('[demo:fixture] failed:', err);
+  process.exit(1);
+});

--- a/packages/db/src/seeds/demo-fixtures/signals.ts
+++ b/packages/db/src/seeds/demo-fixtures/signals.ts
@@ -1,0 +1,105 @@
+/**
+ * Synthetic, source-varied signal corpus for the launch demo fixture (spec 09).
+ *
+ * All content is fictional — no real names, companies, amounts, or dates. Each
+ * entry is shaped like a connector RawSignal payload and is designed to light up
+ * a specific capability so the digest looks dense-but-real for screenshots:
+ * to-dos, FYI clusters, deadlines, commitments, a security alert, and recurring
+ * entities across sources.
+ */
+
+export interface DemoSignal {
+  source: 'gmail' | 'google_calendar' | 'filesystem' | 'voice';
+  type: string;
+  data: Record<string, unknown>;
+}
+
+export const DEMO_SIGNALS: DemoSignal[] = [
+  // email — security alert (spec 06): escalate-only, prominent
+  {
+    source: 'gmail',
+    type: 'message',
+    data: {
+      subject: 'Account notice',
+      snippet: 'We detected a sign-in from a new device on your account.',
+      from: 'no-reply@accounts.example',
+      authoringTier: 'inbox_automated',
+    },
+  },
+  // email — deadline (spec 03) + FYI
+  {
+    source: 'gmail',
+    type: 'message',
+    data: {
+      subject: 'Trial ending soon',
+      snippet: 'Your workspace trial ends in 2 days. Upgrade to keep premium features.',
+      from: 'billing@saas.example',
+      authoringTier: 'inbox_newsletter',
+    },
+  },
+  // email — authored commitment (spec 02) → to-do
+  {
+    source: 'gmail',
+    type: 'message',
+    data: {
+      subject: 'Re: vendor onboarding',
+      snippet: "Thanks — I'll send the signed form by Friday and loop in the team.",
+      from: 'me@demo.example',
+      to: 'partner@acme-demo.example',
+      authoringTier: 'user_sent_reply',
+    },
+  },
+  // calendar — invite (entity: Acme recurs across signals)
+  {
+    source: 'google_calendar',
+    type: 'meeting_invite',
+    data: {
+      title: 'Acme kickoff',
+      description: 'Intro call with the Acme team. Agenda attached.',
+      organizer: 'partner@acme-demo.example',
+      attendees: [{ email: 'partner@acme-demo.example' }],
+      authoringTier: 'received_shared',
+      requiresResponse: true,
+    },
+  },
+  // calendar — authored event description with a commitment
+  {
+    source: 'google_calendar',
+    type: 'calendar_event',
+    data: {
+      title: 'Prep for review',
+      description: "I'll finish the deck before this and share it tonight.",
+      organizer: 'me@demo.example',
+      authoringTier: 'authored_originated',
+    },
+  },
+  // filesystem (idle-miner) — TODO with a deadline
+  {
+    source: 'filesystem',
+    type: 'file',
+    data: {
+      fileName: 'ROADMAP.md',
+      excerpt: '// TODO: ship the export pipeline by the 15th',
+    },
+  },
+  // voice — transcribed note with a commitment (multi-source showcase)
+  {
+    source: 'voice',
+    type: 'transcript',
+    data: {
+      transcript: "Note to self — I'll call the Acme partner on Monday about pricing.",
+      authoringTier: 'authored_originated',
+    },
+  },
+  // email — FYI newsletter (awareness cluster filler)
+  {
+    source: 'gmail',
+    type: 'message',
+    data: {
+      subject: 'Weekly product digest',
+      snippet: 'Highlights from the community this week.',
+      from: 'news@community.example',
+      authoringTier: 'inbox_newsletter',
+    },
+  },
+];

--- a/packages/db/src/seeds/demo-guard.ts
+++ b/packages/db/src/seeds/demo-guard.ts
@@ -1,0 +1,84 @@
+/**
+ * Demo-fixture safety guard (#spec 09, #482) — invariant #0.
+ *
+ * The launch demo fixture must NEVER run for a real or new user. This is the
+ * three-gate guard that runs BEFORE the fixture writes anything. All three must
+ * pass:
+ *   1. Explicit request   — the command/env was deliberately invoked.
+ *   2. Environment safety  — never production; non-local DB needs a loud override
+ *                            (and even then production stays hard-blocked).
+ *   3. Identity isolation  — only ever writes under reserved demo identities
+ *                            (asserted per-user at write time via assertDemoUser).
+ *
+ * Pure + exhaustively tested so the gates can't silently regress.
+ */
+
+export interface DemoGuardEnv {
+  /** NODE_ENV. */
+  nodeEnv: string | undefined;
+  /** DB connection target (host or URL); empty/undefined treated as local. */
+  dbTarget: string | undefined;
+  /** True only when the demo command / SKYTWIN_DEMO_FIXTURE=1 was deliberately set. */
+  explicitOptIn: boolean;
+  /** The loud override token, required to run against a non-local DB. */
+  overrideToken?: string | undefined;
+}
+
+export type DemoGuardResult = { ok: true } | { ok: false; reason: string };
+
+/** The exact token a caller must pass to run against a non-local DB. */
+export const REQUIRED_OVERRIDE_TOKEN = 'i-understand-this-writes-demo-data';
+
+/** Reserved demo user id (matches the seed demo user). */
+export const DEMO_USER_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
+
+/** Local DB targets the fixture may run against without an override. */
+export function isLocalDbTarget(target: string | undefined): boolean {
+  const t = (target ?? '').trim().toLowerCase();
+  if (t === '') return true; // unset → local dev default
+  return (
+    t.includes('localhost') ||
+    t.includes('127.0.0.1') ||
+    t.includes('::1') ||
+    t.includes('@localhost') ||
+    t.startsWith('postgresql://localhost') ||
+    t.startsWith('postgres://localhost')
+  );
+}
+
+/**
+ * The three-gate safety check. Returns ok:false with a reason rather than
+ * throwing, so the caller can print a clear message and exit non-zero.
+ */
+export function assertDemoSafe(env: DemoGuardEnv): DemoGuardResult {
+  // Gate 1 — explicit request.
+  if (!env.explicitOptIn) {
+    return { ok: false, reason: 'not explicitly requested (run `pnpm demo:fixture` or set SKYTWIN_DEMO_FIXTURE=1)' };
+  }
+  // Gate 2 — environment safety. Production is hard-blocked: NO override unblocks it.
+  if ((env.nodeEnv ?? '').toLowerCase() === 'production') {
+    return { ok: false, reason: 'refuses to run in production (no override)' };
+  }
+  if (!isLocalDbTarget(env.dbTarget)) {
+    if (env.overrideToken !== REQUIRED_OVERRIDE_TOKEN) {
+      return {
+        ok: false,
+        reason: `non-local DB target requires --i-understand-this-writes-demo-data (token "${REQUIRED_OVERRIDE_TOKEN}")`,
+      };
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * Gate 3 (per-write): refuse to touch any user that is not demo-namespaced.
+ * Throws — the fixture must abort rather than write to a real user.
+ */
+export function assertDemoUser(userId: string, isDemo: boolean): void {
+  if (!isDemo) {
+    throw new Error(
+      `demo fixture refused to write to non-demo user ${userId} (is_demo=false). ` +
+        'Identity isolation (spec 09 invariant #0).',
+    );
+  }
+}

--- a/packages/db/src/seeds/demo-guard.ts
+++ b/packages/db/src/seeds/demo-guard.ts
@@ -34,16 +34,19 @@ export const DEMO_USER_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
 
 /** Local DB targets the fixture may run against without an override. */
 export function isLocalDbTarget(target: string | undefined): boolean {
-  const t = (target ?? '').trim().toLowerCase();
+  const t = (target ?? '').trim();
   if (t === '') return true; // unset → local dev default
-  return (
-    t.includes('localhost') ||
-    t.includes('127.0.0.1') ||
-    t.includes('::1') ||
-    t.includes('@localhost') ||
-    t.startsWith('postgresql://localhost') ||
-    t.startsWith('postgres://localhost')
-  );
+  const LOCAL = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+  // Exact HOST match, not substring (review #8): 'localhost-fake.evil.com' and
+  // 'evil.com?host=localhost' and '127.0.0.1.evil.com' must NOT read as local.
+  try {
+    const u = new URL(t);
+    return LOCAL.has(u.hostname.toLowerCase());
+  } catch {
+    // Bare host (no scheme) — match the first host token exactly.
+    const host = (t.toLowerCase().split(/[:/?]/)[0] ?? '').trim();
+    return LOCAL.has(host);
+  }
 }
 
 /**

--- a/packages/db/src/seeds/upsert.ts
+++ b/packages/db/src/seeds/upsert.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared idempotent upsert helper for seed/provision code (spec 10 Part B).
+ *
+ * `buildUpsertSql` is a pure SQL builder (no DB) so it can be unit-tested
+ * deterministically; `seedUpsert` executes it against any Postgres-shaped
+ * client. Used by the launch demo fixture (spec 09) and any seed path that must
+ * be safe to run more than once. Identifiers are code-supplied (trusted) and
+ * quoted; all VALUES are parameterized — never interpolate user data here.
+ *
+ * Note: the existing dev seed (`seed.ts`) already uses inline
+ * `INSERT ... ON CONFLICT`, so it is already idempotent; this helper exists to
+ * give new callers (spec 09) one shared, tested implementation rather than
+ * re-deriving the ON CONFLICT SQL each time.
+ */
+
+export interface Queryable {
+  query(text: string, values?: unknown[]): Promise<unknown>;
+}
+
+export interface UpsertSpec {
+  /** Target table name (code-supplied, trusted). */
+  table: string;
+  /** Column → value map. Keys are column names (trusted); values are bound. */
+  row: Record<string, unknown>;
+  /** Conflict-target columns (the unique/pk columns). */
+  conflict: string[];
+  /**
+   * On conflict: 'nothing' (DO NOTHING), 'all' (update every non-conflict
+   * column), or an explicit list of columns to update. Defaults to 'all'.
+   */
+  update?: 'nothing' | 'all' | string[];
+}
+
+/** Quote a SQL identifier (double-quote, escape embedded quotes). */
+function quoteIdent(id: string): string {
+  return `"${id.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Build a parameterized `INSERT ... ON CONFLICT` statement. Pure — no DB.
+ */
+export function buildUpsertSql(spec: UpsertSpec): { text: string; values: unknown[] } {
+  const columns = Object.keys(spec.row);
+  if (columns.length === 0) {
+    throw new Error(`seedUpsert: row for "${spec.table}" has no columns`);
+  }
+  if (spec.conflict.length === 0) {
+    throw new Error(`seedUpsert: "${spec.table}" needs at least one conflict column`);
+  }
+
+  const values = columns.map((c) => spec.row[c]);
+  const placeholders = columns.map((_, i) => `$${i + 1}`);
+  const conflictCols = spec.conflict.map(quoteIdent).join(', ');
+
+  const insert =
+    `INSERT INTO ${quoteIdent(spec.table)} (${columns.map(quoteIdent).join(', ')}) ` +
+    `VALUES (${placeholders.join(', ')})`;
+
+  const mode = spec.update ?? 'all';
+  let onConflict: string;
+  if (mode === 'nothing') {
+    onConflict = `ON CONFLICT (${conflictCols}) DO NOTHING`;
+  } else {
+    const updateCols =
+      mode === 'all'
+        ? columns.filter((c) => !spec.conflict.includes(c))
+        : mode;
+    if (updateCols.length === 0) {
+      // Nothing left to update (all columns are conflict keys) — degrade to DO NOTHING.
+      onConflict = `ON CONFLICT (${conflictCols}) DO NOTHING`;
+    } else {
+      const setClause = updateCols
+        .map((c) => `${quoteIdent(c)} = EXCLUDED.${quoteIdent(c)}`)
+        .join(', ');
+      onConflict = `ON CONFLICT (${conflictCols}) DO UPDATE SET ${setClause}`;
+    }
+  }
+
+  return { text: `${insert} ${onConflict}`, values };
+}
+
+/** Execute an idempotent upsert against a Postgres-shaped client. */
+export async function seedUpsert(client: Queryable, spec: UpsertSpec): Promise<void> {
+  const { text, values } = buildUpsertSql(spec);
+  await client.query(text, values);
+}

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -491,6 +491,7 @@ export interface DateRangeOptions {
 
 export interface UserQueryOptions extends PaginationOptions, DateRangeOptions {
   domain?: string;
+  signalId?: string;
 }
 
 // ============================================================================

--- a/packages/decision-engine/package.json
+++ b/packages/decision-engine/package.json
@@ -23,7 +23,8 @@
     "@skytwin/twin-model": "workspace:*",
     "@skytwin/policy-engine": "workspace:*",
     "@skytwin/llm-client": "workspace:*",
-    "@skytwin/connectors": "workspace:*"
+    "@skytwin/connectors": "workspace:*",
+    "chrono-node": "^2.7.7"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/packages/decision-engine/package.json
+++ b/packages/decision-engine/package.json
@@ -22,7 +22,8 @@
     "@skytwin/core": "workspace:*",
     "@skytwin/twin-model": "workspace:*",
     "@skytwin/policy-engine": "workspace:*",
-    "@skytwin/llm-client": "workspace:*"
+    "@skytwin/llm-client": "workspace:*",
+    "@skytwin/connectors": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/packages/decision-engine/src/__tests__/capability-source-matrix.test.ts
+++ b/packages/decision-engine/src/__tests__/capability-source-matrix.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  capabilityCoversSource,
+  sourcesForCapability,
+  CAPABILITY_SOURCE_MATRIX,
+} from '../capability-source-matrix.js';
+
+describe('capability×source matrix (spec 07 AC6 / spec 02 AC matrix)', () => {
+  it('commitments run on authored channels (mail, calendar, voice) but NOT filesystem', () => {
+    expect(capabilityCoversSource('commitments', 'gmail')).toBe(true);
+    expect(capabilityCoversSource('commitments', 'google_calendar')).toBe(true);
+    expect(capabilityCoversSource('commitments', 'voice')).toBe(true);
+    expect(capabilityCoversSource('commitments', 'filesystem')).toBe(false);
+  });
+
+  it('deadlines run on every text source including filesystem TODOs', () => {
+    for (const s of ['gmail', 'google_calendar', 'filesystem', 'voice', 'email', 'calendar']) {
+      expect(capabilityCoversSource('deadlines', s)).toBe(true);
+    }
+  });
+
+  it('security alerts are inbound-mail only (off for calendar/filesystem/voice by design)', () => {
+    expect(capabilityCoversSource('security', 'gmail')).toBe(true);
+    expect(capabilityCoversSource('security', 'email')).toBe(true);
+    expect(capabilityCoversSource('security', 'google_calendar')).toBe(false);
+    expect(capabilityCoversSource('security', 'filesystem')).toBe(false);
+    expect(capabilityCoversSource('security', 'voice')).toBe(false);
+  });
+
+  it('clusters and entities are source-agnostic (every text source)', () => {
+    for (const s of ['gmail', 'google_calendar', 'filesystem', 'voice']) {
+      expect(capabilityCoversSource('clusters', s)).toBe(true);
+      expect(capabilityCoversSource('entities', s)).toBe(true);
+    }
+  });
+
+  it('unknown source is never covered (fail safe)', () => {
+    expect(capabilityCoversSource('commitments', 'slack')).toBe(false);
+    expect(capabilityCoversSource('deadlines', 'unknown')).toBe(false);
+    expect(capabilityCoversSource('security', '')).toBe(false);
+  });
+
+  it('every capability has a non-empty allowlist and mock sources mirror real ones', () => {
+    for (const cap of Object.keys(CAPABILITY_SOURCE_MATRIX) as Array<
+      keyof typeof CAPABILITY_SOURCE_MATRIX
+    >) {
+      expect(sourcesForCapability(cap).length).toBeGreaterThan(0);
+      // gmail<->email and google_calendar<->calendar parity
+      expect(capabilityCoversSource(cap, 'gmail')).toBe(capabilityCoversSource(cap, 'email'));
+      expect(capabilityCoversSource(cap, 'google_calendar')).toBe(
+        capabilityCoversSource(cap, 'calendar'),
+      );
+    }
+  });
+});

--- a/packages/decision-engine/src/__tests__/commitment-extractor.test.ts
+++ b/packages/decision-engine/src/__tests__/commitment-extractor.test.ts
@@ -83,4 +83,16 @@ describe('extractCommitments (spec 02)', () => {
     const c = extractCommitments(authored("I'll send the report. I will send the report."));
     expect(c).toHaveLength(1);
   });
+
+  it('keeps a real commitment that shares a sentence with a negated clause (review #6)', () => {
+    const c = extractCommitments(
+      authored("I'll send the report, and if I have time I'll also review the deck."),
+    );
+    expect(c.map((x) => x.text)).toContain('Send the report');
+  });
+
+  it('does not treat "by <person>" as a deadline hint (review #7)', () => {
+    expect(extractCommitments(authored("I'll be reviewed by Bob."))[0]?.deadlineHint ?? null).toBeNull();
+    expect(extractCommitments(authored("I'll finish by Friday."))[0]!.deadlineHint).toMatch(/friday/i);
+  });
 });

--- a/packages/decision-engine/src/__tests__/commitment-extractor.test.ts
+++ b/packages/decision-engine/src/__tests__/commitment-extractor.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { extractCommitments } from '../commitment-extractor.js';
+import type { SignalText } from '../signal-text.js';
+
+function authored(body: string, source = 'gmail', participants = ['a@x.com']): SignalText {
+  return {
+    source,
+    title: '',
+    body,
+    authoringTier: source === 'voice' ? 'authored_originated' : 'user_sent_originated',
+    authoredByUser: true,
+    occurredAt: new Date('2026-03-01T12:00:00Z'),
+    participants,
+  };
+}
+
+describe('extractCommitments (spec 02)', () => {
+  it('extracts multiple first-person commitments with their source spans (AC1)', () => {
+    const c = extractCommitments(
+      authored("I'll send the draft tomorrow. Also I will call the vendor next week."),
+    );
+    expect(c).toHaveLength(2);
+    expect(c[0]!.text).toBe('Send the draft tomorrow');
+    expect(c[0]!.rawSpan).toContain("I'll send the draft");
+    expect(c[1]!.text).toBe('Call the vendor next week');
+    expect(c.every((x) => x.committedTo.includes('a@x.com'))).toBe(true);
+  });
+
+  it('normalizes "let me ..." and "I can ..." to imperatives', () => {
+    expect(extractCommitments(authored('Let me pull the numbers.'))[0]!.text).toBe(
+      'Pull the numbers',
+    );
+    expect(extractCommitments(authored('I can reach out to them.'))[0]!.text).toBe(
+      'Reach out to them',
+    );
+  });
+
+  it('returns [] for identical phrasing in NON-authored (inbound) content (AC2, safety)', () => {
+    const inbound: SignalText = {
+      source: 'gmail',
+      title: '',
+      body: "I'll send the draft tomorrow.",
+      authoringTier: 'inbox_personal',
+      authoredByUser: false,
+      occurredAt: new Date('2026-03-01T12:00:00Z'),
+      participants: [],
+    };
+    expect(extractCommitments(inbound)).toEqual([]);
+  });
+
+  it('does not extract questions, past tense, third-party, or hypotheticals (AC3)', () => {
+    const body = [
+      'Can you send it over?',
+      'I sent the draft yesterday.',
+      "She'll handle the vendor.",
+      'I would do it if I could.',
+      "I'd send it but I'm slammed.",
+      "I can't make the meeting.",
+    ].join(' ');
+    expect(extractCommitments(authored(body))).toEqual([]);
+  });
+
+  it('does NOT run on sources outside the commitments matrix (filesystem), even if authored (AC4)', () => {
+    const fileSig = authored("I'll refactor this module.", 'filesystem');
+    fileSig.authoringTier = 'authored_originated';
+    expect(extractCommitments(fileSig)).toEqual([]);
+  });
+
+  it('runs on authored voice transcripts (multi-source showcase)', () => {
+    const c = extractCommitments(authored("I'll call the vendor on Monday.", 'voice'));
+    expect(c).toHaveLength(1);
+    expect(c[0]!.text).toBe('Call the vendor on Monday');
+  });
+
+  it('captures a deadlineHint when present, null otherwise (AC7)', () => {
+    expect(extractCommitments(authored("I'll ship it in 3 days."))[0]!.deadlineHint).toMatch(
+      /3 days/i,
+    );
+    expect(extractCommitments(authored("I'll review the PR."))[0]!.deadlineHint).toBeNull();
+  });
+
+  it('collapses a commitment restated within the same signal (dedup, AC4)', () => {
+    const c = extractCommitments(authored("I'll send the report. I will send the report."));
+    expect(c).toHaveLength(1);
+  });
+});

--- a/packages/decision-engine/src/__tests__/deadline-extractor.test.ts
+++ b/packages/decision-engine/src/__tests__/deadline-extractor.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { extractDeadline } from '../deadline-extractor.js';
+
+const REF = new Date('2026-03-01T12:00:00Z'); // a Sunday
+const DAY = 24 * 60 * 60 * 1000;
+
+function find(body: string, title = '') {
+  return extractDeadline({ title, body, occurredAt: REF });
+}
+
+describe('extractDeadline (spec 03)', () => {
+  it('parses a relative "in N days" deadline anchored to occurredAt', () => {
+    const d = find('Heads up, your trial ends in 2 days.');
+    expect(d).not.toBeNull();
+    expect(d!.kind).toBe('relative');
+    const delta = d!.deadline.getTime() - REF.getTime();
+    expect(delta).toBeGreaterThan(1.5 * DAY);
+    expect(delta).toBeLessThan(2.6 * DAY);
+    expect(d!.rawPhrase.toLowerCase()).toContain('2 days');
+  });
+
+  it('parses an absolute month/day deadline in the future', () => {
+    const d = find('The invoice expires March 5.');
+    expect(d).not.toBeNull();
+    expect(d!.deadline.getTime()).toBeGreaterThan(REF.getTime());
+    expect(d!.kind).toBe('absolute');
+    expect(d!.confidence).toBeGreaterThanOrEqual(0.7);
+  });
+
+  it('resolves a bare weekday to the upcoming occurrence (forwardDate)', () => {
+    const d = find('Please respond by Tuesday.');
+    expect(d).not.toBeNull();
+    expect(d!.deadline.getTime()).toBeGreaterThan(REF.getTime());
+    // Tuesday after Sunday 2026-03-01 is within a week.
+    expect(d!.deadline.getTime() - REF.getTime()).toBeLessThan(7 * DAY);
+  });
+
+  it('returns the EARLIEST credible deadline when several are present', () => {
+    const d = find('Soft target in 10 days, but the hard cutoff is in 3 days.');
+    expect(d).not.toBeNull();
+    expect(d!.deadline.getTime() - REF.getTime()).toBeLessThan(4 * DAY);
+    expect(d!.rawPhrase.toLowerCase()).toContain('3 days');
+  });
+
+  it('rejects past-dated phrases (noise, not urgency)', () => {
+    const d = find('This was due last week and yesterday.');
+    expect(d).toBeNull();
+  });
+
+  it('returns null when there is no temporal expression', () => {
+    expect(find('Just checking in on the project, no rush at all.')).toBeNull();
+  });
+
+  it('returns null for empty content', () => {
+    expect(extractDeadline({ title: '', body: '', occurredAt: REF })).toBeNull();
+  });
+
+  it('reads the title as well as the body', () => {
+    const d = find('', 'Renewal due in 5 days');
+    expect(d).not.toBeNull();
+    expect(d!.deadline.getTime()).toBeGreaterThan(REF.getTime());
+  });
+
+  it('tolerates a garbage occurredAt without throwing', () => {
+    const d = extractDeadline({
+      title: 'x',
+      body: 'due in 2 days',
+      occurredAt: new Date('not-a-date'),
+    });
+    // falls back to "now" as ref; just must not throw and must return a future date
+    expect(d === null || d.deadline instanceof Date).toBe(true);
+  });
+});

--- a/packages/decision-engine/src/__tests__/deadline-urgency.test.ts
+++ b/packages/decision-engine/src/__tests__/deadline-urgency.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { SituationInterpreter } from '../situation-interpreter.js';
+
+const interp = new SituationInterpreter();
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('deadline → urgency wiring (review #1/#2)', () => {
+  it('a STALE deadline (already past relative to now) is NOT marked critical', async () => {
+    const d = await interp.interpret({
+      source: 'gmail',
+      type: 'message',
+      subject: 'Quick note',
+      body: 'Please respond in 2 days.',
+      timestamp: new Date(Date.now() - 60 * DAY), // written 60 days ago → deadline long past
+      authoringTier: 'inbox_personal',
+    });
+    expect(d.urgency).not.toBe('critical');
+    expect(d.urgency).toBe('low'); // falls through to EMAIL_TRIAGE default
+  });
+
+  it('a FAR-OUT deadline does not DOWNGRADE a type default below its baseline', async () => {
+    const d = await interp.interpret({
+      source: 'gmail',
+      type: 'message',
+      subject: 'Calendar invite: planning',
+      body: 'Please confirm in 10 days.',
+      timestamp: new Date(), // now → deadline ~10 days out (future)
+      authoringTier: 'inbox_personal',
+    });
+    // CALENDAR_INVITE default is 'medium'; a far deadline must not make it 'low'.
+    expect(d.urgency).toBe('medium');
+  });
+
+  it('a NEAR future deadline still escalates urgency', async () => {
+    const d = await interp.interpret({
+      source: 'gmail',
+      type: 'message',
+      subject: 'Heads up',
+      body: 'Action needed in 2 hours.',
+      timestamp: new Date(),
+      authoringTier: 'inbox_personal',
+    });
+    expect(['high', 'critical']).toContain(d.urgency);
+  });
+});

--- a/packages/decision-engine/src/__tests__/decision-maker.test.ts
+++ b/packages/decision-engine/src/__tests__/decision-maker.test.ts
@@ -110,6 +110,37 @@ function createContext(
 describe('DecisionMaker', () => {
   let decisionMaker: DecisionMaker;
 
+  describe('risk-assessment persistence ordering (regression: risk_assessment_missing)', () => {
+    it('persists candidate rows BEFORE their risk assessments so the UPDATE lands', async () => {
+      const twinService = createMockTwinService({ preferences: [] });
+      const policyEvaluator = createMockPolicyEvaluator({ allowed: true, requiresApproval: true });
+      const decisionRepo = createMockDecisionRepository();
+      const dm = new DecisionMaker(
+        twinService as never,
+        policyEvaluator as never,
+        decisionRepo as never,
+      );
+
+      await dm.evaluate(createContext(TrustTier.OBSERVER));
+
+      // A candidate was generated, assessed, and persisted.
+      expect(decisionRepo.saveCandidates).toHaveBeenCalled();
+      expect(decisionRepo.saveRiskAssessment).toHaveBeenCalled();
+
+      // saveRiskAssessment runs `UPDATE candidate_actions ... WHERE id = ?`, so
+      // the rows must already exist. If saveRiskAssessment runs first, the
+      // UPDATE no-ops, the full assessment (overallTier/dimensions) is lost,
+      // only the thin placeholder survives, and the approve-time preflight
+      // fails with risk_assessment_missing — blocking the entire
+      // approve→execute path. Lock the order.
+      const candidatesOrder = decisionRepo.saveCandidates.mock.invocationCallOrder[0];
+      const firstRiskOrder = Math.min(
+        ...decisionRepo.saveRiskAssessment.mock.invocationCallOrder,
+      );
+      expect(candidatesOrder).toBeLessThan(firstRiskOrder);
+    });
+  });
+
   describe('Low-risk action on trusted user', () => {
     it('should auto-execute a low-risk action for a trusted user', async () => {
       const twinService = createMockTwinService({

--- a/packages/decision-engine/src/__tests__/decision-maker.test.ts
+++ b/packages/decision-engine/src/__tests__/decision-maker.test.ts
@@ -108,6 +108,8 @@ function createContext(
 // ── Tests ─────────────────────────────────────────────────────────
 
 describe('DecisionMaker', () => {
+  const CALENDAR_WRITE_SCOPES = ['https://www.googleapis.com/auth/calendar.events'];
+
   let decisionMaker: DecisionMaker;
 
   describe('risk-assessment persistence ordering (regression: risk_assessment_missing)', () => {
@@ -377,7 +379,9 @@ describe('DecisionMaker', () => {
         interpretedAt: new Date(),
       };
 
-      const candidates = dm.generateCandidates(decision, emptyProfile);
+      const candidates = dm.generateCandidates(decision, emptyProfile, {
+        grantedScopes: CALENDAR_WRITE_SCOPES,
+      });
 
       expect(candidates.length).toBe(3);
       const actionTypes = candidates.map((c) => c.actionType);
@@ -402,7 +406,9 @@ describe('DecisionMaker', () => {
         interpretedAt: new Date(),
       };
 
-      const candidates = dm.generateCandidates(decision, emptyProfile);
+      const candidates = dm.generateCandidates(decision, emptyProfile, {
+        grantedScopes: CALENDAR_WRITE_SCOPES,
+      });
 
       expect(candidates.length).toBe(3);
       const actionTypes = candidates.map((c) => c.actionType);
@@ -412,6 +418,29 @@ describe('DecisionMaker', () => {
       for (const c of candidates) {
         expect(c.domain).toBe('calendar');
       }
+    });
+
+    it('downgrades scoped calendar writes when granted scopes are missing', () => {
+      const dm = makeDecisionMaker();
+      const decision: DecisionObject = {
+        id: 'dec_inv_no_scope',
+        situationType: SituationType.CALENDAR_INVITE,
+        domain: 'calendar',
+        urgency: 'medium',
+        summary: 'New invite: Weekly sync',
+        rawData: { eventId: 'evt_no_scope' },
+        interpretedAt: new Date(),
+      };
+
+      const candidates = dm.generateCandidates(decision, emptyProfile);
+
+      expect(candidates.length).toBe(3);
+      expect(candidates.every((c) => c.actionType === 'escalate_to_user')).toBe(true);
+      expect(candidates.map((c) => c.parameters['originalActionType']).sort()).toEqual([
+        'accept_invite',
+        'decline_invite',
+        'tentative_accept',
+      ]);
     });
 
     it('CALENDAR_UPDATE should generate acknowledge and dismiss candidates', () => {
@@ -764,6 +793,7 @@ describe('DecisionMaker', () => {
         interpretedAt: new Date(),
       };
       const context = createContext(TrustTier.HIGH_AUTONOMY, decision);
+      context.grantedScopes = CALENDAR_WRITE_SCOPES;
       context.traits = [makeTrait('quick_responder')];
 
       const outcome = await dm.evaluate(context);
@@ -786,6 +816,7 @@ describe('DecisionMaker', () => {
         interpretedAt: new Date(),
       };
       const context = createContext(TrustTier.HIGH_AUTONOMY, decision);
+      context.grantedScopes = CALENDAR_WRITE_SCOPES;
       context.traits = [makeTrait('delegation_averse')];
 
       const outcome = await dm.evaluate(context);
@@ -820,6 +851,7 @@ describe('DecisionMaker', () => {
         interpretedAt: new Date(),
       };
       const context = createContext(TrustTier.HIGH_AUTONOMY, decision);
+      context.grantedScopes = CALENDAR_WRITE_SCOPES;
       context.traits = [makeTrait('privacy_conscious')];
 
       const outcome = await dm.evaluate(context);
@@ -1069,13 +1101,14 @@ describe('DecisionMaker', () => {
         TrustTier.HIGH_AUTONOMY,
       );
 
-      // Calendar domain should produce calendar candidates (accept, decline, propose)
+      // With no granted scopes in the hypothetical query, scoped writes fail safe
+      // to a grant-access escalation instead of pretending calendar writes are allowed.
       const allActions = [
         response.predictedAction,
         ...response.alternativeActions,
       ].filter(Boolean);
       const actionTypes = allActions.map((a) => a!.actionType);
-      expect(actionTypes).toContain('accept_invite');
+      expect(actionTypes).toContain('escalate_to_user');
     });
 
     it('should infer GENERIC for unknown domain', async () => {

--- a/packages/decision-engine/src/__tests__/digest-detail.test.ts
+++ b/packages/decision-engine/src/__tests__/digest-detail.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect } from 'vitest';
 import { buildDigestItemDetail, provenanceLabel } from '../digest-detail.js';
 
 describe('provenanceLabel (spec 14)', () => {
-  it('maps known provenance to human labels', () => {
+  it('maps known provenance to plain-language labels', () => {
     expect(provenanceLabel('user_originated')).toBe('From you');
-    expect(provenanceLabel('trusted_context')).toBe('From your twin');
-    expect(provenanceLabel('untrusted_external')).toBe('Inbound — untrusted');
+    expect(provenanceLabel('trusted_context')).toBe('From your assistant');
+    expect(provenanceLabel('untrusted_external')).toBe('From someone else');
   });
-  it('fails safe to the untrusted wording for unknown/absent', () => {
-    expect(provenanceLabel(undefined)).toBe('Inbound — untrusted');
-    expect(provenanceLabel('weird' as never)).toBe('Inbound — untrusted');
+  it('fails safe to "someone else" for unknown/absent (never imply you wrote it)', () => {
+    expect(provenanceLabel(undefined)).toBe('From someone else');
+    expect(provenanceLabel('weird' as never)).toBe('From someone else');
   });
 });
 
@@ -36,8 +36,10 @@ describe('buildDigestItemDetail (spec 14)', () => {
       blockedReasons: ['missing_write_scope:gmail.send', 'trust_tier:observer'],
       sourceRefs: [],
     });
-    expect(d.whyNotAutoExecuted[0]).toMatch(/No permission granted.*gmail\.send/);
-    expect(d.whyNotAutoExecuted[1]).toMatch(/trust level \(observer\)/);
+    expect(d.whyNotAutoExecuted[0]).toMatch(/don't have permission/i);
+    expect(d.whyNotAutoExecuted[1]).toMatch(/check with you before/i);
+    // No internal jargon leaks to the user.
+    expect(d.whyNotAutoExecuted.join(' ')).not.toMatch(/trust_tier|observer|scope/i);
   });
 
   it('gives a generic review reason when approval is required without specific codes', () => {

--- a/packages/decision-engine/src/__tests__/digest-detail.test.ts
+++ b/packages/decision-engine/src/__tests__/digest-detail.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { buildDigestItemDetail, provenanceLabel } from '../digest-detail.js';
+
+describe('provenanceLabel (spec 14)', () => {
+  it('maps known provenance to human labels', () => {
+    expect(provenanceLabel('user_originated')).toBe('From you');
+    expect(provenanceLabel('trusted_context')).toBe('From your twin');
+    expect(provenanceLabel('untrusted_external')).toBe('Inbound — untrusted');
+  });
+  it('fails safe to the untrusted wording for unknown/absent', () => {
+    expect(provenanceLabel(undefined)).toBe('Inbound — untrusted');
+    expect(provenanceLabel('weird' as never)).toBe('Inbound — untrusted');
+  });
+});
+
+describe('buildDigestItemDetail (spec 14)', () => {
+  it('renders confidence 0..1 as a 0-100 integer, null when absent', () => {
+    expect(buildDigestItemDetail({ confidence: 0.73, sourceRefs: [] }).confidencePct).toBe(73);
+    expect(buildDigestItemDetail({ sourceRefs: [] }).confidencePct).toBeNull();
+    // clamps out-of-range
+    expect(buildDigestItemDetail({ confidence: 1.5, sourceRefs: [] }).confidencePct).toBe(100);
+  });
+
+  it('uses the deadline phrase as the urgency reason when present, else the default', () => {
+    expect(buildDigestItemDetail({ deadlinePhrase: 'in 2 days', sourceRefs: [] }).urgencyReason).toBe(
+      'Deadline: "in 2 days"',
+    );
+    expect(buildDigestItemDetail({ domain: 'email', sourceRefs: [] }).urgencyReason).toBe(
+      'Default for email',
+    );
+  });
+
+  it('humanizes why-not-auto-executed block reasons', () => {
+    const d = buildDigestItemDetail({
+      requiresApproval: true,
+      blockedReasons: ['missing_write_scope:gmail.send', 'trust_tier:observer'],
+      sourceRefs: [],
+    });
+    expect(d.whyNotAutoExecuted[0]).toMatch(/No permission granted.*gmail\.send/);
+    expect(d.whyNotAutoExecuted[1]).toMatch(/trust level \(observer\)/);
+  });
+
+  it('gives a generic review reason when approval is required without specific codes', () => {
+    expect(
+      buildDigestItemDetail({ requiresApproval: true, sourceRefs: [] }).whyNotAutoExecuted,
+    ).toEqual(['Set aside for your review']);
+  });
+
+  it('whyNotAutoExecuted is empty when the item would auto-run', () => {
+    expect(buildDigestItemDetail({ requiresApproval: false, sourceRefs: [] }).whyNotAutoExecuted).toEqual([]);
+  });
+
+  it('passes through source refs and explanation', () => {
+    const d = buildDigestItemDetail({
+      sourceRefs: ['gmail:abc', 'voice:xyz'],
+      explanation: 'Flagged urgent: "in 2 days"',
+    });
+    expect(d.sourceRefs).toEqual(['gmail:abc', 'voice:xyz']);
+    expect(d.explanation).toBe('Flagged urgent: "in 2 days"');
+  });
+});

--- a/packages/decision-engine/src/__tests__/digest.test.ts
+++ b/packages/decision-engine/src/__tests__/digest.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { buildDigest, type DigestItem } from '../digest.js';
+
+function item(p: Partial<DigestItem> & Pick<DigestItem, 'ref'>): DigestItem {
+  return {
+    text: p.ref,
+    actionRequired: false,
+    domain: 'work',
+    ...p,
+  };
+}
+
+describe('buildDigest (spec 01)', () => {
+  it('splits action-required to-dos from FYI topics with no overlap (AC1/AC2)', () => {
+    const items = [
+      item({ ref: 't1', actionRequired: true, domain: 'work' }),
+      item({ ref: 't2', actionRequired: true, domain: 'finance' }),
+      item({ ref: 't3', actionRequired: true, domain: 'work' }),
+      ...Array.from({ length: 7 }, (_, i) => item({ ref: `f${i}`, domain: i % 2 ? 'finance' : 'work' })),
+    ];
+    const d = buildDigest(items, { knownDomains: ['work', 'finance'] });
+    expect(d.todos).toHaveLength(3);
+    const topicRefs = d.topics.flatMap((t) => t.items.map((i) => i.ref));
+    expect(topicRefs).toHaveLength(7);
+    // no overlap
+    const todoRefs = d.todos.map((t) => t.ref);
+    expect(topicRefs.some((r) => todoRefs.includes(r))).toBe(false);
+  });
+
+  it('urgency-orders to-dos and caps at maxTodos (AC1)', () => {
+    const items = [
+      item({ ref: 'low', actionRequired: true, urgency: 'low' }),
+      item({ ref: 'crit', actionRequired: true, urgency: 'critical' }),
+      item({ ref: 'med', actionRequired: true, urgency: 'medium' }),
+      item({ ref: 'high', actionRequired: true, urgency: 'high' }),
+    ];
+    const d = buildDigest(items, { maxTodos: 3 });
+    expect(d.todos.map((t) => t.ref)).toEqual(['crit', 'high', 'med']);
+  });
+
+  it('drops hidden items before partitioning (spec 11 wired)', () => {
+    const items = [
+      item({ ref: 'visible', actionRequired: true }),
+      item({ ref: 'hidden-todo', actionRequired: true, meta: { userOverride: 'hidden' } }),
+      item({ ref: 'hidden-fyi', meta: { hidden_at: 1 } }),
+      item({ ref: 'visible-fyi' }),
+    ];
+    const d = buildDigest(items);
+    const allRefs = [...d.todos.map((t) => t.ref), ...d.topics.flatMap((t) => t.items.map((i) => i.ref))];
+    expect(allRefs).toContain('visible');
+    expect(allRefs).toContain('visible-fyi');
+    expect(allRefs).not.toContain('hidden-todo');
+    expect(allRefs).not.toContain('hidden-fyi');
+  });
+
+  it('carries sourceType + deadline onto to-dos (spec 07/03 for the UI)', () => {
+    const d = buildDigest([
+      item({ ref: 'x', actionRequired: true, sourceType: 'voice', deadline: '2026-03-05' }),
+    ]);
+    expect(d.todos[0]).toMatchObject({ ref: 'x', sourceType: 'voice', deadline: '2026-03-05' });
+  });
+
+  it('groups topics by domain', () => {
+    const d = buildDigest(
+      [item({ ref: 'a', domain: 'finance' }), item({ ref: 'b', domain: 'finance' }), item({ ref: 'c', domain: 'work' })],
+      { knownDomains: ['finance', 'work'] },
+    );
+    const finance = d.topics.find((t) => t.domain === 'finance')!;
+    expect(finance.items.map((i) => i.ref).sort()).toEqual(['a', 'b']);
+  });
+});

--- a/packages/decision-engine/src/__tests__/digest.test.ts
+++ b/packages/decision-engine/src/__tests__/digest.test.ts
@@ -60,6 +60,15 @@ describe('buildDigest (spec 01)', () => {
     expect(d.todos[0]).toMatchObject({ ref: 'x', sourceType: 'voice', deadline: '2026-03-05' });
   });
 
+  it('emits signalRefs[] for citation chips (review #4: UI + v2 prompt expect an array)', () => {
+    const d = buildDigest([
+      item({ ref: 'a', actionRequired: true }),
+      item({ ref: 'b', domain: 'work' }),
+    ], { knownDomains: ['work'] });
+    expect(d.todos[0]!.signalRefs).toEqual(['a']);
+    expect(d.topics[0]!.items[0]!.signalRefs).toEqual(['b']);
+  });
+
   it('groups topics by domain', () => {
     const d = buildDigest(
       [item({ ref: 'a', domain: 'finance' }), item({ ref: 'b', domain: 'finance' }), item({ ref: 'c', domain: 'work' })],

--- a/packages/decision-engine/src/__tests__/entity-linking.test.ts
+++ b/packages/decision-engine/src/__tests__/entity-linking.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractEntities,
+  resolveEntities,
+  linkEntitiesAcrossSignals,
+} from '../entity-linking.js';
+import type { SignalText } from '../signal-text.js';
+
+function sig(body: string, participants: string[] = [], title = ''): SignalText {
+  return {
+    source: 'gmail',
+    title,
+    body,
+    authoredByUser: false,
+    occurredAt: new Date('2026-03-01T00:00:00Z'),
+    participants,
+  };
+}
+
+describe('extractEntities (spec 05)', () => {
+  it('extracts people from participant emails and orgs from suffix-tagged names', () => {
+    const ents = extractEntities(sig('Kickoff with Acme Inc next week.', ['partner@acme.example']));
+    expect(ents.some((e) => e.kind === 'person' && e.normalized === 'partner@acme.example')).toBe(true);
+    expect(ents.some((e) => e.kind === 'org' && e.normalized === 'acme')).toBe(true);
+  });
+});
+
+describe('resolveEntities — people merge on email (spec 05 AC1/AC2)', () => {
+  it('two signals mentioning the same email resolve to ONE entity with both refs', () => {
+    const resolved = linkEntitiesAcrossSignals([
+      { ref: 's1', signal: sig('hi', ['alice@x.example']) },
+      { ref: 's2', signal: sig('again', ['alice@x.example']) },
+    ]);
+    const people = resolved.filter((r) => r.kind === 'person');
+    expect(people).toHaveLength(1);
+    expect(people[0]!.signalRefs.sort()).toEqual(['s1', 's2']);
+  });
+
+  it('same display name but DIFFERENT emails resolve to TWO entities (no false merge)', () => {
+    const resolved = linkEntitiesAcrossSignals([
+      { ref: 's1', signal: sig('Alice says hi', ['alice@x.example']) },
+      { ref: 's2', signal: sig('Alice says hi', ['alice@y.example']) },
+    ]);
+    expect(resolved.filter((r) => r.kind === 'person')).toHaveLength(2);
+  });
+});
+
+describe('resolveEntities — orgs (conservative merge, spec 05 AC3)', () => {
+  it('merges the same org across signals', () => {
+    const resolved = linkEntitiesAcrossSignals([
+      { ref: 's1', signal: sig('Acme Inc kickoff') },
+      { ref: 's2', signal: sig('Acme Inc renewal') },
+    ]);
+    const orgs = resolved.filter((r) => r.kind === 'org');
+    expect(orgs).toHaveLength(1);
+    expect(orgs[0]!.signalRefs.sort()).toEqual(['s1', 's2']);
+  });
+
+  it('keeps clearly-different orgs separate (below the fuzzy floor → mint new)', () => {
+    const resolved = linkEntitiesAcrossSignals([
+      { ref: 's1', signal: sig('Acme Inc kickoff') },
+      { ref: 's2', signal: sig('Globex LLC proposal') },
+    ]);
+    expect(resolved.filter((r) => r.kind === 'org')).toHaveLength(2);
+  });
+
+  it('a high floor forces a split rather than a risky merge (conservative)', () => {
+    const ents = [
+      { kind: 'org' as const, surface: 'Acme Global', normalized: 'acme global', signalRef: 's1', confidence: 0.8 },
+      { kind: 'org' as const, surface: 'Acme Systems', normalized: 'acme systems', signalRef: 's2', confidence: 0.8 },
+    ];
+    // floor 0.9 → "acme global" vs "acme systems" share only "acme" → below → split
+    expect(resolveEntities(ents, 0.9).filter((r) => r.kind === 'org')).toHaveLength(2);
+  });
+});
+
+describe('linkEntitiesAcrossSignals — "everything touching X"', () => {
+  it('aggregates all signal refs that touch a recurring entity', () => {
+    const resolved = linkEntitiesAcrossSignals([
+      { ref: 'email1', signal: sig('meet', ['p@acme.example']) },
+      { ref: 'cal1', signal: sig('Acme Inc sync', ['p@acme.example']) },
+      { ref: 'voice1', signal: sig('call p@acme.example about Acme Inc') },
+    ]);
+    const person = resolved.find((r) => r.entityId === 'person:p@acme.example')!;
+    expect(person.signalRefs.sort()).toEqual(['cal1', 'email1', 'voice1']);
+  });
+});

--- a/packages/decision-engine/src/__tests__/entity-linking.test.ts
+++ b/packages/decision-engine/src/__tests__/entity-linking.test.ts
@@ -72,6 +72,31 @@ describe('resolveEntities — orgs (conservative merge, spec 05 AC3)', () => {
     // floor 0.9 → "acme global" vs "acme systems" share only "acme" → below → split
     expect(resolveEntities(ents, 0.9).filter((r) => r.kind === 'org')).toHaveLength(2);
   });
+
+  it('keeps entity IDs distinct when long org names share the slug prefix', () => {
+    const prefix = 'northwind international procurement operations';
+    const ents = [
+      {
+        kind: 'org' as const,
+        surface: `${prefix} Alpha LLC`,
+        normalized: `${prefix} alpha`,
+        signalRef: 's1',
+        confidence: 0.8,
+      },
+      {
+        kind: 'org' as const,
+        surface: `${prefix} Beta LLC`,
+        normalized: `${prefix} beta`,
+        signalRef: 's2',
+        confidence: 0.8,
+      },
+    ];
+
+    const orgs = resolveEntities(ents, 1).filter((r) => r.kind === 'org');
+
+    expect(orgs).toHaveLength(2);
+    expect(new Set(orgs.map((r) => r.entityId)).size).toBe(2);
+  });
 });
 
 describe('linkEntitiesAcrossSignals — "everything touching X"', () => {

--- a/packages/decision-engine/src/__tests__/locale.test.ts
+++ b/packages/decision-engine/src/__tests__/locale.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLanguage, resolveTimezone, isNonEnglish } from '../locale.js';
+
+describe('resolveLanguage (spec 12)', () => {
+  it('returns the language when set, else falls back to en', () => {
+    expect(resolveLanguage('es')).toBe('es');
+    expect(resolveLanguage('ja-JP')).toBe('ja-JP');
+    expect(resolveLanguage(null)).toBe('en');
+    expect(resolveLanguage('')).toBe('en');
+    expect(resolveLanguage('   ')).toBe('en');
+  });
+});
+
+describe('resolveTimezone (spec 12)', () => {
+  it('returns the tz when set without defaulting', () => {
+    expect(resolveTimezone('America/New_York')).toEqual({
+      timezone: 'America/New_York',
+      defaulted: false,
+    });
+  });
+  it('falls back to UTC and flags defaulted (caller logs a warning)', () => {
+    expect(resolveTimezone(null)).toEqual({ timezone: 'UTC', defaulted: true });
+    expect(resolveTimezone('')).toEqual({ timezone: 'UTC', defaulted: true });
+  });
+});
+
+describe('isNonEnglish (spec 12)', () => {
+  it('false for en variants (incl. unset → en)', () => {
+    expect(isNonEnglish('en')).toBe(false);
+    expect(isNonEnglish('en-US')).toBe(false);
+    expect(isNonEnglish(null)).toBe(false);
+  });
+  it('true for non-English locales (routes to the LLM path)', () => {
+    expect(isNonEnglish('es')).toBe(true);
+    expect(isNonEnglish('ja-JP')).toBe(true);
+    expect(isNonEnglish('zh-Hant')).toBe(true);
+  });
+});

--- a/packages/decision-engine/src/__tests__/security-alert.test.ts
+++ b/packages/decision-engine/src/__tests__/security-alert.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { SituationInterpreter } from '../situation-interpreter.js';
+import { DecisionMaker } from '../decision-maker.js';
+import { SituationType } from '@skytwin/shared-types';
+import type { DecisionObject, TwinProfile } from '@skytwin/shared-types';
+
+const interp = new SituationInterpreter();
+
+const SEC_EXAMPLES = [
+  'We detected a sign-in from a new device.',
+  'Your password may have been exposed in a data breach.',
+  'Your account will be deleted due to inactivity.',
+  'Unusual activity detected — verify your identity.',
+];
+
+describe('security-alert classification (spec 06)', () => {
+  it('classifies the synthetic alerts as SECURITY_ALERT with high urgency (AC1)', async () => {
+    for (const body of SEC_EXAMPLES) {
+      const d = await interp.interpret({
+        source: 'gmail',
+        type: 'message',
+        subject: 'Account notice',
+        body,
+        authoringTier: 'inbox_automated',
+      });
+      expect(d.situationType).toBe(SituationType.SECURITY_ALERT);
+      expect(d.urgency).toBe('high');
+    }
+  });
+
+  it('a breach alert about a financial provider classifies as SECURITY_ALERT, not FINANCE (AC5 precedence)', async () => {
+    const d = await interp.interpret({
+      source: 'gmail',
+      type: 'message',
+      subject: 'Your bank account: unusual activity detected',
+      body: 'We detected a sign-in from a new device. A payment may need review.',
+      authoringTier: 'inbox_automated',
+    });
+    expect(d.situationType).toBe(SituationType.SECURITY_ALERT);
+  });
+
+  it('provenance is untrusted_external even when the message claims a trusted sender (AC4)', async () => {
+    const d = await interp.interpret({
+      source: 'gmail',
+      type: 'message',
+      subject: 'security alert',
+      body: 'We are your trusted bank. A new device was detected on your account.',
+      authoringTier: 'inbox_automated',
+    });
+    expect(d.provenance).toBe('untrusted_external');
+  });
+
+  it('does NOT elevate ordinary mail with no security markers (AC7 negative)', async () => {
+    const d = await interp.interpret({
+      source: 'gmail',
+      type: 'message',
+      subject: 'Lunch next week?',
+      body: 'Want to grab lunch and catch up sometime?',
+      authoringTier: 'inbox_personal',
+    });
+    expect(d.situationType).not.toBe(SituationType.SECURITY_ALERT);
+  });
+
+  it('summary carries the open-provider-directly guidance (AC6)', async () => {
+    const d = await interp.interpret({
+      source: 'gmail',
+      type: 'message',
+      subject: 'Security alert',
+      body: 'A new device was detected.',
+      authoringTier: 'inbox_automated',
+    });
+    expect(d.summary.toLowerCase()).toContain('open the provider directly');
+  });
+});
+
+describe('security-alert candidates are escalate-only (spec 06 AC2/AC3)', () => {
+  const dm = new DecisionMaker({} as never, {} as never, {} as never);
+  const profile = {
+    id: 't',
+    userId: 'u',
+    version: 1,
+    preferences: [],
+    inferences: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as TwinProfile;
+  const decision: DecisionObject = {
+    id: 'd1',
+    situationType: SituationType.SECURITY_ALERT,
+    domain: 'security',
+    urgency: 'high',
+    summary: 'Security alert needs review.',
+    rawData: { subject: 'new device', body: 'click http://evil.example/verify to confirm' },
+    interpretedAt: new Date(),
+    provenance: 'untrusted_external',
+  };
+
+  it('generates ONLY a human-review escalation — no auto-executable action (AC2)', () => {
+    const cands = dm.generateCandidates(decision, profile);
+    expect(cands).toHaveLength(1);
+    expect(cands[0]!.actionType).toBe('escalate_to_user');
+    expect(cands[0]!.reversible).toBe(true);
+  });
+
+  it('no candidate parameter contains a URL drawn from the message body (AC3)', () => {
+    const cands = dm.generateCandidates(decision, profile);
+    expect(JSON.stringify(cands)).not.toMatch(/https?:\/\//);
+  });
+});

--- a/packages/decision-engine/src/__tests__/signal-text.test.ts
+++ b/packages/decision-engine/src/__tests__/signal-text.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import type { RawSignal } from '@skytwin/connectors';
+import { toSignalText, isAuthoredByUser } from '../signal-text.js';
+
+function sig(partial: Partial<RawSignal> & Pick<RawSignal, 'source' | 'data'>): RawSignal {
+  return {
+    id: partial.id ?? 'sig_test',
+    source: partial.source,
+    type: partial.type ?? 'test',
+    data: partial.data,
+    timestamp: partial.timestamp ?? new Date('2026-03-01T12:00:00Z'),
+  };
+}
+
+describe('toSignalText — per-source mapping (spec 07 AC1)', () => {
+  it('maps a gmail signal (subject/snippet/recipients + authoring tier)', () => {
+    const t = toSignalText(
+      sig({
+        source: 'gmail',
+        data: {
+          subject: 'Project kickoff',
+          snippet: "I'll send the draft tomorrow.",
+          from: 'me@example.com',
+          to: 'a@example.com, b@example.com',
+          cc: 'c@example.com',
+          authoringTier: 'user_sent_originated',
+        },
+      }),
+    );
+    expect(t.source).toBe('gmail');
+    expect(t.title).toBe('Project kickoff');
+    expect(t.body).toBe("I'll send the draft tomorrow.");
+    expect(t.authoringTier).toBe('user_sent_originated');
+    expect(t.authoredByUser).toBe(true);
+    expect(t.participants).toEqual(
+      expect.arrayContaining(['a@example.com', 'b@example.com', 'c@example.com', 'me@example.com']),
+    );
+    expect(t.occurredAt.toISOString()).toBe('2026-03-01T12:00:00.000Z');
+  });
+
+  it('maps a google_calendar signal (title/description/attendees)', () => {
+    const t = toSignalText(
+      sig({
+        source: 'google_calendar',
+        data: {
+          title: 'Design review',
+          description: 'Bring the figma link.',
+          organizer: 'org@example.com',
+          attendees: [{ email: 'x@example.com' }, { email: 'y@example.com' }],
+          authoringTier: 'received_shared',
+        },
+      }),
+    );
+    expect(t.title).toBe('Design review');
+    expect(t.body).toBe('Bring the figma link.');
+    expect(t.participants).toEqual(['org@example.com', 'x@example.com', 'y@example.com']);
+    expect(t.authoredByUser).toBe(false); // received_shared is not user-authored
+  });
+
+  it('maps a filesystem signal (fileName/excerpt), not user-authored', () => {
+    const t = toSignalText(
+      sig({
+        source: 'filesystem',
+        data: { fileName: 'TODO.md', excerpt: '// TODO: ship by Friday' },
+      }),
+    );
+    expect(t.title).toBe('TODO.md');
+    expect(t.body).toBe('// TODO: ship by Friday');
+    expect(t.authoredByUser).toBe(false); // no tier → fail safe
+  });
+
+  it('maps a voice transcript signal as authored when tier says so', () => {
+    const t = toSignalText(
+      sig({
+        source: 'voice',
+        data: { transcript: "I'll call the vendor on Monday.", authoringTier: 'authored_originated' },
+      }),
+    );
+    expect(t.title).toBe('Voice note');
+    expect(t.body).toBe("I'll call the vendor on Monday.");
+    expect(t.authoredByUser).toBe(true); // authored_originated → authored
+  });
+});
+
+describe('toSignalText — fail-safe behavior (spec 07 AC2)', () => {
+  it('unknown source falls back to best-effort and authoredByUser=false', () => {
+    const t = toSignalText(
+      sig({
+        source: 'slack',
+        data: { text: 'hello there', from: 'u@example.com', authoringTier: undefined },
+      }),
+    );
+    expect(t.source).toBe('slack');
+    expect(t.body).toBe('hello there');
+    expect(t.authoredByUser).toBe(false);
+  });
+
+  it('unknown source NEVER reports authored even with authored-looking content', () => {
+    const t = toSignalText(sig({ source: 'mystery', data: { body: "I'll do it" } }));
+    expect(t.authoredByUser).toBe(false);
+  });
+
+  it('missing/garbage timestamp coerces to a valid Date (never NaN)', () => {
+    const t = toSignalText({
+      id: 'x',
+      source: 'gmail',
+      type: 't',
+      data: { subject: 's' },
+      // @ts-expect-error deliberately malformed
+      timestamp: 'not-a-date',
+    });
+    expect(Number.isNaN(t.occurredAt.getTime())).toBe(false);
+  });
+});
+
+describe('isAuthoredByUser — tier mapping (spec 07 AC5)', () => {
+  it('true for user_sent_* and authored_originated', () => {
+    expect(isAuthoredByUser('user_sent_originated')).toBe(true);
+    expect(isAuthoredByUser('user_sent_reply')).toBe(true);
+    expect(isAuthoredByUser('authored_originated')).toBe(true);
+  });
+
+  it('false for received/inbox/automated and undefined', () => {
+    expect(isAuthoredByUser('received_shared')).toBe(false);
+    expect(isAuthoredByUser('inbox_personal')).toBe(false);
+    expect(isAuthoredByUser('inbox_automated')).toBe(false);
+    expect(isAuthoredByUser(undefined)).toBe(false);
+  });
+});

--- a/packages/decision-engine/src/__tests__/source-coverage.test.ts
+++ b/packages/decision-engine/src/__tests__/source-coverage.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { computeCoverage, type ConnectedAccountInfo } from '../source-coverage.js';
+
+function acct(provider: string, isActive = true): ConnectedAccountInfo {
+  return { provider, scopes: [], isActive };
+}
+
+function statusOf(cov: ReturnType<typeof computeCoverage>, cap: string) {
+  return cov.capabilityStatus.find((c) => c.capability === cap)!.status;
+}
+
+describe('computeCoverage (spec 13)', () => {
+  it('email-only: security available, others partial, not cold-start (AC1/AC4)', () => {
+    const cov = computeCoverage([acct('gmail')]);
+    expect(cov.connected).toEqual(['gmail']);
+    expect(cov.coldStart).toBe(false);
+    expect(statusOf(cov, 'security')).toBe('available'); // gmail is its only real source
+    expect(statusOf(cov, 'deadlines')).toBe('partial'); // could also use calendar/fs/voice
+    expect(cov.missing).toContain('google_calendar');
+  });
+
+  it('calendar-only: security UNAVAILABLE (no inbound mail), deadlines partial', () => {
+    const cov = computeCoverage([acct('google_calendar')]);
+    expect(statusOf(cov, 'security')).toBe('unavailable');
+    expect(statusOf(cov, 'commitments')).toBe('partial');
+    expect(cov.missing).toContain('gmail');
+  });
+
+  it('filesystem-only: commitments unavailable (files arent promises), deadlines partial', () => {
+    const cov = computeCoverage([acct('filesystem')]);
+    expect(statusOf(cov, 'commitments')).toBe('unavailable');
+    expect(statusOf(cov, 'security')).toBe('unavailable');
+    expect(statusOf(cov, 'deadlines')).toBe('partial');
+  });
+
+  it('voice-only: commitments partial, security unavailable', () => {
+    const cov = computeCoverage([acct('voice')]);
+    expect(statusOf(cov, 'commitments')).toBe('partial');
+    expect(statusOf(cov, 'security')).toBe('unavailable');
+  });
+
+  it('gmail + calendar: richer coverage, security available', () => {
+    const cov = computeCoverage([acct('gmail'), acct('google_calendar')]);
+    expect(cov.connected).toEqual(['gmail', 'google_calendar']);
+    expect(statusOf(cov, 'security')).toBe('available');
+    expect(statusOf(cov, 'commitments')).toBe('partial'); // voice still missing
+  });
+
+  it('zero sources: cold-start true, everything unavailable (AC3)', () => {
+    const cov = computeCoverage([]);
+    expect(cov.coldStart).toBe(true);
+    expect(cov.connected).toEqual([]);
+    expect(cov.capabilityStatus.every((c) => c.status === 'unavailable')).toBe(true);
+  });
+
+  it('inactive accounts do not count as connected', () => {
+    const cov = computeCoverage([acct('gmail', false)]);
+    expect(cov.connected).toEqual([]);
+    expect(cov.coldStart).toBe(true);
+  });
+
+  it('the "google" provider expands to gmail + calendar', () => {
+    const cov = computeCoverage([acct('google')]);
+    expect(cov.connected).toEqual(['gmail', 'google_calendar']);
+  });
+});

--- a/packages/decision-engine/src/__tests__/topic-clusterer.test.ts
+++ b/packages/decision-engine/src/__tests__/topic-clusterer.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { clusterSignals, type ClusterSignal } from '../topic-clusterer.js';
+
+function sigs(...specs: Array<[string, string | null]>): ClusterSignal[] {
+  return specs.map(([ref, domain]) => ({ ref, domain, subject: ref }));
+}
+
+const KNOWN = ['finance', 'work', 'health'];
+
+function allRefs(clusters: ReturnType<typeof clusterSignals>): string[] {
+  return clusters.flatMap((c) => c.signalRefs).sort();
+}
+
+describe('clusterSignals (spec 04)', () => {
+  it('partitions every signal into exactly one cluster (completeness + no overlap)', () => {
+    const input = sigs(['a', 'finance'], ['b', 'work'], ['c', 'finance'], ['d', 'health']);
+    const clusters = clusterSignals(input, { knownDomains: KNOWN });
+    expect(allRefs(clusters)).toEqual(['a', 'b', 'c', 'd']);
+    const counts: Record<string, number> = {};
+    for (const c of clusters) for (const r of c.signalRefs) counts[r] = (counts[r] ?? 0) + 1;
+    expect(Object.values(counts).every((n) => n === 1)).toBe(true);
+  });
+
+  it('anchors known-domain signals to their domain; only no-fit goes to "other"', () => {
+    const input = sigs(['a', 'finance'], ['b', 'astrology']); // astrology not known
+    const clusters = clusterSignals(input, { knownDomains: KNOWN });
+    const finance = clusters.find((c) => c.domain === 'finance')!;
+    const other = clusters.find((c) => c.domain === 'other')!;
+    expect(finance.signalRefs).toEqual(['a']);
+    expect(other.signalRefs).toEqual(['b']);
+    // a known-domain signal is never put in "other"
+    expect(other.signalRefs).not.toContain('a');
+  });
+
+  it('never exceeds maxClusters and merges overflow into "More updates" (logged)', () => {
+    const input = sigs(
+      ['a', 'd1'], ['b', 'd2'], ['c', 'd3'], ['d', 'd4'], ['e', 'd5'],
+    );
+    const onMerge = vi.fn();
+    const clusters = clusterSignals(input, { maxClusters: 3, onMerge });
+    expect(clusters.length).toBeLessThanOrEqual(3);
+    expect(allRefs(clusters)).toEqual(['a', 'b', 'c', 'd', 'e']); // nothing dropped
+    expect(clusters.some((c) => c.domain === 'other')).toBe(true);
+    expect(onMerge).toHaveBeenCalled();
+  });
+
+  it('falls back to grouping by tagged domain when no knownDomains given', () => {
+    const input = sigs(['a', 'travel'], ['b', 'travel'], ['c', 'shopping']);
+    const clusters = clusterSignals(input, {});
+    const travel = clusters.find((c) => c.domain === 'travel')!;
+    expect(travel.signalRefs.sort()).toEqual(['a', 'b']);
+    expect(clusters.find((c) => c.domain === 'shopping')!.signalRefs).toEqual(['c']);
+  });
+
+  it('routes null-domain signals to "other"', () => {
+    const clusters = clusterSignals(sigs(['a', null], ['b', 'finance']), { knownDomains: KNOWN });
+    expect(clusters.find((c) => c.domain === 'other')!.signalRefs).toEqual(['a']);
+  });
+
+  it('gives known-domain clusters higher confidence than "other"', () => {
+    const clusters = clusterSignals(sigs(['a', 'finance'], ['b', null]), { knownDomains: KNOWN });
+    const finance = clusters.find((c) => c.domain === 'finance')!;
+    const other = clusters.find((c) => c.domain === 'other')!;
+    expect(finance.confidence).toBeGreaterThan(other.confidence);
+  });
+});

--- a/packages/decision-engine/src/__tests__/visibility-filter.test.ts
+++ b/packages/decision-engine/src/__tests__/visibility-filter.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { isHidden, filterVisible } from '../visibility-filter.js';
+
+describe('isHidden (spec 11)', () => {
+  it('true for userOverride=hidden', () => {
+    expect(isHidden({ userOverride: 'hidden' })).toBe(true);
+  });
+  it('true for a hidden_at / hiddenAt timestamp (snake or camel)', () => {
+    expect(isHidden({ hidden_at: '2026-01-01T00:00:00Z' })).toBe(true);
+    expect(isHidden({ hiddenAt: new Date() })).toBe(true);
+  });
+  it('false for visible content, null, or undefined meta', () => {
+    expect(isHidden({ userOverride: 'pinned' })).toBe(false);
+    expect(isHidden({})).toBe(false);
+    expect(isHidden(null)).toBe(false);
+    expect(isHidden(undefined)).toBe(false);
+  });
+});
+
+describe('filterVisible (spec 11)', () => {
+  it('drops hidden items and preserves order', () => {
+    const items = [
+      { ref: 'a', meta: {} },
+      { ref: 'b', meta: { userOverride: 'hidden' } },
+      { ref: 'c', meta: { hidden_at: 1 } },
+      { ref: 'd', meta: { userOverride: 'pinned' } },
+    ];
+    const visible = filterVisible(items, (i) => i.meta);
+    expect(visible.map((i) => i.ref)).toEqual(['a', 'd']);
+  });
+});

--- a/packages/decision-engine/src/capability-source-matrix.ts
+++ b/packages/decision-engine/src/capability-source-matrix.ts
@@ -1,0 +1,62 @@
+/**
+ * Capability × source coverage matrix (#spec 07 step 4).
+ *
+ * One tested allowlist of which inbox-intelligence capability runs on which
+ * signal source, so "does commitment extraction run on voice notes?" has a
+ * single, auditable answer instead of scattered `if (source === 'gmail')`
+ * checks. Spec 13 (coverage transparency) evaluates THIS matrix against the
+ * connectors a user actually authorized.
+ *
+ * Rationale per capability:
+ *  - commitments: authored content only — sent mail, calendar descriptions the
+ *    user wrote, transcribed voice notes. NOT filesystem (files aren't promises).
+ *  - deadlines: any text body, including idle-miner TODO/deadline comments.
+ *  - security: inbound-notification shaped — email today (SMS/push later).
+ *    Calendar/filesystem/voice don't carry breach alerts; off by design.
+ *  - clusters / entities: source-agnostic — operate on normalized SignalText.
+ *
+ * Both the real source string and its mock are listed (gmail + email,
+ * google_calendar + calendar) so dev/test fixtures get the same coverage.
+ */
+
+export type Capability =
+  | 'commitments'
+  | 'deadlines'
+  | 'security'
+  | 'clusters'
+  | 'entities';
+
+const ALL_TEXT_SOURCES = [
+  'gmail',
+  'email',
+  'google_calendar',
+  'calendar',
+  'filesystem',
+  'voice',
+] as const;
+
+export const CAPABILITY_SOURCE_MATRIX: Readonly<
+  Record<Capability, ReadonlySet<string>>
+> = {
+  commitments: new Set(['gmail', 'email', 'google_calendar', 'calendar', 'voice']),
+  deadlines: new Set(ALL_TEXT_SOURCES),
+  security: new Set(['gmail', 'email']),
+  clusters: new Set(ALL_TEXT_SOURCES),
+  entities: new Set(ALL_TEXT_SOURCES),
+};
+
+/**
+ * Does `capability` run on signals from `source`? Unknown source → false
+ * (a capability never silently runs on a source it wasn't allowlisted for).
+ */
+export function capabilityCoversSource(
+  capability: Capability,
+  source: string,
+): boolean {
+  return CAPABILITY_SOURCE_MATRIX[capability]?.has(source) ?? false;
+}
+
+/** All sources a capability is allowlisted for (sorted, for display/tests). */
+export function sourcesForCapability(capability: Capability): string[] {
+  return [...(CAPABILITY_SOURCE_MATRIX[capability] ?? [])].sort();
+}

--- a/packages/decision-engine/src/commitment-extractor.ts
+++ b/packages/decision-engine/src/commitment-extractor.ts
@@ -44,8 +44,16 @@ const COMMIT_RE =
 const NEGATE_RE = /\b(i\s+would|i\s?['’]?d\b|if\s+i|i\s+wo\s?n['’]?t|i\s+ca\s?n['’]?t|i\s+cannot)\b/i;
 
 // Rough temporal-phrase detector for the deadline hint (not resolution).
-const DEADLINE_HINT_RE =
-  /\b(today|tonight|tomorrow|this\s+(?:week|morning|afternoon|evening|month)|next\s+\w+|by\s+\w+(?:\s+\d{1,2})?|in\s+\d+\s+\w+|within\s+\d+\s+\w+|on\s+\w+(?:\s+\d{1,2})?|\d{1,2}\/\d{1,2})\b/i;
+// `by`/`on` are restricted to day/month/date followers so "by Bob"/"on Alice"
+// don't read as deadlines (review #7).
+const _DOW_MON =
+  '(?:mon|tues|wednes|thurs|fri|satur|sun)day|(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*|tomorrow|tonight';
+const DEADLINE_HINT_RE = new RegExp(
+  `\\b(today|tonight|tomorrow|this\\s+(?:week|morning|afternoon|evening|month)|next\\s+\\w+|` +
+    `by\\s+(?:${_DOW_MON}|the\\s+\\d{1,2}|\\d{1,2})|on\\s+(?:${_DOW_MON}|the\\s+\\d{1,2}|\\d{1,2})|` +
+    `in\\s+\\d+\\s+\\w+|within\\s+\\d+\\s+\\w+|\\d{1,2}\\/\\d{1,2})\\b`,
+  'i',
+);
 
 function splitSentences(text: string): string[] {
   return text
@@ -71,23 +79,28 @@ function ruleExtract(input: SignalText): Commitment[] {
   const seen = new Set<string>();
   for (const sentence of splitSentences(input.body)) {
     if (sentence.endsWith('?')) continue; // questions aren't commitments
-    if (NEGATE_RE.test(sentence)) continue; // hypothetical / negated
-    const modal = sentence.match(COMMIT_RE);
-    if (!modal) continue;
+    // Split into clauses so a negation in ONE clause ("...if I have time...")
+    // doesn't suppress a genuine commitment in another clause of the same
+    // sentence (review #6).
+    for (const clause of sentence.split(/\s*(?:[,;]|\band\b)\s*/i)) {
+      if (NEGATE_RE.test(clause)) continue; // hypothetical / negated clause
+      const modal = clause.match(COMMIT_RE);
+      if (!modal) continue;
 
-    const text = normalizeImperative(sentence, modal);
-    const key = text.toLowerCase();
-    if (!text || seen.has(key)) continue; // dedup restated commitments
-    seen.add(key);
+      const text = normalizeImperative(clause, modal);
+      const key = text.toLowerCase();
+      if (!text || seen.has(key)) continue; // dedup restated commitments
+      seen.add(key);
 
-    const hintMatch = sentence.match(DEADLINE_HINT_RE);
-    out.push({
-      text,
-      rawSpan: sentence,
-      deadlineHint: hintMatch ? hintMatch[0] : null,
-      committedTo: input.participants,
-      confidence: 0.7,
-    });
+      const hintMatch = clause.match(DEADLINE_HINT_RE);
+      out.push({
+        text,
+        rawSpan: clause.trim(),
+        deadlineHint: hintMatch ? hintMatch[0] : null,
+        committedTo: input.participants,
+        confidence: 0.7,
+      });
+    }
   }
   return out;
 }

--- a/packages/decision-engine/src/commitment-extractor.ts
+++ b/packages/decision-engine/src/commitment-extractor.ts
@@ -1,0 +1,106 @@
+/**
+ * Commitment extraction from user-authored content (#spec 02, #475).
+ *
+ * Surfaces the user's OWN stated obligations ("I'll send the draft tomorrow")
+ * as to-do candidates. Consumes the normalized `SignalText` (spec 07), so it
+ * runs on any authored channel — sent mail, calendar descriptions the user
+ * wrote, transcribed voice notes — not just email.
+ *
+ * Security boundary (safety invariant #8): commitments are extracted ONLY from
+ * content the user authored (`authoredByUser`) and ONLY from sources the
+ * capability matrix allowlists. Inbound "you agreed to X" is a poisoning vector
+ * and must never become a self-imposed to-do.
+ *
+ * This module ships the deterministic rule extractor (zero-cost, always
+ * available). An LLM strategy can be layered later via `CommitmentStrategy`;
+ * the rule path is the fallback the spec requires.
+ */
+
+import type { SignalText } from './signal-text.js';
+import { capabilityCoversSource } from './capability-source-matrix.js';
+
+export interface Commitment {
+  /** Normalized imperative ("Send the draft tomorrow"). */
+  text: string;
+  /** The source sentence, verbatim — for the ExplanationRecord / citation. */
+  rawSpan: string;
+  /** Raw temporal phrase ("tomorrow") if present — resolved by spec 03. */
+  deadlineHint: string | null;
+  /** Who the commitment was made to (recipients / attendees). */
+  committedTo: string[];
+  confidence: number;
+}
+
+/** Optional pluggable strategy (e.g. LLM). The rule extractor is the default. */
+export interface CommitmentStrategy {
+  extract(input: SignalText): Commitment[];
+}
+
+// First-person future-modal openers that signal a commitment.
+const COMMIT_RE =
+  /\b(i\s?['’]?\s?ll|i\s+will|i\s+can|i\s+am\s+going\s+to|i\s?['’]?m\s+going\s+to|let\s+me|i\s+shall)\b/i;
+
+// Hypothetical / negated forms that look like commitments but aren't.
+const NEGATE_RE = /\b(i\s+would|i\s?['’]?d\b|if\s+i|i\s+wo\s?n['’]?t|i\s+ca\s?n['’]?t|i\s+cannot)\b/i;
+
+// Rough temporal-phrase detector for the deadline hint (not resolution).
+const DEADLINE_HINT_RE =
+  /\b(today|tonight|tomorrow|this\s+(?:week|morning|afternoon|evening|month)|next\s+\w+|by\s+\w+(?:\s+\d{1,2})?|in\s+\d+\s+\w+|within\s+\d+\s+\w+|on\s+\w+(?:\s+\d{1,2})?|\d{1,2}\/\d{1,2})\b/i;
+
+function splitSentences(text: string): string[] {
+  return text
+    .split(/(?<=[.!?])\s+|\n+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function normalizeImperative(sentence: string, modal: RegExpMatchArray): string {
+  const after = sentence
+    .slice((modal.index ?? 0) + modal[0].length)
+    .replace(/^[\s,:-]+/, '')
+    .replace(/^(?:make\s+sure\s+(?:to|that)?|going\s+to|to|that)\s+/i, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/[.!?]+$/, '');
+  if (!after) return sentence.replace(/[.!?]+$/, '').trim();
+  return after.charAt(0).toUpperCase() + after.slice(1);
+}
+
+function ruleExtract(input: SignalText): Commitment[] {
+  const out: Commitment[] = [];
+  const seen = new Set<string>();
+  for (const sentence of splitSentences(input.body)) {
+    if (sentence.endsWith('?')) continue; // questions aren't commitments
+    if (NEGATE_RE.test(sentence)) continue; // hypothetical / negated
+    const modal = sentence.match(COMMIT_RE);
+    if (!modal) continue;
+
+    const text = normalizeImperative(sentence, modal);
+    const key = text.toLowerCase();
+    if (!text || seen.has(key)) continue; // dedup restated commitments
+    seen.add(key);
+
+    const hintMatch = sentence.match(DEADLINE_HINT_RE);
+    out.push({
+      text,
+      rawSpan: sentence,
+      deadlineHint: hintMatch ? hintMatch[0] : null,
+      committedTo: input.participants,
+      confidence: 0.7,
+    });
+  }
+  return out;
+}
+
+/**
+ * Extract commitments from a (normalized) signal. Returns [] for content the
+ * user didn't author or sources the matrix doesn't allowlist for commitments.
+ */
+export function extractCommitments(
+  input: SignalText,
+  strategy?: CommitmentStrategy,
+): Commitment[] {
+  if (!input.authoredByUser) return [];
+  if (!capabilityCoversSource('commitments', input.source)) return [];
+  return strategy ? strategy.extract(input) : ruleExtract(input);
+}

--- a/packages/decision-engine/src/deadline-extractor.ts
+++ b/packages/decision-engine/src/deadline-extractor.ts
@@ -1,0 +1,86 @@
+/**
+ * Deadline / temporal extraction from signal content (#spec 03, #476).
+ *
+ * The urgency machinery in `situation-interpreter.ts` already maps a `deadline`
+ * field to an urgency tier — but nothing populated that field from free text, so
+ * it was effectively dead for email/calendar/file/voice signals. This module is
+ * the missing producer: it parses absolute and relative temporal expressions out
+ * of a signal's title/body and resolves them to an absolute timestamp, which the
+ * existing consumer then turns into urgency.
+ *
+ * Input is the minimal `DeadlineSource` shape, which the normalized `SignalText`
+ * (spec 07) satisfies structurally — so this runs on any text-bearing source.
+ * Pure and side-effect-free; uses the maintained `chrono-node` NL-date library
+ * (Layer 1: tried-and-true) rather than a hand-rolled date grammar.
+ */
+
+import * as chrono from 'chrono-node';
+
+export interface DeadlineSource {
+  title: string;
+  body: string;
+  /** Reference anchor for relative phrases ("in 3 days", "Friday"). */
+  occurredAt: Date;
+}
+
+export interface ExtractedDeadline {
+  deadline: Date;
+  /** The matched phrase ("in 2 days") — for the urgency ExplanationRecord. */
+  rawPhrase: string;
+  kind: 'absolute' | 'relative';
+  confidence: number;
+}
+
+const RELATIVE_HINT =
+  /\b(today|tonight|tomorrow|yesterday|in|within|next|this|last|day|days|week|weeks|month|months|hour|hours|minute|minutes|min|mins)\b/i;
+
+function validDate(d: unknown): d is Date {
+  return d instanceof Date && !Number.isNaN(d.getTime());
+}
+
+/**
+ * Extract the earliest credible FUTURE deadline from a signal's text, anchored
+ * to `occurredAt`. Returns null when there is no temporal expression, or only
+ * past-dated ones (a past "deadline" is noise, not urgency).
+ *
+ * Note (v1 limitation): timezone-aware end-of-day / weekday resolution is left
+ * to chrono's reference-relative parsing; per-user-timezone resolution is a
+ * spec 12 follow-up. Documented rather than silently approximated.
+ */
+export function extractDeadline(src: DeadlineSource): ExtractedDeadline | null {
+  const ref = validDate(src.occurredAt) ? src.occurredAt : new Date();
+  const text = `${src.title ?? ''}\n${src.body ?? ''}`.trim();
+  if (!text) return null;
+
+  let results: ReturnType<typeof chrono.parse>;
+  try {
+    // forwardDate biases bare day/weekday names to the upcoming occurrence.
+    results = chrono.parse(text, ref, { forwardDate: true });
+  } catch {
+    return null;
+  }
+
+  const candidates: ExtractedDeadline[] = [];
+  for (const r of results) {
+    const date = r.start.date();
+    if (!validDate(date)) continue;
+    // Reject past/now deadlines relative to when the content was written.
+    if (date.getTime() <= ref.getTime()) continue;
+
+    const phrase = r.text;
+    const kind: 'absolute' | 'relative' = RELATIVE_HINT.test(phrase)
+      ? 'relative'
+      : 'absolute';
+    const certainDay = r.start.isCertain('day');
+    const certainMonth = r.start.isCertain('month');
+    const confidence =
+      certainDay && certainMonth ? 0.9 : certainDay || kind === 'relative' ? 0.7 : 0.5;
+
+    candidates.push({ deadline: date, rawPhrase: phrase, kind, confidence });
+  }
+
+  if (candidates.length === 0) return null;
+  // The binding deadline is the earliest credible one.
+  candidates.sort((a, b) => a.deadline.getTime() - b.deadline.getTime());
+  return candidates[0]!;
+}

--- a/packages/decision-engine/src/decision-maker.ts
+++ b/packages/decision-engine/src/decision-maker.ts
@@ -437,10 +437,46 @@ export class DecisionMaker {
         return this.generateDocumentCandidates(decision, profile);
       case SituationType.HEALTH_WELLNESS:
         return this.generateHealthCandidates(decision, profile);
+      case SituationType.SECURITY_ALERT:
+        return this.generateSecurityAlertCandidates(decision);
       case SituationType.GENERIC:
       default:
         return this.generateGenericCandidates(decision, profile);
     }
+  }
+
+  /**
+   * Escalate-only candidates for an inbound security alert (spec 06, #479).
+   *
+   * Safety invariant #8: a SECURITY_ALERT is inbound, untrusted, and a phishing
+   * surface. The ONLY candidate is a human-review escalation that tells the user
+   * to open the provider directly — NEVER an auto-executable action, and NEVER a
+   * URL drawn from the (untrusted) message body. Parameters are deliberately
+   * link-free.
+   */
+  private generateSecurityAlertCandidates(decision: DecisionObject): CandidateAction[] {
+    return [
+      {
+        id: crypto.randomUUID(),
+        decisionId: decision.id,
+        actionType: 'escalate_to_user',
+        description:
+          "Review this security alert in the provider's official app or website. " +
+          'Do not click links in the message.',
+        domain: decision.domain,
+        parameters: {
+          summary: decision.summary,
+          urgency: decision.urgency,
+          safeAction: 'open_provider_directly',
+        },
+        estimatedCostCents: 0,
+        reversible: true,
+        confidence: ConfidenceLevel.HIGH,
+        reasoning:
+          'Security alerts are inbound and untrusted (phishing surface). Surfaced ' +
+          'for human review only — never auto-executed, never via links in the message.',
+      },
+    ];
   }
 
   /**

--- a/packages/decision-engine/src/decision-maker.ts
+++ b/packages/decision-engine/src/decision-maker.ts
@@ -147,8 +147,14 @@ export class DecisionMaker {
 
     // Step 3: Generate candidate actions (LLM strategy or built-in rules)
     const candidates = this.candidateGenerator
-      ? await this.candidateGenerator.generate(context.decision, profile, enrichedContext)
-      : this.generateCandidates(context.decision, profile, { senderLabelHints });
+      ? applyScopeGate(
+          await this.candidateGenerator.generate(context.decision, profile, enrichedContext),
+          context.grantedScopes ?? [],
+        )
+      : this.generateCandidates(context.decision, profile, {
+          senderLabelHints,
+          grantedScopes: context.grantedScopes,
+        });
 
     // Stamp provenance onto every candidate from the originating decision so
     // the policy engine's injection guard can gate without re-deriving where
@@ -423,11 +429,9 @@ export class DecisionMaker {
   ): CandidateAction[] {
     const candidates = this.dispatchCandidates(decision, profile, extras);
     // Scope gate (spec 11, #485): never propose a write the user didn't grant.
-    // When grantedScopes is supplied, downgrade scoped-write candidates lacking
-    // the scope to a human-review "grant access" item. Fail-safe NOT granted.
-    return extras?.grantedScopes
-      ? applyScopeGate(candidates, extras.grantedScopes)
-      : candidates;
+    // Missing scopes are an empty grant set, so scoped writes fail safe to a
+    // human-review "grant access" item.
+    return applyScopeGate(candidates, extras?.grantedScopes ?? []);
   }
 
   private dispatchCandidates(

--- a/packages/decision-engine/src/decision-maker.ts
+++ b/packages/decision-engine/src/decision-maker.ts
@@ -184,6 +184,15 @@ export class DecisionMaker {
       return outcome;
     }
 
+    // Persist the candidate rows BEFORE assessing/saving their risk.
+    // saveRiskAssessment UPDATEs candidate_actions by id, so the rows must
+    // already exist — otherwise the UPDATE no-ops, the full RiskAssessment
+    // (overallTier/dimensions) is lost, and only the thin placeholder
+    // saveCandidates writes survives. That left the approve-time preflight
+    // unable to find a parseable assessment → risk_assessment_missing → the
+    // entire approve→execute path was blocked.
+    await this.decisionRepository.saveCandidates(candidates);
+
     // Step 4: Assess risk for each candidate
     const assessments = new Map<string, RiskAssessment>();
     for (const candidate of candidates) {
@@ -287,7 +296,8 @@ export class DecisionMaker {
         : {}),
     };
 
-    await this.decisionRepository.saveCandidates(candidates);
+    // (candidates were persisted earlier, before risk assessment, so the
+    // saveRiskAssessment UPDATEs above could land on existing rows.)
     await this.decisionRepository.saveOutcome(outcome);
 
     return outcome;

--- a/packages/decision-engine/src/decision-maker.ts
+++ b/packages/decision-engine/src/decision-maker.ts
@@ -19,6 +19,7 @@ import {
 } from '@skytwin/shared-types';
 import type { TwinService } from '@skytwin/twin-model';
 import type { PolicyEvaluator } from '@skytwin/policy-engine';
+import { applyScopeGate } from '@skytwin/policy-engine';
 import { normalizeSenderAddress } from '@skytwin/core';
 import { RiskAssessor } from './risk-assessor.js';
 import type { CandidateGenerator } from './strategies/candidate-strategy.js';
@@ -408,7 +409,21 @@ export class DecisionMaker {
   generateCandidates(
     decision: DecisionObject,
     profile: TwinProfile,
-    extras?: { senderLabelHints?: SenderLabelHint[] },
+    extras?: { senderLabelHints?: SenderLabelHint[]; grantedScopes?: string[] },
+  ): CandidateAction[] {
+    const candidates = this.dispatchCandidates(decision, profile, extras);
+    // Scope gate (spec 11, #485): never propose a write the user didn't grant.
+    // When grantedScopes is supplied, downgrade scoped-write candidates lacking
+    // the scope to a human-review "grant access" item. Fail-safe NOT granted.
+    return extras?.grantedScopes
+      ? applyScopeGate(candidates, extras.grantedScopes)
+      : candidates;
+  }
+
+  private dispatchCandidates(
+    decision: DecisionObject,
+    profile: TwinProfile,
+    extras?: { senderLabelHints?: SenderLabelHint[]; grantedScopes?: string[] },
   ): CandidateAction[] {
     switch (decision.situationType) {
       case SituationType.EMAIL_TRIAGE:

--- a/packages/decision-engine/src/digest-detail.ts
+++ b/packages/decision-engine/src/digest-detail.ts
@@ -21,6 +21,13 @@ export interface DigestItemDetailInput {
   /** Machine block codes, e.g. 'missing_write_scope:gmail.send', 'trust_tier:observer'. */
   blockedReasons?: string[];
   explanation?: string | null;
+  /**
+   * Explicit "why this urgency" string. When provided it overrides the
+   * computed default (deadline phrase / "Default for <domain>"), so callers
+   * that know the real urgency driver (a security alert, an RSVP, a stated
+   * deadline) can surface it instead of a generic placeholder.
+   */
+  urgencyReason?: string;
 }
 
 export interface DigestItemDetail {
@@ -69,9 +76,11 @@ export function buildDigestItemDetail(input: DigestItemDetailInput): DigestItemD
       ? Math.round(Math.max(0, Math.min(1, input.confidence)) * 100)
       : null;
 
-  const urgencyReason = input.deadlinePhrase
-    ? `Deadline: "${input.deadlinePhrase}"`
-    : `Default for ${input.domain ?? 'this kind of item'}`;
+  const urgencyReason =
+    input.urgencyReason?.trim() ||
+    (input.deadlinePhrase
+      ? `Deadline: "${input.deadlinePhrase}"`
+      : `Default for ${input.domain ?? 'this kind of item'}`);
 
   const whyNotAutoExecuted =
     input.requiresApproval && input.blockedReasons && input.blockedReasons.length > 0

--- a/packages/decision-engine/src/digest-detail.ts
+++ b/packages/decision-engine/src/digest-detail.ts
@@ -28,6 +28,12 @@ export interface DigestItemDetailInput {
    * deadline) can surface it instead of a generic placeholder.
    */
   urgencyReason?: string;
+  /**
+   * The action the twin recommends — the user's actual next step ("Accept
+   * this calendar invitation", "Review the sign-in in your account settings").
+   * Actionable, not a system label.
+   */
+  suggestedAction?: string;
 }
 
 export interface DigestItemDetail {
@@ -37,6 +43,8 @@ export interface DigestItemDetail {
   sourceRefs: string[];
   whyNotAutoExecuted: string[];
   explanation: string | null;
+  /** The twin's recommended next step (actionable), if known. */
+  suggestedAction: string | null;
 }
 
 // Provenance → human label. Unknown / absent fails safe to the untrusted wording
@@ -96,5 +104,6 @@ export function buildDigestItemDetail(input: DigestItemDetailInput): DigestItemD
     sourceRefs: input.sourceRefs,
     whyNotAutoExecuted,
     explanation: input.explanation ?? null,
+    suggestedAction: input.suggestedAction?.trim() || null,
   };
 }

--- a/packages/decision-engine/src/digest-detail.ts
+++ b/packages/decision-engine/src/digest-detail.ts
@@ -1,0 +1,91 @@
+/**
+ * Power-view detail view-model (#spec 14).
+ *
+ * One digest, two depths: the clean view (spec 01/08) is default; power users
+ * expand a row to see the technical depth SkyTwin already computed — provenance,
+ * confidence, why-this-urgency, the real source refs, and (for to-dos) why it
+ * did NOT auto-execute. This is the single place raw codes become human strings,
+ * so the UI stays dumb. Pure + testable.
+ */
+
+import type { ActionProvenance } from '@skytwin/shared-types';
+
+export interface DigestItemDetailInput {
+  provenance?: ActionProvenance;
+  /** 0..1 */
+  confidence?: number;
+  deadlinePhrase?: string | null;
+  domain?: string | null;
+  sourceRefs: string[];
+  requiresApproval?: boolean;
+  /** Machine block codes, e.g. 'missing_write_scope:gmail.send', 'trust_tier:observer'. */
+  blockedReasons?: string[];
+  explanation?: string | null;
+}
+
+export interface DigestItemDetail {
+  provenanceLabel: string;
+  confidencePct: number | null;
+  urgencyReason: string;
+  sourceRefs: string[];
+  whyNotAutoExecuted: string[];
+  explanation: string | null;
+}
+
+// Provenance → human label. Unknown / absent fails safe to the untrusted wording
+// (mirrors the provenance fail-safe — never imply trust we can't prove).
+const PROVENANCE_LABELS: Record<string, string> = {
+  user_originated: 'From you',
+  trusted_context: 'From your twin',
+  untrusted_external: 'Inbound — untrusted',
+};
+
+export function provenanceLabel(p: ActionProvenance | undefined): string {
+  return (p && PROVENANCE_LABELS[p]) || 'Inbound — untrusted';
+}
+
+/** Map a single machine block code to a human reason. */
+function humanizeBlockReason(code: string): string {
+  const [kind, detail] = code.split(':');
+  switch (kind) {
+    case 'missing_write_scope':
+      return `No permission granted to do this for you${detail ? ` (needs ${detail})` : ''}`;
+    case 'trust_tier':
+      return `Your trust level (${detail ?? 'low'}) asks me to check first`;
+    case 'policy':
+      return `Held by a safety policy${detail ? `: ${detail}` : ''}`;
+    case 'untrusted_origin':
+      return 'From untrusted content — needs your confirmation';
+    case 'spend_limit':
+      return 'Would exceed your spend limit';
+    default:
+      return code;
+  }
+}
+
+export function buildDigestItemDetail(input: DigestItemDetailInput): DigestItemDetail {
+  const confidencePct =
+    typeof input.confidence === 'number' && Number.isFinite(input.confidence)
+      ? Math.round(Math.max(0, Math.min(1, input.confidence)) * 100)
+      : null;
+
+  const urgencyReason = input.deadlinePhrase
+    ? `Deadline: "${input.deadlinePhrase}"`
+    : `Default for ${input.domain ?? 'this kind of item'}`;
+
+  const whyNotAutoExecuted =
+    input.requiresApproval && input.blockedReasons && input.blockedReasons.length > 0
+      ? input.blockedReasons.map(humanizeBlockReason)
+      : input.requiresApproval
+        ? ['Set aside for your review']
+        : [];
+
+  return {
+    provenanceLabel: provenanceLabel(input.provenance),
+    confidencePct,
+    urgencyReason,
+    sourceRefs: input.sourceRefs,
+    whyNotAutoExecuted,
+    explanation: input.explanation ?? null,
+  };
+}

--- a/packages/decision-engine/src/digest-detail.ts
+++ b/packages/decision-engine/src/digest-detail.ts
@@ -47,32 +47,34 @@ export interface DigestItemDetail {
   suggestedAction: string | null;
 }
 
-// Provenance → human label. Unknown / absent fails safe to the untrusted wording
-// (mirrors the provenance fail-safe — never imply trust we can't prove).
+// Provenance → plain-English label a non-technical person understands. The
+// fail-safe still resolves to "someone else" (never imply you wrote something
+// we can't prove you did), but without the alarming "untrusted" wording — the
+// caution lives in the "why I'm asking you" line, not a scary origin label.
 const PROVENANCE_LABELS: Record<string, string> = {
   user_originated: 'From you',
-  trusted_context: 'From your twin',
-  untrusted_external: 'Inbound — untrusted',
+  trusted_context: 'From your assistant',
+  untrusted_external: 'From someone else',
 };
 
 export function provenanceLabel(p: ActionProvenance | undefined): string {
-  return (p && PROVENANCE_LABELS[p]) || 'Inbound — untrusted';
+  return (p && PROVENANCE_LABELS[p]) || 'From someone else';
 }
 
 /** Map a single machine block code to a human reason. */
 function humanizeBlockReason(code: string): string {
-  const [kind, detail] = code.split(':');
+  const [kind] = code.split(':');
   switch (kind) {
     case 'missing_write_scope':
-      return `No permission granted to do this for you${detail ? ` (needs ${detail})` : ''}`;
+      return "I don't have permission to do this for you yet";
     case 'trust_tier':
-      return `Your trust level (${detail ?? 'low'}) asks me to check first`;
+      return "You've asked me to check with you before I act";
     case 'policy':
-      return `Held by a safety policy${detail ? `: ${detail}` : ''}`;
+      return 'A safety rule is holding this for review';
     case 'untrusted_origin':
-      return 'From untrusted content — needs your confirmation';
+      return 'It came from someone else, so I want your OK first';
     case 'spend_limit':
-      return 'Would exceed your spend limit';
+      return 'It would cost more than your limit';
     default:
       return code;
   }

--- a/packages/decision-engine/src/digest-detail.ts
+++ b/packages/decision-engine/src/digest-detail.ts
@@ -34,6 +34,8 @@ export interface DigestItemDetailInput {
    * Actionable, not a system label.
    */
   suggestedAction?: string;
+  /** When the underlying signal arrived (ISO string), for a "when" line. */
+  occurredAt?: string;
 }
 
 export interface DigestItemDetail {
@@ -45,6 +47,8 @@ export interface DigestItemDetail {
   explanation: string | null;
   /** The twin's recommended next step (actionable), if known. */
   suggestedAction: string | null;
+  /** When the underlying signal arrived (ISO string), if known. */
+  occurredAt: string | null;
 }
 
 // Provenance → plain-English label a non-technical person understands. The
@@ -107,5 +111,6 @@ export function buildDigestItemDetail(input: DigestItemDetailInput): DigestItemD
     whyNotAutoExecuted,
     explanation: input.explanation ?? null,
     suggestedAction: input.suggestedAction?.trim() || null,
+    occurredAt: input.occurredAt ?? null,
   };
 }

--- a/packages/decision-engine/src/digest.ts
+++ b/packages/decision-engine/src/digest.ts
@@ -26,6 +26,8 @@ import type { SourceCoverage } from './source-coverage.js';
 export interface DigestItem {
   ref: string;
   text: string;
+  /** One-line preview of what the signal actually says (snippet / body). */
+  body?: string;
   /** True when the decision pipeline escalated this to the user (a to-do). */
   actionRequired: boolean;
   domain: string | null;
@@ -39,6 +41,8 @@ export interface DigestItem {
 export interface DigestTodo {
   ref: string;
   text: string;
+  /** One-line preview of what the signal actually says (snippet / body). */
+  body?: string;
   sourceType?: string;
   deadline?: string | null;
   /** Citation refs for the UI chips (review #4: UI + v2 prompt expect signalRefs[]). */
@@ -50,6 +54,8 @@ export interface DigestTodo {
 export interface DigestTopicItem {
   ref: string;
   text: string;
+  /** One-line preview of what the signal actually says (snippet / body). */
+  body?: string;
   sourceType?: string;
   signalRefs: string[];
   detail?: DigestItemDetail;
@@ -100,6 +106,7 @@ export function buildDigest(items: DigestItem[], opts: BuildDigestOptions = {}):
     .map((i) => ({
       ref: i.ref,
       text: i.text,
+      body: i.body,
       sourceType: i.sourceType,
       deadline: i.deadline ?? null,
       signalRefs: [i.ref],
@@ -117,7 +124,7 @@ export function buildDigest(items: DigestItem[], opts: BuildDigestOptions = {}):
     title: c.title,
     items: c.signalRefs.map((ref) => {
       const it = byRef.get(ref);
-      return { ref, text: it?.text ?? '', sourceType: it?.sourceType, signalRefs: [ref] };
+      return { ref, text: it?.text ?? '', body: it?.body, sourceType: it?.sourceType, signalRefs: [ref] };
     }),
   }));
 

--- a/packages/decision-engine/src/digest.ts
+++ b/packages/decision-engine/src/digest.ts
@@ -39,12 +39,15 @@ export interface DigestTodo {
   text: string;
   sourceType?: string;
   deadline?: string | null;
+  /** Citation refs for the UI chips (review #4: UI + v2 prompt expect signalRefs[]). */
+  signalRefs: string[];
 }
 
 export interface DigestTopicItem {
   ref: string;
   text: string;
   sourceType?: string;
+  signalRefs: string[];
 }
 
 export interface DigestTopic {
@@ -87,7 +90,13 @@ export function buildDigest(items: DigestItem[], opts: BuildDigestOptions = {}):
     .filter((i) => i.actionRequired)
     .sort((a, b) => URGENCY_RANK[a.urgency ?? 'low'] - URGENCY_RANK[b.urgency ?? 'low'])
     .slice(0, maxTodos)
-    .map((i) => ({ ref: i.ref, text: i.text, sourceType: i.sourceType, deadline: i.deadline ?? null }));
+    .map((i) => ({
+      ref: i.ref,
+      text: i.text,
+      sourceType: i.sourceType,
+      deadline: i.deadline ?? null,
+      signalRefs: [i.ref],
+    }));
 
   // Topics: everything else, clustered by domain.
   const fyi = visible.filter((i) => !i.actionRequired);
@@ -101,7 +110,7 @@ export function buildDigest(items: DigestItem[], opts: BuildDigestOptions = {}):
     title: c.title,
     items: c.signalRefs.map((ref) => {
       const it = byRef.get(ref);
-      return { ref, text: it?.text ?? '', sourceType: it?.sourceType };
+      return { ref, text: it?.text ?? '', sourceType: it?.sourceType, signalRefs: [ref] };
     }),
   }));
 

--- a/packages/decision-engine/src/digest.ts
+++ b/packages/decision-engine/src/digest.ts
@@ -1,0 +1,109 @@
+/**
+ * Digest assembly: split to-dos (act) from topics (be-aware) (#spec 01, #474).
+ *
+ * The reference AI-inbox product opens with a short "suggested to-dos" list
+ * above grouped "topics to catch up on". This composes that structured payload:
+ *   - to-dos  = items the decision pipeline flagged action-required, urgency-
+ *               ordered and capped.
+ *   - topics  = everything else, grouped into life-domain clusters (spec 04).
+ *
+ * Also the integration point for two earlier specs:
+ *   - spec 11: hidden content is filtered out FIRST (the digest must honor the
+ *              user's hide choices — closes that wiring).
+ *   - spec 07: sourceType travels per item so the UI (spec 08) can show source
+ *              chips.
+ *
+ * Pure + testable. The caller supplies items already tagged with actionRequired
+ * (derived from the decision outcome) + domain; deriving those is the briefing
+ * generator's job (spec 01 step 0).
+ */
+
+import { clusterSignals } from './topic-clusterer.js';
+import { filterVisible, type SignalVisibilityMeta } from './visibility-filter.js';
+
+export interface DigestItem {
+  ref: string;
+  text: string;
+  /** True when the decision pipeline escalated this to the user (a to-do). */
+  actionRequired: boolean;
+  domain: string | null;
+  sourceType?: string;
+  deadline?: string | null;
+  urgency?: 'low' | 'medium' | 'high' | 'critical';
+  /** Visibility metadata (spec 11) — hidden items are dropped. */
+  meta?: SignalVisibilityMeta | null;
+}
+
+export interface DigestTodo {
+  ref: string;
+  text: string;
+  sourceType?: string;
+  deadline?: string | null;
+}
+
+export interface DigestTopicItem {
+  ref: string;
+  text: string;
+  sourceType?: string;
+}
+
+export interface DigestTopic {
+  domain: string;
+  title: string;
+  items: DigestTopicItem[];
+}
+
+export interface Digest {
+  todos: DigestTodo[];
+  topics: DigestTopic[];
+}
+
+export interface BuildDigestOptions {
+  knownDomains?: string[];
+  maxTodos?: number;
+  maxClusters?: number;
+}
+
+const URGENCY_RANK: Record<NonNullable<DigestItem['urgency']>, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+/**
+ * Partition digest items into the to-do and topic buckets. Hidden items are
+ * dropped first (spec 11). To-dos are urgency-ordered and capped; topics are
+ * domain clusters (spec 04). No item appears in both buckets.
+ */
+export function buildDigest(items: DigestItem[], opts: BuildDigestOptions = {}): Digest {
+  const maxTodos = opts.maxTodos ?? 7;
+
+  // spec 11: never surface content the user hid.
+  const visible = filterVisible(items, (i) => i.meta ?? null);
+
+  // To-dos: action-required, urgency-ordered, capped.
+  const todos: DigestTodo[] = visible
+    .filter((i) => i.actionRequired)
+    .sort((a, b) => URGENCY_RANK[a.urgency ?? 'low'] - URGENCY_RANK[b.urgency ?? 'low'])
+    .slice(0, maxTodos)
+    .map((i) => ({ ref: i.ref, text: i.text, sourceType: i.sourceType, deadline: i.deadline ?? null }));
+
+  // Topics: everything else, clustered by domain.
+  const fyi = visible.filter((i) => !i.actionRequired);
+  const byRef = new Map(fyi.map((i) => [i.ref, i]));
+  const clusters = clusterSignals(
+    fyi.map((i) => ({ ref: i.ref, domain: i.domain, subject: i.text })),
+    { knownDomains: opts.knownDomains, maxClusters: opts.maxClusters },
+  );
+  const topics: DigestTopic[] = clusters.map((c) => ({
+    domain: c.domain,
+    title: c.title,
+    items: c.signalRefs.map((ref) => {
+      const it = byRef.get(ref);
+      return { ref, text: it?.text ?? '', sourceType: it?.sourceType };
+    }),
+  }));
+
+  return { todos, topics };
+}

--- a/packages/decision-engine/src/digest.ts
+++ b/packages/decision-engine/src/digest.ts
@@ -20,6 +20,8 @@
 
 import { clusterSignals } from './topic-clusterer.js';
 import { filterVisible, type SignalVisibilityMeta } from './visibility-filter.js';
+import type { DigestItemDetail } from './digest-detail.js';
+import type { SourceCoverage } from './source-coverage.js';
 
 export interface DigestItem {
   ref: string;
@@ -41,6 +43,8 @@ export interface DigestTodo {
   deadline?: string | null;
   /** Citation refs for the UI chips (review #4: UI + v2 prompt expect signalRefs[]). */
   signalRefs: string[];
+  /** Power-view technical depth (spec 14); the generator builds it via buildDigestItemDetail. */
+  detail?: DigestItemDetail;
 }
 
 export interface DigestTopicItem {
@@ -48,6 +52,7 @@ export interface DigestTopicItem {
   text: string;
   sourceType?: string;
   signalRefs: string[];
+  detail?: DigestItemDetail;
 }
 
 export interface DigestTopic {
@@ -59,6 +64,8 @@ export interface DigestTopic {
 export interface Digest {
   todos: DigestTodo[];
   topics: DigestTopic[];
+  /** Source coverage for the power-view panel (spec 13/14). Optional. */
+  coverage?: SourceCoverage;
 }
 
 export interface BuildDigestOptions {

--- a/packages/decision-engine/src/entity-linking.ts
+++ b/packages/decision-engine/src/entity-linking.ts
@@ -1,0 +1,159 @@
+/**
+ * Entity extraction + cross-signal resolution (#spec 05, #478).
+ *
+ * Pulls people / orgs from signal text and resolves mentions to a stable
+ * `entityId` so the same entity recurring across signals is linked (and the
+ * digest can collapse "one matter, many citations"). The resolution is the
+ * bug-prone part: a FALSE MERGE corrupts the graph, so this is deliberately
+ * conservative — strong keys (email) for people, a token-overlap floor for
+ * orgs, and mint-a-new-entity-on-doubt.
+ *
+ * Pure + testable. Persistence reuses the existing `MemoryPort.recordEntity`
+ * (KnowledgeEntity already exists, port.ts); the read-by-entity port method
+ * (`getSignalsForEntity`) is the remaining integration seam (spec 05 §5).
+ */
+
+import type { SignalText } from './signal-text.js';
+
+export type EntityKind = 'person' | 'org';
+
+export interface ExtractedEntity {
+  kind: EntityKind;
+  surface: string;
+  normalized: string;
+  signalRef: string;
+  confidence: number;
+}
+
+export interface ResolvedEntity {
+  entityId: string;
+  kind: EntityKind;
+  surfaces: string[];
+  signalRefs: string[];
+  confidence: number;
+}
+
+const EMAIL_RE = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi;
+const ORG_SUFFIX_RE =
+  /\b([A-Z][\w&]*(?:\s+[A-Z][\w&]*)*)\s+(Inc|LLC|Corp|Corporation|Co|Ltd|GmbH)\b/g;
+
+/** Default token-overlap floor for fuzzy org merge — conservative (#260-style gate). */
+export const ORG_MERGE_FLOOR = 0.6;
+
+function firstEmail(s: string): string | null {
+  const m = s.match(EMAIL_RE);
+  return m ? m[0].toLowerCase() : null;
+}
+
+function normalizeOrg(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\b(inc|llc|corp|corporation|co|ltd|gmbh)\b\.?/g, '')
+    .replace(/[^a-z0-9 ]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokens(s: string): Set<string> {
+  return new Set(s.split(' ').filter(Boolean));
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let inter = 0;
+  for (const x of a) if (b.has(x)) inter++;
+  return inter / (a.size + b.size - inter);
+}
+
+/** Extract person (emails) + org (suffix-tagged) entities from a signal. */
+export function extractEntities(signal: SignalText): ExtractedEntity[] {
+  const ref = `${signal.source}:${signal.title}`; // caller may override via signalRef
+  const text = `${signal.title}\n${signal.body}`;
+  const out: ExtractedEntity[] = [];
+
+  const emails = new Set<string>();
+  for (const p of signal.participants) {
+    const e = firstEmail(p);
+    if (e) emails.add(e);
+  }
+  for (const m of text.match(EMAIL_RE) ?? []) emails.add(m.toLowerCase());
+  for (const email of emails) {
+    out.push({ kind: 'person', surface: email, normalized: email, signalRef: ref, confidence: 0.95 });
+  }
+
+  for (const m of text.matchAll(ORG_SUFFIX_RE)) {
+    const surface = m[0];
+    out.push({ kind: 'org', surface, normalized: normalizeOrg(surface), signalRef: ref, confidence: 0.8 });
+  }
+
+  return out;
+}
+
+function slug(s: string): string {
+  return s.replace(/\s+/g, '-').slice(0, 40) || 'x';
+}
+
+/**
+ * Resolve extracted mentions to stable entities. People merge on exact
+ * (normalized) email; orgs merge on exact normalized string OR token-overlap
+ * >= floor; otherwise a NEW entity is minted. Conservative: when uncertain it
+ * splits (mints) rather than risking a false merge.
+ */
+export function resolveEntities(
+  extracted: ExtractedEntity[],
+  floor: number = ORG_MERGE_FLOOR,
+): ResolvedEntity[] {
+  const resolved: ResolvedEntity[] = [];
+  let mintCounter = 0;
+
+  const add = (target: ResolvedEntity, e: ExtractedEntity) => {
+    if (!target.surfaces.includes(e.surface)) target.surfaces.push(e.surface);
+    if (!target.signalRefs.includes(e.signalRef)) target.signalRefs.push(e.signalRef);
+  };
+
+  for (const e of extracted) {
+    if (e.kind === 'person') {
+      // Strong key: email. Exact match only — never fuzzy-merge people.
+      const id = `person:${e.normalized}`;
+      const existing = resolved.find((r) => r.entityId === id);
+      if (existing) add(existing, e);
+      else resolved.push({ entityId: id, kind: 'person', surfaces: [e.surface], signalRefs: [e.signalRef], confidence: e.confidence });
+      continue;
+    }
+
+    // org: exact normalized, else fuzzy >= floor against same-kind, else mint.
+    const exact = resolved.find((r) => r.kind === 'org' && r.entityId === `org:${slug(e.normalized)}`);
+    if (exact) {
+      add(exact, e);
+      continue;
+    }
+    const fuzzy = resolved.find(
+      (r) => r.kind === 'org' && jaccard(tokens(r.entityId.replace(/^org:/, '').replace(/-/g, ' ')), tokens(e.normalized)) >= floor,
+    );
+    if (fuzzy) {
+      add(fuzzy, e);
+      continue;
+    }
+    mintCounter++;
+    resolved.push({
+      entityId: `org:${slug(e.normalized)}`,
+      kind: 'org',
+      surfaces: [e.surface],
+      signalRefs: [e.signalRef],
+      confidence: e.confidence,
+    });
+  }
+
+  return resolved;
+}
+
+/** Convenience: signals → extracted → resolved, with per-signal refs. */
+export function linkEntitiesAcrossSignals(
+  signals: Array<{ ref: string; signal: SignalText }>,
+): ResolvedEntity[] {
+  const all: ExtractedEntity[] = [];
+  for (const { ref, signal } of signals) {
+    for (const e of extractEntities(signal)) all.push({ ...e, signalRef: ref });
+  }
+  return resolveEntities(all);
+}

--- a/packages/decision-engine/src/entity-linking.ts
+++ b/packages/decision-engine/src/entity-linking.ts
@@ -28,6 +28,8 @@ export interface ExtractedEntity {
 export interface ResolvedEntity {
   entityId: string;
   kind: EntityKind;
+  /** Full normalized key — used for matching (NOT the truncated slug). */
+  normalized: string;
   surfaces: string[];
   signalRefs: string[];
   confidence: number;
@@ -117,18 +119,28 @@ export function resolveEntities(
       const id = `person:${e.normalized}`;
       const existing = resolved.find((r) => r.entityId === id);
       if (existing) add(existing, e);
-      else resolved.push({ entityId: id, kind: 'person', surfaces: [e.surface], signalRefs: [e.signalRef], confidence: e.confidence });
+      else
+        resolved.push({
+          entityId: id,
+          kind: 'person',
+          normalized: e.normalized,
+          surfaces: [e.surface],
+          signalRefs: [e.signalRef],
+          confidence: e.confidence,
+        });
       continue;
     }
 
     // org: exact normalized, else fuzzy >= floor against same-kind, else mint.
-    const exact = resolved.find((r) => r.kind === 'org' && r.entityId === `org:${slug(e.normalized)}`);
+    // Compare against the FULL normalized string, not the truncated entityId
+    // slug, so long org names don't degrade the overlap score (review #10).
+    const exact = resolved.find((r) => r.kind === 'org' && r.normalized === e.normalized);
     if (exact) {
       add(exact, e);
       continue;
     }
     const fuzzy = resolved.find(
-      (r) => r.kind === 'org' && jaccard(tokens(r.entityId.replace(/^org:/, '').replace(/-/g, ' ')), tokens(e.normalized)) >= floor,
+      (r) => r.kind === 'org' && jaccard(tokens(r.normalized), tokens(e.normalized)) >= floor,
     );
     if (fuzzy) {
       add(fuzzy, e);
@@ -138,6 +150,7 @@ export function resolveEntities(
     resolved.push({
       entityId: `org:${slug(e.normalized)}`,
       kind: 'org',
+      normalized: e.normalized,
       surfaces: [e.surface],
       signalRefs: [e.signalRef],
       confidence: e.confidence,

--- a/packages/decision-engine/src/entity-linking.ts
+++ b/packages/decision-engine/src/entity-linking.ts
@@ -13,6 +13,7 @@
  * (`getSignalsForEntity`) is the remaining integration seam (spec 05 §5).
  */
 
+import { createHash } from 'node:crypto';
 import type { SignalText } from './signal-text.js';
 
 export type EntityKind = 'person' | 'org';
@@ -69,7 +70,7 @@ function jaccard(a: Set<string>, b: Set<string>): number {
 
 /** Extract person (emails) + org (suffix-tagged) entities from a signal. */
 export function extractEntities(signal: SignalText): ExtractedEntity[] {
-  const ref = `${signal.source}:${signal.title}`; // caller may override via signalRef
+  const ref = `${signal.source}:${signal.title}`;
   const text = `${signal.title}\n${signal.body}`;
   const out: ExtractedEntity[] = [];
 
@@ -95,6 +96,14 @@ function slug(s: string): string {
   return s.replace(/\s+/g, '-').slice(0, 40) || 'x';
 }
 
+function stableHash(s: string): string {
+  return createHash('sha256').update(s).digest('hex').slice(0, 12);
+}
+
+function orgEntityId(normalized: string): string {
+  return `org:${slug(normalized)}:${stableHash(normalized)}`;
+}
+
 /**
  * Resolve extracted mentions to stable entities. People merge on exact
  * (normalized) email; orgs merge on exact normalized string OR token-overlap
@@ -106,7 +115,6 @@ export function resolveEntities(
   floor: number = ORG_MERGE_FLOOR,
 ): ResolvedEntity[] {
   const resolved: ResolvedEntity[] = [];
-  let mintCounter = 0;
 
   const add = (target: ResolvedEntity, e: ExtractedEntity) => {
     if (!target.surfaces.includes(e.surface)) target.surfaces.push(e.surface);
@@ -146,9 +154,8 @@ export function resolveEntities(
       add(fuzzy, e);
       continue;
     }
-    mintCounter++;
     resolved.push({
-      entityId: `org:${slug(e.normalized)}`,
+      entityId: orgEntityId(e.normalized),
       kind: 'org',
       normalized: e.normalized,
       surfaces: [e.surface],

--- a/packages/decision-engine/src/index.ts
+++ b/packages/decision-engine/src/index.ts
@@ -28,6 +28,21 @@ export type {
   AuthoredExamplesPort,
   DraftEmailCandidateGeneratorOptions,
 } from './strategies/draft-email-candidate.js';
+// Multi-source normalization (spec 07): the channel-agnostic accessor + matrix
+// that make commitment/deadline/security/clustering/entity capabilities
+// source-agnostic.
+export {
+  toSignalText,
+  isAuthoredByUser,
+  type SignalText,
+} from './signal-text.js';
+export {
+  CAPABILITY_SOURCE_MATRIX,
+  capabilityCoversSource,
+  sourcesForCapability,
+  type Capability,
+} from './capability-source-matrix.js';
+
 export { isTrivialAutoEmail } from './cost-gate.js';
 export type {
   CostGatePort,

--- a/packages/decision-engine/src/index.ts
+++ b/packages/decision-engine/src/index.ts
@@ -66,6 +66,11 @@ export {
   type ConnectedAccountInfo,
   type CoverageCapability,
 } from './source-coverage.js';
+export {
+  isHidden,
+  filterVisible,
+  type SignalVisibilityMeta,
+} from './visibility-filter.js';
 
 export { isTrivialAutoEmail } from './cost-gate.js';
 export type {

--- a/packages/decision-engine/src/index.ts
+++ b/packages/decision-engine/src/index.ts
@@ -90,6 +90,12 @@ export {
   type ExtractedEntity,
   type ResolvedEntity,
 } from './entity-linking.js';
+export {
+  buildDigestItemDetail,
+  provenanceLabel,
+  type DigestItemDetail,
+  type DigestItemDetailInput,
+} from './digest-detail.js';
 
 export { isTrivialAutoEmail } from './cost-gate.js';
 export type {

--- a/packages/decision-engine/src/index.ts
+++ b/packages/decision-engine/src/index.ts
@@ -72,6 +72,15 @@ export {
   type SignalVisibilityMeta,
 } from './visibility-filter.js';
 export { resolveLanguage, resolveTimezone, isNonEnglish } from './locale.js';
+export {
+  buildDigest,
+  type Digest,
+  type DigestItem,
+  type DigestTodo,
+  type DigestTopic,
+  type DigestTopicItem,
+  type BuildDigestOptions,
+} from './digest.js';
 
 export { isTrivialAutoEmail } from './cost-gate.js';
 export type {

--- a/packages/decision-engine/src/index.ts
+++ b/packages/decision-engine/src/index.ts
@@ -81,6 +81,15 @@ export {
   type DigestTopicItem,
   type BuildDigestOptions,
 } from './digest.js';
+export {
+  extractEntities,
+  resolveEntities,
+  linkEntitiesAcrossSignals,
+  ORG_MERGE_FLOOR,
+  type EntityKind,
+  type ExtractedEntity,
+  type ResolvedEntity,
+} from './entity-linking.js';
 
 export { isTrivialAutoEmail } from './cost-gate.js';
 export type {

--- a/packages/decision-engine/src/index.ts
+++ b/packages/decision-engine/src/index.ts
@@ -52,6 +52,13 @@ export {
   type Commitment,
   type CommitmentStrategy,
 } from './commitment-extractor.js';
+export {
+  clusterSignals,
+  type ClusterSignal,
+  type TopicCluster,
+  type ClusterOptions,
+  type ClusterStrategy,
+} from './topic-clusterer.js';
 
 export { isTrivialAutoEmail } from './cost-gate.js';
 export type {

--- a/packages/decision-engine/src/index.ts
+++ b/packages/decision-engine/src/index.ts
@@ -47,6 +47,11 @@ export {
   type DeadlineSource,
   type ExtractedDeadline,
 } from './deadline-extractor.js';
+export {
+  extractCommitments,
+  type Commitment,
+  type CommitmentStrategy,
+} from './commitment-extractor.js';
 
 export { isTrivialAutoEmail } from './cost-gate.js';
 export type {

--- a/packages/decision-engine/src/index.ts
+++ b/packages/decision-engine/src/index.ts
@@ -59,6 +59,13 @@ export {
   type ClusterOptions,
   type ClusterStrategy,
 } from './topic-clusterer.js';
+export {
+  computeCoverage,
+  type SourceCoverage,
+  type CapabilityStatus,
+  type ConnectedAccountInfo,
+  type CoverageCapability,
+} from './source-coverage.js';
 
 export { isTrivialAutoEmail } from './cost-gate.js';
 export type {

--- a/packages/decision-engine/src/index.ts
+++ b/packages/decision-engine/src/index.ts
@@ -42,6 +42,11 @@ export {
   sourcesForCapability,
   type Capability,
 } from './capability-source-matrix.js';
+export {
+  extractDeadline,
+  type DeadlineSource,
+  type ExtractedDeadline,
+} from './deadline-extractor.js';
 
 export { isTrivialAutoEmail } from './cost-gate.js';
 export type {

--- a/packages/decision-engine/src/index.ts
+++ b/packages/decision-engine/src/index.ts
@@ -71,6 +71,7 @@ export {
   filterVisible,
   type SignalVisibilityMeta,
 } from './visibility-filter.js';
+export { resolveLanguage, resolveTimezone, isNonEnglish } from './locale.js';
 
 export { isTrivialAutoEmail } from './cost-gate.js';
 export type {

--- a/packages/decision-engine/src/locale.ts
+++ b/packages/decision-engine/src/locale.ts
@@ -1,0 +1,30 @@
+/**
+ * Locale & timezone resolution helpers (#spec 12, #486).
+ *
+ * The briefing prose locale was hardcoded 'en', users have no language/timezone,
+ * and the extraction fallbacks are English-only. These pure helpers centralize
+ * the safe-fallback rules and the "is this non-English?" routing signal so the
+ * LLM path handles other locales and the English rule fallback marks itself
+ * `degraded` instead of silently returning empty.
+ */
+
+/** Resolve the effective language, falling back to 'en'. */
+export function resolveLanguage(lang?: string | null): string {
+  const l = (lang ?? '').trim();
+  return l.length > 0 ? l : 'en';
+}
+
+/**
+ * Resolve the effective timezone. `defaulted` is true when we fell back to UTC
+ * (the caller should log a warning — we never silently guess a tz).
+ */
+export function resolveTimezone(tz?: string | null): { timezone: string; defaulted: boolean } {
+  const t = (tz ?? '').trim();
+  return t.length > 0 ? { timezone: t, defaulted: false } : { timezone: 'UTC', defaulted: true };
+}
+
+/** True when the language is anything other than English. Drives LLM-vs-rule routing. */
+export function isNonEnglish(lang?: string | null): boolean {
+  const l = resolveLanguage(lang).toLowerCase();
+  return !(l === 'en' || l.startsWith('en-') || l.startsWith('en_'));
+}

--- a/packages/decision-engine/src/signal-text.ts
+++ b/packages/decision-engine/src/signal-text.ts
@@ -1,0 +1,186 @@
+/**
+ * Normalized text accessor for any RawSignal, regardless of source (#spec 07).
+ *
+ * Every capability that reads signal content — commitment extraction (spec 02),
+ * deadline extraction (spec 03), the security classifier (spec 06) — should
+ * consume `SignalText` rather than reaching into a source-specific `data` shape.
+ * That's what makes those capabilities source-agnostic: a commitment spoken into
+ * a voice note or a deadline in a project-file TODO is read the same way as one
+ * in an email.
+ *
+ * Pure and side-effect-free so it can be unit-tested without a connector. The
+ * per-source field mapping lives here; unknown sources fall back to best-effort
+ * field lookups and `authoredByUser = false` (fail safe — never assume the user
+ * authored content we can't classify).
+ */
+
+import type { RawSignal, AuthoringTier } from '@skytwin/connectors';
+
+export interface SignalText {
+  /** Channel string from the originating RawSignal (e.g. 'gmail', 'voice'). */
+  source: string;
+  /** Subject / event title / file name / "Voice note". */
+  title: string;
+  /** Body / event description / file excerpt / transcript. */
+  body: string;
+  /** AuthoringTier if the connector stamped one (email + calendar do today). */
+  authoringTier?: AuthoringTier;
+  /** Derived: did the user author this content? Fail-safe false when unknown. */
+  authoredByUser: boolean;
+  /** Timestamp anchor for relative deadline/temporal resolution. */
+  occurredAt: Date;
+  /** Recipients / attendees / collaborators (bare-ish address strings). */
+  participants: string[];
+}
+
+/**
+ * Tiers that mean "the user authored this content." Maps both the email
+ * `user_sent_*` tiers and the channel-agnostic `authored_originated` tier
+ * (#251 extension). Everything else — inbound, received, automated, or
+ * unknown — is NOT user-authored.
+ */
+const AUTHORED_TIERS: ReadonlySet<AuthoringTier> = new Set<AuthoringTier>([
+  'user_sent_originated',
+  'user_sent_reply',
+  'authored_originated',
+]);
+
+/** True only for tiers that denote user-authored content. Fail-safe: undefined → false. */
+export function isAuthoredByUser(tier: AuthoringTier | undefined): boolean {
+  return tier !== undefined && AUTHORED_TIERS.has(tier);
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+/** First non-empty string among the candidates. */
+function firstStr(...vals: unknown[]): string {
+  for (const v of vals) {
+    const s = str(v);
+    if (s) return s;
+  }
+  return '';
+}
+
+/** Split a raw address-list header ("A <a@x>, b@y") into trimmed parts. */
+function splitAddresses(v: unknown): string[] {
+  if (Array.isArray(v)) {
+    return v.map((x) => str(x)).filter((s) => s.length > 0);
+  }
+  return str(v)
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/** Pull attendee/organizer emails from a calendar `data` payload. */
+function calendarParticipants(data: Record<string, unknown>): string[] {
+  const out: string[] = [];
+  const organizer = str(data['organizer']) || str(data['from']);
+  if (organizer) out.push(organizer);
+  const attendees = data['attendees'];
+  if (Array.isArray(attendees)) {
+    for (const a of attendees) {
+      if (a && typeof a === 'object' && 'email' in a) {
+        const email = str((a as Record<string, unknown>)['email']);
+        if (email) out.push(email);
+      } else {
+        const email = str(a);
+        if (email) out.push(email);
+      }
+    }
+  }
+  // de-dup, preserve order
+  return [...new Set(out)];
+}
+
+function coerceDate(ts: unknown): Date {
+  if (ts instanceof Date) return ts;
+  if (typeof ts === 'string' || typeof ts === 'number') {
+    const d = new Date(ts);
+    if (!Number.isNaN(d.getTime())) return d;
+  }
+  return new Date(0); // epoch fallback — deterministic, never NaN
+}
+
+/**
+ * Normalize a RawSignal into channel-agnostic SignalText. The per-source
+ * mapping covers the connectors that exist today (gmail, google_calendar,
+ * their mocks, filesystem from idle-miner, voice transcripts); any other
+ * source falls through to a best-effort generic mapping with
+ * `authoredByUser = false`.
+ */
+export function toSignalText(signal: RawSignal): SignalText {
+  const data: Record<string, unknown> =
+    signal.data && typeof signal.data === 'object'
+      ? (signal.data as Record<string, unknown>)
+      : {};
+
+  const tierRaw = data['authoringTier'];
+  const authoringTier =
+    typeof tierRaw === 'string' ? (tierRaw as AuthoringTier) : undefined;
+
+  let title = '';
+  let body = '';
+  let participants: string[] = [];
+
+  switch (signal.source) {
+    case 'gmail':
+    case 'email':
+      title = str(data['subject']);
+      // Gmail signals carry `snippet` (a body proxy); mocks may carry `body`.
+      body = firstStr(data['body'], data['snippet'], data['text']);
+      participants = [
+        ...splitAddresses(data['to']),
+        ...splitAddresses(data['cc']),
+        ...splitAddresses(data['from']),
+      ];
+      participants = [...new Set(participants)];
+      break;
+
+    case 'google_calendar':
+    case 'calendar':
+      title = firstStr(data['title'], data['summary']);
+      body = str(data['description']);
+      participants = calendarParticipants(data);
+      break;
+
+    case 'filesystem':
+      title = firstStr(data['fileName'], data['path'], data['title']);
+      body = firstStr(data['excerpt'], data['body'], data['content'], data['snippet']);
+      break;
+
+    case 'voice':
+      title = firstStr(data['title']) || 'Voice note';
+      body = firstStr(data['transcript'], data['text'], data['body']);
+      break;
+
+    default:
+      // Unknown/future source — best-effort, fail safe on authorship.
+      title = firstStr(data['title'], data['subject'], data['name'], data['summary']);
+      body = firstStr(
+        data['body'],
+        data['description'],
+        data['snippet'],
+        data['transcript'],
+        data['text'],
+      );
+      participants = [
+        ...splitAddresses(data['to']),
+        ...splitAddresses(data['from']),
+      ];
+      participants = [...new Set(participants)];
+      break;
+  }
+
+  return {
+    source: signal.source,
+    title,
+    body,
+    authoringTier,
+    authoredByUser: isAuthoredByUser(authoringTier),
+    occurredAt: coerceDate(signal.timestamp),
+    participants,
+  };
+}

--- a/packages/decision-engine/src/situation-interpreter.ts
+++ b/packages/decision-engine/src/situation-interpreter.ts
@@ -1,6 +1,7 @@
 import type { DecisionObject } from '@skytwin/shared-types';
 import { SituationType, resolveActionProvenance } from '@skytwin/shared-types';
 import type { SituationStrategy } from './strategies/situation-strategy.js';
+import { extractDeadline } from './deadline-extractor.js';
 
 /**
  * The SituationInterpreter examines raw events from signal connectors and
@@ -29,6 +30,12 @@ export class SituationInterpreter {
    * but setting it explicitly keeps the audit trail honest.
    */
   async interpret(rawEvent: Record<string, unknown>): Promise<DecisionObject> {
+    // Spec 03: stamp a content-derived deadline (if the connector didn't supply
+    // one) BEFORE either path runs, so the rule-based assessUrgency and any LLM
+    // strategy both see it. Mutates rawEvent in place — only sets `deadline`
+    // when absent, so connector-provided deadlines win.
+    this.enrichDeadline(rawEvent);
+
     const decision = this.strategy
       ? await this.strategy.interpret(rawEvent)
       : this.interpretRuleBased(rawEvent);
@@ -37,6 +44,37 @@ export class SituationInterpreter {
       decision.provenance = this.deriveProvenance(rawEvent);
     }
     return decision;
+  }
+
+  /**
+   * Extract a deadline from the event's free text and stamp `rawEvent.deadline`
+   * (ISO) plus `rawEvent.deadlinePhrase` for the explanation, when no structured
+   * deadline is already present. No-op if the connector supplied one. (spec 03)
+   */
+  private enrichDeadline(rawEvent: Record<string, unknown>): void {
+    if (rawEvent['deadline'] || rawEvent['dueDate'] || rawEvent['expiresAt']) return;
+    const data =
+      typeof rawEvent['data'] === 'object' && rawEvent['data'] !== null
+        ? (rawEvent['data'] as Record<string, unknown>)
+        : {};
+    const title = String(
+      rawEvent['subject'] ?? rawEvent['title'] ?? data['subject'] ?? data['title'] ?? '',
+    );
+    const body = String(
+      rawEvent['body'] ?? data['body'] ?? data['snippet'] ?? data['description'] ?? '',
+    );
+    if (!title && !body) return;
+    const tsRaw = rawEvent['timestamp'] ?? data['timestamp'] ?? rawEvent['receivedAt'];
+    const occurredAt = tsRaw ? new Date(String(tsRaw)) : new Date();
+    const found = extractDeadline({
+      title,
+      body,
+      occurredAt: Number.isNaN(occurredAt.getTime()) ? new Date() : occurredAt,
+    });
+    if (found) {
+      rawEvent['deadline'] = found.deadline.toISOString();
+      rawEvent['deadlinePhrase'] = found.rawPhrase;
+    }
   }
 
   /**

--- a/packages/decision-engine/src/situation-interpreter.ts
+++ b/packages/decision-engine/src/situation-interpreter.ts
@@ -10,26 +10,31 @@ import { extractDeadline } from './deadline-extractor.js';
  * triage, NOT a trust boundary — provenance stays untrusted regardless.
  */
 const SECURITY_ALERT_MARKERS: readonly string[] = [
+  // Curated to specific multi-word phrases (review #3): bare 'new device',
+  // 'compromised', 'password was', 'detected a login', 'was exposed' over-matched
+  // shipping notices, articles, and benign "welcome back" mail. These require
+  // account/sign-in context so they don't fire on ordinary content.
   'data breach',
   'security breach',
   'security alert',
   'suspicious sign-in',
   'suspicious signin',
   'suspicious login',
-  'new sign-in',
-  'new device',
+  'sign-in from a new device',
+  'log in from a new device',
+  'login from a new device',
+  'new device was detected',
+  'new sign-in to your account',
+  'unrecognized device',
   'unusual activity',
-  'unusual sign-in',
   'verify your identity',
   'verify your account',
   'account will be deleted',
   'account has been compromised',
-  'compromised',
+  'password was exposed',
+  'exposed in a data breach',
+  'exposed on the dark web',
   'dark web',
-  'was exposed',
-  'detected a login',
-  'detected a sign-in',
-  'password was',
 ];
 
 /**
@@ -69,10 +74,36 @@ export class SituationInterpreter {
       ? await this.strategy.interpret(rawEvent)
       : this.interpretRuleBased(rawEvent);
 
+    // Defense-in-depth (review safety #2): the security-marker check must hold
+    // even when an LLM strategy did the classification. If markers match, force
+    // SECURITY_ALERT so the escalate-only candidate path applies regardless of
+    // which path classified. (The rule path already returns SECURITY_ALERT.)
+    if (
+      decision.situationType !== SituationType.SECURITY_ALERT &&
+      this.matchesSecurityMarkers(rawEvent)
+    ) {
+      decision.situationType = SituationType.SECURITY_ALERT;
+      decision.domain = 'security';
+      if (decision.urgency === 'low' || decision.urgency === 'medium') {
+        decision.urgency = 'high';
+      }
+    }
+
     if (!decision.provenance) {
       decision.provenance = this.deriveProvenance(rawEvent);
     }
     return decision;
+  }
+
+  /** True when the event's subject/body match an inbound security-alert marker. */
+  private matchesSecurityMarkers(rawEvent: Record<string, unknown>): boolean {
+    const data =
+      typeof rawEvent['data'] === 'object' && rawEvent['data'] !== null
+        ? (rawEvent['data'] as Record<string, unknown>)
+        : {};
+    const subject = String(rawEvent['subject'] ?? data['subject'] ?? '').toLowerCase();
+    const body = String(rawEvent['body'] ?? data['body'] ?? data['snippet'] ?? '').toLowerCase();
+    return SECURITY_ALERT_MARKERS.some((m) => subject.includes(m) || body.includes(m));
   }
 
   /**
@@ -100,7 +131,11 @@ export class SituationInterpreter {
       body,
       occurredAt: Number.isNaN(occurredAt.getTime()) ? new Date() : occurredAt,
     });
-    if (found) {
+    // Only stamp a deadline still in the FUTURE relative to now (review #1): the
+    // extractor rejects past-relative-to-occurredAt, but a "respond in 2 days"
+    // from a 5-day-old email is already past now and would read as `critical` in
+    // assessUrgency (which measures from Date.now()).
+    if (found && found.deadline.getTime() > Date.now()) {
       rawEvent['deadline'] = found.deadline.toISOString();
       rawEvent['deadlinePhrase'] = found.rawPhrase;
     }
@@ -434,10 +469,14 @@ export class SituationInterpreter {
       const hoursUntilDeadline =
         (deadlineDate.getTime() - Date.now()) / (1000 * 60 * 60);
 
-      if (hoursUntilDeadline < 1) return 'critical';
-      if (hoursUntilDeadline < 4) return 'high';
-      if (hoursUntilDeadline < 24) return 'medium';
-      return 'low';
+      // Stale (negative) deadlines fall through to the per-type default rather
+      // than reading as `critical` (review #1). Far-out deadlines (>=24h) also
+      // fall through — a deadline must never DOWNGRADE a type's default urgency
+      // (review #2); previously this returned 'low' and de-prioritized e.g.
+      // calendar invites whose body mentioned a far date.
+      if (hoursUntilDeadline >= 0 && hoursUntilDeadline < 1) return 'critical';
+      if (hoursUntilDeadline >= 0 && hoursUntilDeadline < 4) return 'high';
+      if (hoursUntilDeadline >= 0 && hoursUntilDeadline < 24) return 'medium';
     }
 
     // Default urgency by situation type

--- a/packages/decision-engine/src/situation-interpreter.ts
+++ b/packages/decision-engine/src/situation-interpreter.ts
@@ -4,6 +4,35 @@ import type { SituationStrategy } from './strategies/situation-strategy.js';
 import { extractDeadline } from './deadline-extractor.js';
 
 /**
+ * Inbound account-security markers (spec 06). Matched case-insensitively as
+ * substrings of subject/body. Deliberately specific phrases (not bare "breach"
+ * / "exposed") to limit false positives on ordinary mail. A severity hint for
+ * triage, NOT a trust boundary — provenance stays untrusted regardless.
+ */
+const SECURITY_ALERT_MARKERS: readonly string[] = [
+  'data breach',
+  'security breach',
+  'security alert',
+  'suspicious sign-in',
+  'suspicious signin',
+  'suspicious login',
+  'new sign-in',
+  'new device',
+  'unusual activity',
+  'unusual sign-in',
+  'verify your identity',
+  'verify your account',
+  'account will be deleted',
+  'account has been compromised',
+  'compromised',
+  'dark web',
+  'was exposed',
+  'detected a login',
+  'detected a sign-in',
+  'password was',
+];
+
+/**
  * The SituationInterpreter examines raw events from signal connectors and
  * creates typed DecisionObjects. It classifies the situation type, determines
  * urgency, and extracts a structured representation of the decision at hand.
@@ -130,6 +159,16 @@ export class SituationInterpreter {
     const subject = String(rawEvent['subject'] ?? '').toLowerCase();
     const category = String(rawEvent['category'] ?? '').toLowerCase();
     const body = String(rawEvent['body'] ?? '').toLowerCase();
+
+    // Security alert (spec 06) — evaluated FIRST so a breach alert about a
+    // financial provider classifies as SECURITY_ALERT, not FINANCE_OPERATION,
+    // and a "verify your account" never falls through to plain EMAIL_TRIAGE.
+    // Inbound + untrusted; the candidate generator forces escalate-only.
+    if (
+      SECURITY_ALERT_MARKERS.some((m) => subject.includes(m) || body.includes(m))
+    ) {
+      return SituationType.SECURITY_ALERT;
+    }
 
     // Email triage
     if (
@@ -365,6 +404,7 @@ export class SituationInterpreter {
       [SituationType.SOCIAL_MEDIA]: 'social',
       [SituationType.DOCUMENT_MANAGEMENT]: 'documents',
       [SituationType.HEALTH_WELLNESS]: 'health',
+      [SituationType.SECURITY_ALERT]: 'security',
       [SituationType.GENERIC]: String(rawEvent['source'] ?? 'unknown'),
     };
 
@@ -415,6 +455,7 @@ export class SituationInterpreter {
       [SituationType.SOCIAL_MEDIA]: 'low',
       [SituationType.DOCUMENT_MANAGEMENT]: 'low',
       [SituationType.HEALTH_WELLNESS]: 'medium',
+      [SituationType.SECURITY_ALERT]: 'high',
       [SituationType.GENERIC]: 'low',
     };
 
@@ -524,6 +565,11 @@ export class SituationInterpreter {
         const typeStr = healthType ? `${String(healthType)}` : 'Health event';
         const providerStr = provider ? ` with ${String(provider)}` : '';
         return `${typeStr}${providerStr} needs attention.`;
+      }
+
+      case SituationType.SECURITY_ALERT: {
+        const what = subject ? `: "${String(subject)}"` : '';
+        return `Security alert needs review${what}. Open the provider directly; do not trust links in the message.`;
       }
 
       case SituationType.GENERIC:

--- a/packages/decision-engine/src/source-coverage.ts
+++ b/packages/decision-engine/src/source-coverage.ts
@@ -1,0 +1,104 @@
+/**
+ * Source-coverage model (#spec 13, #487).
+ *
+ * Given which connectors a user authorized, computes what the digest CAN and
+ * CANNOT surface, per capability — the inverse of spec 07's capability×source
+ * matrix. Drives graceful degradation ("a capability no-ops cleanly when its
+ * source is absent") and coverage transparency ("Calendar not connected — connect
+ * it for meeting to-dos"). Pure + testable; the UI affordances live in spec 08.
+ */
+
+import { CAPABILITY_SOURCE_MATRIX, type Capability } from './capability-source-matrix.js';
+
+export interface ConnectedAccountInfo {
+  provider: string;
+  scopes: string[];
+  isActive: boolean;
+}
+
+export type CoverageCapability = Capability | 'todos';
+
+export interface CapabilityStatus {
+  capability: CoverageCapability;
+  status: 'available' | 'partial' | 'unavailable';
+  /** Real sources that, if connected, would enable or enrich this capability. */
+  unlockedBy: string[];
+}
+
+export interface SourceCoverage {
+  connected: string[];
+  /** Real sources not connected that would unlock/enrich some capability. */
+  missing: string[];
+  capabilityStatus: CapabilityStatus[];
+  /** True when zero sources are connected (distinct from "connected but quiet"). */
+  coldStart: boolean;
+}
+
+// Mock sources (dev/test) are not real connectable accounts; excluded from the
+// coverage math so a real gmail user isn't told they're "missing" the email mock.
+const MOCK_SOURCES = new Set(['email', 'calendar']);
+
+// Some providers map to multiple sources.
+function normalizeProvider(provider: string): string[] {
+  if (provider === 'google') return ['gmail', 'google_calendar'];
+  return [provider];
+}
+
+function realSources(sources: Iterable<string>): string[] {
+  return [...sources].filter((s) => !MOCK_SOURCES.has(s));
+}
+
+const ALL_REAL_SOURCES = [
+  ...new Set(realSources(Object.values(CAPABILITY_SOURCE_MATRIX).flatMap((s) => [...s]))),
+];
+
+const COVERAGE_CAPABILITIES: CoverageCapability[] = [
+  'todos',
+  'commitments',
+  'deadlines',
+  'security',
+  'clusters',
+  'entities',
+];
+
+/**
+ * Evaluate coverage for a user's connected accounts.
+ *  - unavailable: no allowed source connected.
+ *  - available: every (real) allowed source connected.
+ *  - partial: some but not all allowed sources connected.
+ */
+export function computeCoverage(accounts: ConnectedAccountInfo[]): SourceCoverage {
+  const connectedSet = new Set<string>();
+  for (const a of accounts) {
+    if (a.isActive) {
+      for (const s of normalizeProvider(a.provider)) {
+        if (!MOCK_SOURCES.has(s)) connectedSet.add(s);
+      }
+    }
+  }
+  const connected = [...connectedSet].sort();
+
+  const capabilityStatus: CapabilityStatus[] = COVERAGE_CAPABILITIES.map((cap) => {
+    const allowed =
+      cap === 'todos'
+        ? ALL_REAL_SOURCES
+        : realSources(CAPABILITY_SOURCE_MATRIX[cap as Capability] ?? new Set());
+    const connectedAllowed = allowed.filter((s) => connectedSet.has(s));
+    const missingAllowed = allowed.filter((s) => !connectedSet.has(s)).sort();
+
+    let status: CapabilityStatus['status'];
+    if (connectedAllowed.length === 0) status = 'unavailable';
+    else if (missingAllowed.length === 0) status = 'available';
+    else status = 'partial';
+
+    return { capability: cap, status, unlockedBy: missingAllowed };
+  });
+
+  const missing = [
+    ...new Set(
+      capabilityStatus.flatMap((c) => (c.status === 'available' ? [] : c.unlockedBy)),
+    ),
+  ].sort();
+
+  return { connected, missing, capabilityStatus, coldStart: connected.length === 0 };
+}

--- a/packages/decision-engine/src/topic-clusterer.ts
+++ b/packages/decision-engine/src/topic-clusterer.ts
@@ -1,0 +1,98 @@
+/**
+ * Signal topic clustering for the digest (#spec 04, #477).
+ *
+ * Groups the briefing's awareness signals into named topic clusters scoped to
+ * life domains, for the "Topics to catch up on" section (spec 01). Clusters
+ * anchor to the user's KNOWN domains (from domain-extraction) when one fits, so
+ * SkyTwin beats the reference product's mis-filing — only genuine no-fit signals
+ * land in "More updates".
+ *
+ * Ships the deterministic fallback (group by the domain already tagged on each
+ * signal); an LLM strategy can layer on via `ClusterStrategy`. Pure + testable.
+ */
+
+export interface ClusterSignal {
+  ref: string;
+  domain: string | null;
+  subject?: string;
+  summary?: string;
+}
+
+export interface TopicCluster {
+  domain: string;
+  title: string;
+  signalRefs: string[];
+  confidence: number;
+}
+
+export interface ClusterOptions {
+  /** Known life domains (from domain-extraction) to anchor clusters to. */
+  knownDomains?: string[];
+  /** Hard cap on cluster count (default 8). Overflow merges into "More updates". */
+  maxClusters?: number;
+  /** Optional callback when overflow merging happens (caller logs it). */
+  onMerge?: (mergedDomains: string[]) => void;
+}
+
+export interface ClusterStrategy {
+  cluster(signals: ClusterSignal[], opts: ClusterOptions): TopicCluster[];
+}
+
+const OTHER_DOMAIN = 'other';
+const OTHER_TITLE = 'More updates';
+
+function titleFor(domain: string): string {
+  if (domain === OTHER_DOMAIN) return OTHER_TITLE;
+  return domain.charAt(0).toUpperCase() + domain.slice(1).replace(/[_-]+/g, ' ');
+}
+
+/**
+ * Deterministically cluster signals by their tagged domain, anchored to
+ * `knownDomains`. Guarantees: every signal appears in exactly one cluster;
+ * output length never exceeds `maxClusters` (overflow merges into "More
+ * updates"); a signal whose domain is a known domain is never placed in "other".
+ */
+export function clusterSignals(
+  signals: ClusterSignal[],
+  opts: ClusterOptions = {},
+  strategy?: ClusterStrategy,
+): TopicCluster[] {
+  if (strategy) return strategy.cluster(signals, opts);
+
+  const known = new Set(opts.knownDomains ?? []);
+  const maxClusters = Math.max(1, opts.maxClusters ?? 8);
+
+  // Bucket by domain (anchored to known domains; else "other").
+  const buckets = new Map<string, string[]>();
+  for (const s of signals) {
+    const fits = s.domain && (known.size === 0 || known.has(s.domain));
+    const key = fits ? (s.domain as string) : OTHER_DOMAIN;
+    const arr = buckets.get(key) ?? [];
+    arr.push(s.ref);
+    buckets.set(key, arr);
+  }
+
+  let clusters: TopicCluster[] = [...buckets.entries()].map(([domain, refs]) => ({
+    domain,
+    title: titleFor(domain),
+    signalRefs: refs,
+    confidence: domain === OTHER_DOMAIN ? 0.5 : 0.9,
+  }));
+
+  // Cap: keep the largest (maxClusters - 1) named clusters, merge the rest +
+  // any existing "other" into a single "More updates" cluster.
+  if (clusters.length > maxClusters) {
+    clusters.sort((a, b) => b.signalRefs.length - a.signalRefs.length);
+    const keep = clusters.slice(0, maxClusters - 1).filter((c) => c.domain !== OTHER_DOMAIN);
+    const overflow = clusters.filter((c) => !keep.includes(c));
+    const mergedRefs = overflow.flatMap((c) => c.signalRefs);
+    const mergedDomains = overflow.map((c) => c.domain).filter((d) => d !== OTHER_DOMAIN);
+    if (opts.onMerge && mergedDomains.length > 0) opts.onMerge(mergedDomains);
+    clusters = [
+      ...keep,
+      { domain: OTHER_DOMAIN, title: OTHER_TITLE, signalRefs: mergedRefs, confidence: 0.5 },
+    ];
+  }
+
+  return clusters;
+}

--- a/packages/decision-engine/src/visibility-filter.ts
+++ b/packages/decision-engine/src/visibility-filter.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared hidden-content predicate (#spec 11, #485).
+ *
+ * The memory layer already honors user hide/pin (the gbrain CRDB adapter drops
+ * pages with `metadata.userOverride === 'hidden'` / a `hidden_at` timestamp from
+ * retrieval), but the briefing/digest never consulted it — so hidden content
+ * leaked into the digest. This is the ONE definition of "hidden" the digest
+ * input selection must route through, so there are not two divergent notions.
+ *
+ * Pure + testable.
+ */
+
+export interface SignalVisibilityMeta {
+  /** Per-page/per-sender override set by hide controls (#270). */
+  userOverride?: string | null;
+  /** Snake/camel timestamp variants set when content is hidden. */
+  hidden_at?: unknown;
+  hiddenAt?: unknown;
+}
+
+/** True when the user has hidden this content. Null/undefined meta → not hidden. */
+export function isHidden(meta: SignalVisibilityMeta | null | undefined): boolean {
+  if (!meta) return false;
+  if (meta.userOverride === 'hidden') return true;
+  if (meta.hidden_at != null || meta.hiddenAt != null) return true;
+  return false;
+}
+
+/** Drop items the user has hidden, per `getMeta`. Preserves order. */
+export function filterVisible<T>(
+  items: T[],
+  getMeta: (item: T) => SignalVisibilityMeta | null | undefined,
+): T[] {
+  return items.filter((item) => !isHidden(getMeta(item)));
+}

--- a/packages/policy-engine/src/__tests__/policy-evaluator.test.ts
+++ b/packages/policy-engine/src/__tests__/policy-evaluator.test.ts
@@ -535,5 +535,33 @@ describe('PolicyEvaluator', () => {
       expect(result.allowed).toBe(true);
       expect(result.requiresApproval).toBe(false);
     });
+
+    it('requires approval for missing-write-scope escalations even when risk is negligible', async () => {
+      const repo = createMockPolicyRepository();
+      const evaluator = new PolicyEvaluator(repo as never);
+
+      const action = createAction({
+        actionType: 'escalate_to_user',
+        parameters: {
+          reason: 'missing_write_scope',
+          requiredScope: 'gmail.send',
+          originalActionType: 'send_reply',
+        },
+        estimatedCostCents: 0,
+        reversible: true,
+      });
+      const riskAssessment = createRiskAssessment(RiskTier.NEGLIGIBLE);
+
+      const result = await evaluator.evaluate(
+        action,
+        [],
+        TrustTier.HIGH_AUTONOMY,
+        riskAssessment,
+      );
+
+      expect(result.allowed).toBe(true);
+      expect(result.requiresApproval).toBe(true);
+      expect(result.reason).toContain('Write access is missing');
+    });
   });
 });

--- a/packages/policy-engine/src/__tests__/scope-gate.test.ts
+++ b/packages/policy-engine/src/__tests__/scope-gate.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { requiredWriteScope, hasWriteScope, applyScopeGate } from '../scope-gate.js';
+import { ConfidenceLevel, type CandidateAction } from '@skytwin/shared-types';
+
+const GMAIL_SEND = 'https://www.googleapis.com/auth/gmail.send';
+
+function cand(actionType: string): CandidateAction {
+  return {
+    id: 'c1',
+    decisionId: 'd1',
+    actionType,
+    description: `do ${actionType}`,
+    domain: 'email',
+    parameters: { to: 'a@x.com', body: 'hi' },
+    estimatedCostCents: 0,
+    reversible: false,
+    confidence: ConfidenceLevel.HIGH,
+    reasoning: 'x',
+  };
+}
+
+describe('requiredWriteScope (spec 11)', () => {
+  it('maps send/reply to gmail.send and calendar writes to calendar.events', () => {
+    expect(requiredWriteScope('send_reply')?.scope).toBe('gmail.send');
+    expect(requiredWriteScope('create_calendar_event')?.scope).toBe('calendar.events');
+    expect(requiredWriteScope('calendar_update')?.scope).toBe('calendar.events');
+  });
+  it('returns null for non-scoped actions', () => {
+    expect(requiredWriteScope('create_note')).toBeNull();
+    expect(requiredWriteScope('escalate_to_user')).toBeNull();
+  });
+});
+
+describe('hasWriteScope — fail-safe (spec 11)', () => {
+  it('true when the granted scopes include the required scope', () => {
+    expect(hasWriteScope('send_reply', [GMAIL_SEND])).toBe(true);
+  });
+  it('false (fail-safe) when the required scope is missing, empty, or unrelated', () => {
+    expect(hasWriteScope('send_reply', [])).toBe(false);
+    expect(hasWriteScope('send_reply', ['gmail.readonly'])).toBe(false);
+    // @ts-expect-error garbage input
+    expect(hasWriteScope('send_reply', null)).toBe(false);
+  });
+  it('true for actions that need no tracked scope', () => {
+    expect(hasWriteScope('create_note', [])).toBe(true);
+  });
+});
+
+describe('applyScopeGate (spec 11)', () => {
+  it('downgrades an un-granted send into a human-review grant-access escalation', () => {
+    const [out] = applyScopeGate([cand('send_reply')], []);
+    expect(out!.actionType).toBe('escalate_to_user');
+    expect(out!.parameters.reason).toBe('missing_write_scope');
+    expect(out!.parameters.requiredScope).toBe('gmail.send');
+    expect(out!.reversible).toBe(true);
+  });
+  it('passes a properly-scoped send through unchanged', () => {
+    const [out] = applyScopeGate([cand('send_reply')], [GMAIL_SEND]);
+    expect(out!.actionType).toBe('send_reply');
+  });
+  it('passes non-write candidates through unchanged', () => {
+    const [out] = applyScopeGate([cand('create_note')], []);
+    expect(out!.actionType).toBe('create_note');
+  });
+});

--- a/packages/policy-engine/src/__tests__/scope-gate.test.ts
+++ b/packages/policy-engine/src/__tests__/scope-gate.test.ts
@@ -24,6 +24,7 @@ describe('requiredWriteScope (spec 11)', () => {
     expect(requiredWriteScope('send_reply')?.scope).toBe('gmail.send');
     expect(requiredWriteScope('create_calendar_event')?.scope).toBe('calendar.events');
     expect(requiredWriteScope('calendar_update')?.scope).toBe('calendar.events');
+    expect(requiredWriteScope('tentative_accept')?.scope).toBe('calendar.events');
   });
   it('returns null for non-scoped actions', () => {
     expect(requiredWriteScope('create_note')).toBeNull();

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -15,6 +15,12 @@ export {
 export { TrustTierEngine } from './trust-tier-engine.js';
 export { ApprovalRouter, type ApprovalRepositoryPort } from './approval-router.js';
 export {
+  requiredWriteScope,
+  hasWriteScope,
+  applyScopeGate,
+  type ScopeRequirement,
+} from './scope-gate.js';
+export {
   SpendTracker,
   resolveEffectiveCaps,
   type SpendRepositoryPort,

--- a/packages/policy-engine/src/policy-evaluator.ts
+++ b/packages/policy-engine/src/policy-evaluator.ts
@@ -149,6 +149,14 @@ export class PolicyEvaluator {
     let confirmationLevel: ConfirmationLevel | undefined = guard.confirmationLevel;
     let approvalReason = guard.reason ?? '';
 
+    if (
+      action.actionType === 'escalate_to_user' &&
+      action.parameters['reason'] === 'missing_write_scope'
+    ) {
+      requiresApproval = true;
+      approvalReason = approvalReason || 'Write access is missing; user approval is required to grant access.';
+    }
+
     // Check autonomy settings if provided
     if (autonomySettings) {
       const settingsDecision = this.checkAutonomySettings(action, autonomySettings, riskAssessment);

--- a/packages/policy-engine/src/scope-gate.ts
+++ b/packages/policy-engine/src/scope-gate.ts
@@ -31,6 +31,11 @@ export function requiredWriteScope(actionType: string): ScopeRequirement | null 
   if (/(create|update|modify|delete|cancel|move|rsvp).*(event|calendar)|^calendar_/.test(a)) {
     return { scope: 'calendar.events', provider: 'google_calendar' };
   }
+  // Invite RSVP actions are calendar writes too (review #5) — they don't contain
+  // the literal "event"/"calendar" but they mutate the calendar via the API.
+  if (/(accept|decline|tentative)_invite|propose_alternative|^rsvp|respond_to_event/.test(a)) {
+    return { scope: 'calendar.events', provider: 'google_calendar' };
+  }
   return null;
 }
 

--- a/packages/policy-engine/src/scope-gate.ts
+++ b/packages/policy-engine/src/scope-gate.ts
@@ -1,0 +1,81 @@
+/**
+ * Write-scope gate (#spec 11, #485).
+ *
+ * The decision engine must never PROPOSE (let alone auto-execute) a write action
+ * the user never granted permission for. Scopes are stored on
+ * `connected_accounts` but were never consulted; this gate closes that. It
+ * composes with the injection guard — scope gating answers "are we allowed to
+ * attempt this at all", the injection guard answers "is this attempt safe to
+ * auto-run".
+ *
+ * Fail-safe: a scoped write action with empty/unknown granted scopes is treated
+ * as NOT granted (mirrors the provenance fail-safe, safety invariant #8).
+ */
+
+import type { CandidateAction } from '@skytwin/shared-types';
+
+export interface ScopeRequirement {
+  scope: string;
+  provider: string;
+}
+
+/**
+ * The write scope an action shape requires, or null if it isn't a write we gate
+ * on a specific scope (those are left to the injection guard / policy engine).
+ */
+export function requiredWriteScope(actionType: string): ScopeRequirement | null {
+  const a = actionType.toLowerCase();
+  if (/^send_|reply|compose|^email_send/.test(a)) {
+    return { scope: 'gmail.send', provider: 'gmail' };
+  }
+  if (/(create|update|modify|delete|cancel|move|rsvp).*(event|calendar)|^calendar_/.test(a)) {
+    return { scope: 'calendar.events', provider: 'google_calendar' };
+  }
+  return null;
+}
+
+/**
+ * Does the user have the write scope this action requires? True when the action
+ * needs no tracked scope. Fail-safe: a required scope absent from `grantedScopes`
+ * (including empty/garbage) returns false.
+ */
+export function hasWriteScope(actionType: string, grantedScopes: string[]): boolean {
+  const req = requiredWriteScope(actionType);
+  if (!req) return true;
+  if (!Array.isArray(grantedScopes) || grantedScopes.length === 0) return false;
+  return grantedScopes.some((s) => typeof s === 'string' && s.includes(req.scope));
+}
+
+/**
+ * Downgrade any candidate whose write scope the user hasn't granted into a
+ * human-review "grant access" escalation. Non-write (or properly-scoped)
+ * candidates pass through unchanged. The downgraded candidate carries no
+ * auto-executable payload.
+ */
+export function applyScopeGate(
+  candidates: CandidateAction[],
+  grantedScopes: string[],
+): CandidateAction[] {
+  return candidates.map((c) => {
+    if (hasWriteScope(c.actionType, grantedScopes)) return c;
+    const req = requiredWriteScope(c.actionType);
+    return {
+      ...c,
+      actionType: 'escalate_to_user',
+      description:
+        `Connect write access (${req?.scope ?? 'required permission'}) to enable: ` +
+        `${c.description}`,
+      parameters: {
+        reason: 'missing_write_scope',
+        requiredScope: req?.scope ?? null,
+        provider: req?.provider ?? null,
+        originalActionType: c.actionType,
+      },
+      estimatedCostCents: 0,
+      reversible: true,
+      reasoning:
+        'Not proposed for auto-execution: the user has not granted the write ' +
+        `scope (${req?.scope ?? 'unknown'}) this action requires (spec 11).`,
+    };
+  });
+}

--- a/packages/policy-engine/src/scope-gate.ts
+++ b/packages/policy-engine/src/scope-gate.ts
@@ -33,7 +33,7 @@ export function requiredWriteScope(actionType: string): ScopeRequirement | null 
   }
   // Invite RSVP actions are calendar writes too (review #5) — they don't contain
   // the literal "event"/"calendar" but they mutate the calendar via the API.
-  if (/(accept|decline|tentative)_invite|propose_alternative|^rsvp|respond_to_event/.test(a)) {
+  if (/(accept|decline|tentative)_invite|tentative_accept|propose_alternative|^rsvp|respond_to_event/.test(a)) {
     return { scope: 'calendar.events', provider: 'google_calendar' };
   }
   return null;

--- a/packages/policy-prompts/prompts/briefing-prose/v2.md
+++ b/packages/policy-prompts/prompts/briefing-prose/v2.md
@@ -8,7 +8,7 @@ model_hints:
 temperature: 0.35
 expected_latency_ms: 800
 daily_token_budget_per_user: 40000
-deterministic_fallback: structured-passthrough
+deterministic_fallback: pass-through
 description: |
   Compose a daily briefing that SPLITS action-required to-dos from awareness
   topics (spec 01). v2 emits a structured payload (todos + domain-grouped topics)

--- a/packages/policy-prompts/prompts/briefing-prose/v2.md
+++ b/packages/policy-prompts/prompts/briefing-prose/v2.md
@@ -1,0 +1,57 @@
+---
+name: briefing-prose
+version: 2
+model_hints:
+  preferred: claude-haiku-4-5
+  acceptable: [claude-sonnet-4-6, gpt-5-mini]
+  fallback: deterministic
+temperature: 0.35
+expected_latency_ms: 800
+daily_token_budget_per_user: 40000
+deterministic_fallback: structured-passthrough
+description: |
+  Compose a daily briefing that SPLITS action-required to-dos from awareness
+  topics (spec 01). v2 emits a structured payload (todos + domain-grouped topics)
+  in addition to scannable Markdown, so the digest UI (spec 08) can render
+  two buckets with source chips and citations. When `domain` is set, the briefing
+  is scoped to that Lifebook domain.
+---
+
+# System
+You are a daily briefing writer for a digital twin. Split the day into two
+sections: **To-dos** (items that need the user to act) FIRST, then **Topics to
+catch up on** (awareness-only), grouped by life domain. An item is a to-do iff
+its `actionRequired` flag is true (the decision pipeline escalated it). Never put
+an `actionRequired` item under Topics. Lead with what needs the user.
+
+{{#if domain}}
+This is a per-Lifebook briefing scoped to **{{domain}}**. Only include items
+relevant to {{domain}}.
+{{/if}}
+
+User risk profile: {{risk_profile}}
+User language: {{language}}
+Date: {{date}}
+
+# User
+Today's items (each tagged actionRequired, domain, sourceType, deadline, signalRefs):
+{{events}}
+
+Pending tasks:
+{{pending_tasks}}
+
+# Output
+Return a JSON object:
+{
+  "briefing": string (valid Markdown, ≤600 words, To-dos section then Topics),
+  "todos": [{ "text": string, "sourceType": string, "deadline": string|null, "signalRefs": string[] }],
+  "topics": [{ "domain": string, "title": string, "items": [{ "text": string, "sourceType": string, "signalRefs": string[] }] }],
+  "highlight_count": number
+}
+
+# Constraints
+- To-dos FIRST, at most 7, each a single imperative sentence; urgency-ordered.
+- Topics SECOND, grouped by domain; never include an actionRequired item.
+- No item appears in both `todos` and `topics`.
+- Write in the user's language ({{language}}).
+- Return valid JSON only.

--- a/packages/shared-types/src/decision.ts
+++ b/packages/shared-types/src/decision.ts
@@ -48,6 +48,8 @@ export interface DecisionContext {
   episodicMemories?: import('./mempalace.js').EpisodicMemory[];
   /** Wake-up context (L0+L1) from the memory palace */
   wakeUpContext?: import('./mempalace.js').WakeUpContext;
+  /** OAuth/API scopes the user has granted for the source account. Missing means no write scopes. */
+  grantedScopes?: string[];
 }
 
 /**

--- a/packages/shared-types/src/enums.ts
+++ b/packages/shared-types/src/enums.ts
@@ -59,6 +59,9 @@ export enum SituationType {
   SOCIAL_MEDIA = 'social_media',
   DOCUMENT_MANAGEMENT = 'document_management',
   HEALTH_WELLNESS = 'health_wellness',
+  // Inbound account-security alert (breach/exposure, new-device, account
+  // deletion). Escalate-only — untrusted + phishing surface (spec 06, #479).
+  SECURITY_ALERT = 'security_alert',
   GENERIC = 'generic',
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,6 +495,9 @@ importers:
       '@skytwin/twin-model':
         specifier: workspace:*
         version: link:../twin-model
+      chrono-node:
+        specifier: ^2.7.7
+        version: 2.9.1
     devDependencies:
       typescript:
         specifier: ^6.0.3
@@ -2690,6 +2693,10 @@ packages:
 
   chromium-pickle-js@0.2.0:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
+
+  chrono-node@2.9.1:
+    resolution: {integrity: sha512-nqP8Zp11efCYQIESXPxeDM8ikzN5BDb3Zzou+a66fZq+X2hzKFdsNLQE2/uBAh//BZEMbaMo1eTnagK7hOenAg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   ci-info@2.0.0:
     resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
@@ -7584,6 +7591,8 @@ snapshots:
       - supports-color
 
   chromium-pickle-js@0.2.0: {}
+
+  chrono-node@2.9.1: {}
 
   ci-info@2.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,9 @@ importers:
 
   packages/decision-engine:
     dependencies:
+      '@skytwin/connectors':
+        specifier: workspace:*
+        version: link:../connectors
       '@skytwin/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
Implements the Inbox-Intelligence epic (#484) — 13 specs building the digest read
layer, source-agnostic extractors, the cross-cutting trust layer, UI, and launch
fixtures. Every commit builds + tests green; full suite green (70/70 turbo tasks).

## What's implemented (tested logic per commit)
- **#480 (07)** SignalText multi-source accessor + capability×source matrix
- **#474 (01)** digest to-do/FYI split (buildDigest) + briefing-prose v2 prompt
- **#476 (03)** deadline extraction (chrono-node) feeding urgency
- **#475 (02)** commitment extraction from authored content (gated, safety #8)
- **#479 (06)** inbound security-alert classifier, escalate-only [SAFETY]
- **#477 (04)** signal topic clustering
- **#478 (05)** entity extraction + conservative cross-signal resolution
- **#487 (13)** source-coverage model (graceful degradation / transparency)
- **#485 (11)** access-faithful gates: write-scope gate + hidden-content filter [SAFETY]
- **#486 (12)** locale & timezone (migration 063, briefing language wiring)
- **#483 (10)** observer default + provisioning + seedUpsert + promotion soak-floor
- **#482 (09)** launch demo fixture (3-gate guard, migration 064) — never runs for a real user
- **#481 (08)** digest UI: two-bucket, source-aware, cited (web) + API passthrough

## Integration seams left (documented in commits)
- briefing-generator decision-outcome query → actionRequired (spec 01 step 0)
- structured_payload column + generator write (spec 01/08 data population)
- MemoryPort.getSignalsForEntity port method + adapters (spec 05 §5)
- extractor degraded-locale routing on 02/03/06 (spec 12)
- mobile BriefingScreen mirror (spec 08)

## Tests
New: SignalText, capability-matrix, deadline, commitment, security-alert,
clustering, coverage, scope-gate, visibility, locale, digest, entity-linking,
seedUpsert, demo-guard, soak-floor. Full monorepo suite green.

Closes #480 #474 #476 #475 #479 #477 #478 #487 #485 #486 #483 #482 #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)
