### PR TITLE
feat(web): one-time tier-ladder intro card for cold-start observer users (#483 AC 3c)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "dev": "NODE_OPTIONS='--max-old-space-size=384' tsx watch src/index.ts",
     "start": "node dist/index.js",
-    "test": "echo 'No tests yet'",
+    "test": "vitest run",
     "lint": "echo 'No linting yet'"
   },
   "dependencies": {
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^1.3.0"
   }
 }

--- a/apps/web/public/js/components/__tests__/tier-ladder-intro.test.js
+++ b/apps/web/public/js/components/__tests__/tier-ladder-intro.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  shouldShowTierLadderIntro,
+  renderTierLadderIntroCard,
+  renderTierLadderIntro,
+} from '../tier-ladder-intro.js';
+import { tierLadderIntroSeenKey } from '../../storage-keys.js';
+
+/**
+ * Tests for the #483 tier-ladder INTRODUCTION card (AC 3c):
+ * a cold-start `observer` user is shown a one-time, dismissable intro;
+ * an existing (promoted) user — or one who already dismissed it — is not.
+ *
+ * The web app has no jsdom in its test env, so the component is split into
+ * pure functions (decision + HTML builder) plus a storage-injectable wrapper
+ * exercised here. The DOM side effect (`dismissTierLadderIntro`) is the only
+ * untested seam and is a one-liner `getElementById(...).remove()`.
+ */
+
+/** Minimal in-memory Storage stand-in. */
+function fakeStorage(initial = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    removeItem: (k) => map.delete(k),
+  };
+}
+
+describe('shouldShowTierLadderIntro', () => {
+  it('shows for a cold-start observer who has not dismissed', () => {
+    expect(shouldShowTierLadderIntro({ currentTier: 'observer', dismissed: false })).toBe(true);
+  });
+
+  it('hides once dismissed, even for an observer', () => {
+    expect(shouldShowTierLadderIntro({ currentTier: 'observer', dismissed: true })).toBe(false);
+  });
+
+  it('hides for a user who has climbed past observer', () => {
+    for (const tier of ['suggest', 'low_autonomy', 'moderate_autonomy', 'high_autonomy']) {
+      expect(shouldShowTierLadderIntro({ currentTier: tier, dismissed: false })).toBe(false);
+    }
+  });
+
+  it('hides when the tier is unknown/missing (fail safe — no nag)', () => {
+    expect(shouldShowTierLadderIntro({})).toBe(false);
+    expect(shouldShowTierLadderIntro({ currentTier: undefined, dismissed: false })).toBe(false);
+  });
+});
+
+describe('renderTierLadderIntroCard', () => {
+  it('renders a dismissable card with the data-action + data-key wired', () => {
+    const key = tierLadderIntroSeenKey('user-123');
+    const html = renderTierLadderIntroCard(key);
+    expect(html).toContain('id="tier-ladder-intro"');
+    expect(html).toContain('data-action="dismiss-tier-ladder-intro"');
+    expect(html).toContain(`data-key="${key}"`);
+  });
+
+  it('does NOT use any inline event-handler attribute (CLAUDE.md)', () => {
+    const html = renderTierLadderIntroCard(tierLadderIntroSeenKey('user-123'));
+    expect(html).not.toMatch(/on(click|keydown|keyup|mousedown|change|input)\s*=/i);
+  });
+
+  it('introduces the ladder, naming the bottom rung in human copy', () => {
+    const html = renderTierLadderIntroCard('skytwin_tier_ladder_intro_seen_x');
+    // Reuses existing tier labels rather than inventing new prose.
+    expect(html).toContain('Watch &amp; Suggest');
+    expect(html).toContain('Ask me first');
+    expect(html).toContain('Handle small stuff');
+    expect(html).toContain('Handle most things');
+  });
+
+  it('escapes a key that contains HTML-significant characters', () => {
+    const html = renderTierLadderIntroCard('a"><img src=x>');
+    expect(html).not.toContain('<img src=x>');
+    expect(html).toContain('&quot;');
+  });
+});
+
+describe('renderTierLadderIntro (storage-gated wrapper)', () => {
+  it('renders the card for a fresh observer with empty storage', () => {
+    const html = renderTierLadderIntro({
+      userId: 'u1',
+      currentTier: 'observer',
+      storage: fakeStorage(),
+    });
+    expect(html).toContain('id="tier-ladder-intro"');
+    expect(html).toContain(tierLadderIntroSeenKey('u1'));
+  });
+
+  it('returns empty string when the dismissal flag is already set', () => {
+    const key = tierLadderIntroSeenKey('u1');
+    const html = renderTierLadderIntro({
+      userId: 'u1',
+      currentTier: 'observer',
+      storage: fakeStorage({ [key]: '1' }),
+    });
+    expect(html).toBe('');
+  });
+
+  it('returns empty string for a promoted user', () => {
+    const html = renderTierLadderIntro({
+      userId: 'u1',
+      currentTier: 'suggest',
+      storage: fakeStorage(),
+    });
+    expect(html).toBe('');
+  });
+
+  it('returns empty string when userId is missing', () => {
+    expect(renderTierLadderIntro({ currentTier: 'observer', storage: fakeStorage() })).toBe('');
+  });
+
+  it('fails safe to empty string when storage throws (private mode)', () => {
+    const throwingStorage = {
+      getItem: () => { throw new Error('SecurityError'); },
+      setItem: () => {},
+      removeItem: () => {},
+    };
+    const html = renderTierLadderIntro({
+      userId: 'u1',
+      currentTier: 'observer',
+      storage: throwingStorage,
+    });
+    expect(html).toBe('');
+  });
+
+  it('scopes the dismissal flag per user', () => {
+    const key1 = tierLadderIntroSeenKey('alice');
+    const storage = fakeStorage({ [key1]: '1' });
+    // alice dismissed → hidden
+    expect(renderTierLadderIntro({ userId: 'alice', currentTier: 'observer', storage })).toBe('');
+    // bob, same browser, has not → still shown
+    expect(renderTierLadderIntro({ userId: 'bob', currentTier: 'observer', storage }))
+      .toContain('id="tier-ladder-intro"');
+  });
+});

--- a/apps/web/public/js/components/tier-ladder-intro.js
+++ b/apps/web/public/js/components/tier-ladder-intro.js
@@ -1,0 +1,140 @@
+/**
+ * Tier-ladder INTRODUCTION card — issue #483 (Part C, AC 3c).
+ *
+ * A brand-new user defaults to the most conservative trust tier, `observer`
+ * (LOCKED 2026-06-06 — see issue #483 "Resolved Decision"; the default lives
+ * in `apps/api/src/routes/users.ts` and `packages/db/src/schemas/schema.sql`,
+ * the ladder + promotion criteria in `packages/shared-types/src/enums.ts` and
+ * `packages/shared-types/src/policy.ts`). The dashboard already shows trust
+ * *progress* via `progress-bar.js`, but a cold-start observer lands on that
+ * progress bar with no introduction to what the ladder even is.
+ *
+ * This card closes that gap: a one-time, dismissable explanation of what
+ * `observer` means and how the climb works. It is shown exactly once per
+ * browser to a cold-start `observer` user and never re-shown once dismissed
+ * (localStorage flag) — and never shown to a user who has already climbed
+ * past `observer`.
+ *
+ * Copy reuses the existing tier labels (`tier-promotion-modal.js` TIER_COPY,
+ * `progress-bar.js` TIER_LABEL) rather than inventing new prose — the issue
+ * explicitly asks to reuse existing labels/copy.
+ *
+ * Design split for testability (no jsdom in the web app's test env):
+ *   - `shouldShowTierLadderIntro({ currentTier, dismissed })` — pure decision.
+ *   - `renderTierLadderIntroCard(key)` — pure HTML-string builder.
+ *   - `renderTierLadderIntro({ userId, currentTier, storage })` — thin wrapper
+ *     that reads the localStorage flag and composes the two above.
+ *   - `dismissTierLadderIntro(key)` — DOM + storage side effect.
+ */
+import { tierLadderIntroSeenKey } from '../storage-keys.js';
+
+const CARD_ID = 'tier-ladder-intro';
+
+// Pure attribute escaper. We deliberately do NOT reuse api-client's
+// `escapeHtml`, which builds a DOM node (`document.createElement`) and so
+// can't run in the web app's DOM-less vitest env — and would be overkill
+// for a controlled attribute value. The only untrusted segment is the
+// userId baked into the localStorage key; this hardens it regardless.
+function escapeAttr(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Card is only meaningful for the cold-start tier. Once the user has accepted
+// a promotion to `suggest` or beyond, the tier-promotion ceremony already
+// explained what the next tier does — re-introducing the ladder would be noise.
+const INTRO_TIER = 'observer';
+
+/**
+ * Pure decision: should the introduction card render?
+ *
+ * @param {object} opts
+ * @param {string} [opts.currentTier] — server-authoritative current tier.
+ * @param {boolean} [opts.dismissed]  — whether the user already dismissed it.
+ * @returns {boolean}
+ */
+export function shouldShowTierLadderIntro({ currentTier, dismissed } = {}) {
+  if (dismissed) return false;
+  return currentTier === INTRO_TIER;
+}
+
+/**
+ * Pure HTML-string builder for the card body. Exported for unit testing.
+ * `key` is embedded as the dismiss target; it is escaped because it contains
+ * a userId segment.
+ *
+ * @param {string} key — the localStorage flag key (passed to the dismiss btn).
+ * @returns {string} HTML
+ */
+export function renderTierLadderIntroCard(key) {
+  const safeKey = escapeAttr(key);
+  return `
+    <div class="card" id="${CARD_ID}" style="border-left: 3px solid var(--border-strong, var(--border)); background: linear-gradient(135deg, var(--bg-card) 0%, var(--bg) 100%);">
+      <div class="card-header">
+        <span class="card-title">You're in the driver's seat — here's how trust grows</span>
+        <button class="btn btn-outline btn-sm" data-action="dismiss-tier-ladder-intro" data-key="${safeKey}" aria-label="Dismiss tier introduction" style="padding: 0.15rem 0.5rem; font-size: 0.7rem;">Got it</button>
+      </div>
+      <div class="card-subtitle" style="line-height: 1.65;">
+        Right now I'm at <strong>Watch &amp; Suggest</strong> — I observe what comes in and explain what I'd do,
+        but I never act without your OK. That's the safe starting line for everyone.
+        <br><br>
+        As you approve my calls, I earn your trust step by step:
+        <strong>Watch &amp; Suggest</strong> &rarr; <strong>Ask me first</strong> &rarr;
+        <strong>Handle small stuff</strong> &rarr; <strong>Handle most things</strong>.
+        Each level lets me do a little more on my own — but only after a run of approvals,
+        and only once <em>you</em> accept the bump. I never promote myself.
+        Your spend limits and safety rules hold at every level.
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Compose the card for the dashboard. Returns an HTML string, or '' when the
+ * card should not render (not observer, already dismissed, or storage
+ * unavailable). Safe to call on every render — it's a no-op once dismissed.
+ *
+ * @param {object} opts
+ * @param {string} opts.userId
+ * @param {string} [opts.currentTier]
+ * @param {Storage} [opts.storage] — injectable for tests; defaults to
+ *   `localStorage` in the browser, `null` when no DOM (returns '').
+ * @returns {string} HTML or ''
+ */
+export function renderTierLadderIntro({
+  userId,
+  currentTier,
+  storage = typeof localStorage !== 'undefined' ? localStorage : null,
+} = {}) {
+  if (!userId) return '';
+  const key = tierLadderIntroSeenKey(userId);
+  let dismissed = false;
+  try {
+    dismissed = storage ? storage.getItem(key) === '1' : false;
+  } catch {
+    // Private mode / storage disabled: fail safe to "already seen" so a
+    // user who can't persist the dismissal isn't nagged on every render.
+    return '';
+  }
+  if (!shouldShowTierLadderIntro({ currentTier, dismissed })) return '';
+  return renderTierLadderIntroCard(key);
+}
+
+/**
+ * Persist the dismissal and remove the card from the DOM. Wired from the
+ * dashboard's hash-gated singleton click delegator (see dashboard-view.js).
+ *
+ * @param {string} key — the localStorage flag key from the dismiss button.
+ */
+export function dismissTierLadderIntro(key) {
+  if (key) {
+    try { localStorage.setItem(key, '1'); } catch { /* private mode */ }
+  }
+  if (typeof document !== 'undefined') {
+    document.getElementById(CARD_ID)?.remove();
+  }
+}

--- a/apps/web/public/js/pages/dashboard-view.js
+++ b/apps/web/public/js/pages/dashboard-view.js
@@ -17,6 +17,7 @@
  */
 
 import { askTwin, escapeHtml } from '../api-client.js';
+import { dismissTierLadderIntro } from '../components/tier-ladder-intro.js';
 import {
   KEY_USER_ID,
   KEY_ONBOARDED,
@@ -629,6 +630,9 @@ export function initDashboardGlobals() {
     } else if (action === 'connect-google') {
       const uid = el.getAttribute('data-user-id');
       if (uid) handleConnectGoogleFromDashboard(uid);
+    } else if (action === 'dismiss-tier-ladder-intro') {
+      const key = el.getAttribute('data-key');
+      if (key) dismissTierLadderIntro(key);
     }
   });
 

--- a/apps/web/public/js/pages/dashboard.js
+++ b/apps/web/public/js/pages/dashboard.js
@@ -1,5 +1,6 @@
 import { fetchHealth, fetchDecisions, fetchAccuracy, fetchConfidence, fetchLearning, fetchPendingApprovals, fetchSkillGaps, fetchTrustProgress, fetchLearned, fetchUnmetCredentials, fetchOAuthStatus, fetchCredentialsStatus, fetchBriefing, fetchLatestTwinBriefing, fetchLifebooks, fetchSettings, escapeHtml } from '../api-client.js';
 import { renderTrustProgress } from '../components/progress-bar.js';
+import { renderTierLadderIntro } from '../components/tier-ladder-intro.js';
 import {
   KEY_USER_ID,
   KEY_TOUR_MODE,
@@ -559,6 +560,8 @@ export async function renderDashboard(container, userId) {
     ${pending > 0 ? renderNotificationOptIn() : ''}
 
     ${renderUnmetCredentials(unmetCreds)}
+
+    ${prog && !tourMode ? renderTierLadderIntro({ userId, currentTier: prog.currentTier }) : ''}
 
     ${prog ? renderTrustProgress(prog) : ''}
 

--- a/apps/web/public/js/storage-keys.js
+++ b/apps/web/public/js/storage-keys.js
@@ -65,6 +65,17 @@ export function firstApprovalIntroSeenKey(userId) {
   return `skytwin_first_approval_intro_seen_${userId}`;
 }
 
+/**
+ * One-time flag for the tier-ladder INTRODUCTION card (#483 Part C, AC 3c).
+ * A cold-start `observer` user lands on a trust progress bar they were never
+ * introduced to; this gates a brief, dismissable "what observer means + how
+ * the climb works" card so it shows exactly once per browser and never again
+ * after dismissal.
+ */
+export function tierLadderIntroSeenKey(userId) {
+  return `skytwin_tier_ladder_intro_seen_${userId}`;
+}
+
 /** One-time celebration toast for crossing into the next trust tier. */
 export function tierCelebratedKey(userId, tier) {
   return `skytwin_tier_celebrated_${userId}_${tier}`;

--- a/apps/web/vitest.config.js
+++ b/apps/web/vitest.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+// The dashboard SPA under public/js is plain browser ESM (served statically,
+// not TS-compiled). Its unit tests are written to run in a DOM-less node env:
+// pure render helpers + storage-injectable wrappers, no jsdom dependency.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['public/js/**/*.test.js'],
+    passWithNoTests: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^1.3.0
+        version: 1.6.1(@types/node@25.9.1)(lightningcss@1.32.0)(terser@5.48.0)
 
   apps/worker:
     dependencies:
@@ -4448,10 +4451,6 @@ packages:
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -9546,12 +9545,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.8:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postgres-array@2.0.0: {}
 
   postgres-bytea@1.0.1: {}
@@ -10345,7 +10338,7 @@ snapshots:
   vite@5.4.21(@types/node@25.9.1)(lightningcss@1.32.0)(terser@5.48.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.5.8
+      postcss: 8.5.15
       rollup: 4.60.1
     optionalDependencies:
       '@types/node': 25.9.1


### PR DESCRIPTION
## What changed

A brand-new user defaults to the most conservative trust tier, `observer` (the LOCKED #483 default — code in `apps/api/src/routes/users.ts`, DB default in `packages/db/src/schemas/schema.sql`, ladder + promotion criteria in `packages/shared-types/src/enums.ts` and `packages/shared-types/src/policy.ts`). The dashboard already showed trust *progress* (`progress-bar.js`), but a cold-start observer landed on that progress bar with no introduction to what the ladder even is — exactly the gap the launch-readiness audit flagged as still open under #483.

This PR adds the one-time, dismissable tier-ladder **introduction**:

- **New component** `apps/web/public/js/components/tier-ladder-intro.js` — renders a brief card above the trust-progress bar explaining what "Watch & Suggest" means and how the climb works (`observer → suggest → low_autonomy → moderate_autonomy`, consensual, never self-promoting). Shown exactly once per browser to an `observer` user, never to a user who has already climbed, and never again after dismissal.
- **Storage key** `tierLadderIntroSeenKey(userId)` added to `storage-keys.js` (flag `skytwin_tier_ladder_intro_seen_<userId>`), so it's auditable + swept by the existing tour-exit/dev-reset helpers.
- **Dashboard render** (`dashboard.js`) places the card above `renderTrustProgress`, gated on `prog && !tourMode`.
- **Dismissal** wired through the dashboard's existing **hash-gated singleton click delegator** (`dashboard-view.js`) via a `data-action="dismiss-tier-ladder-intro"` attribute — no inline `onclick`/`onkeydown` (CLAUDE.md "Frontend Event Handling"). The dismiss handler reads `data-key` from the clicked element at click time, so a dev "Switch user" can't fire a stale-userId dismissal.

### Design / safety notes
- Copy **reuses the existing tier labels** (`tier-promotion-modal.js` TIER_COPY, `progress-bar.js` TIER_LABEL) rather than inventing new prose, as the issue asks.
- The card uses a **neutral hairline edge**, not the iris accent — `DESIGN.md` reserves the accent for "needs you / act here. Nothing else." This card is awareness, not an action.
- No safety invariants touched (no policy/execution/provenance/spend paths).

## Which ACs it satisfies

- **AC 3c** — "A cold-start `observer` user is shown a one-time, dismissable tier-ladder introduction; an existing user is not re-shown it." ✅

This PR is scoped to AC 3c only (the slice the launch-readiness audit carved out). Parts A (new-user bootstrap), B (idempotent seeding), and C.1 (soak-floor enforcement) are separate work.

## Tests added

14 new vitest cases in `apps/web/public/js/components/__tests__/tier-ladder-intro.test.js`:
- `shouldShowTierLadderIntro`: observer-shows, dismissed-hides, all 4 promoted tiers hide, unknown-tier fail-safe.
- `renderTierLadderIntroCard`: data-action + data-key wiring, **no inline event-handler attribute** assertion, reused tier labels present, attribute escaping.
- `renderTierLadderIntro` (storage-gated): fresh-observer renders, dismissed → '', promoted → '', missing userId → '', **private-mode (storage throws) fail-safe** → '', per-user flag scoping.

The component is split into a pure decision fn + pure HTML builder + storage-injectable wrapper so it runs in the web app's DOM-less vitest env (no jsdom). This PR also wires `apps/web` up to vitest (was a `echo 'No tests yet'` no-op) with a node-env config scoped to `public/js/**/*.test.js`.

Verified: `pnpm --filter @skytwin/web test` equivalent → **14/14 passing**. `tsc` build is unaffected (the web app's tsconfig only compiles `src/**/*.ts`; this change is served-as-is browser JS under `public/js/`).

Addresses #483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)