### PR TITLE
feat(security): AsyncLocalStorage request-context for userId isolation (#408)

### DIFF
--- a/apps/api/src/__tests__/request-context-middleware.test.ts
+++ b/apps/api/src/__tests__/request-context-middleware.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { requestContext } from '../middleware/request-context.js';
+import { getRequestUserId } from '@skytwin/db';
+
+/**
+ * Tests for the request-context middleware (#408).
+ *
+ * Uses the REAL @skytwin/db AsyncLocalStorage store (not a mock) so the test
+ * proves the middleware actually installs a context that deep callees observe.
+ */
+
+function mockReq(overrides: Partial<Request> = {}): Request {
+  return {
+    headers: {},
+    params: {},
+    query: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+function mockRes(): Response {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+describe('requestContext middleware (#408)', () => {
+  it('installs the authenticated userId so next() and its callees observe it', () => {
+    const req = mockReq({ authenticatedUserId: 'auth-user' });
+    const res = mockRes();
+    let observed: string | undefined;
+    const next: NextFunction = () => {
+      observed = getRequestUserId();
+    };
+
+    requestContext(req, res, next);
+    expect(observed).toBe('auth-user');
+  });
+
+  it('prefers the authenticated identity over the route param', () => {
+    const req = mockReq({
+      authenticatedUserId: 'auth-user',
+      params: { userId: 'param-user' } as Request['params'],
+    });
+    let observed: string | undefined;
+    requestContext(req, mockRes(), () => {
+      observed = getRequestUserId();
+    });
+    expect(observed).toBe('auth-user');
+  });
+
+  it('falls back to the route param when there is no authenticated identity (dev bypass)', () => {
+    const req = mockReq({ params: { userId: 'param-user' } as Request['params'] });
+    let observed: string | undefined;
+    requestContext(req, mockRes(), () => {
+      observed = getRequestUserId();
+    });
+    expect(observed).toBe('param-user');
+  });
+
+  it('does NOT trust body or query userId for the context', () => {
+    const req = mockReq({
+      body: { userId: 'body-user' },
+      query: { userId: 'query-user' } as Request['query'],
+    });
+    let observed: string | undefined;
+    requestContext(req, mockRes(), () => {
+      observed = getRequestUserId();
+    });
+    // No authenticated id, no route param → no context installed.
+    expect(observed).toBeUndefined();
+  });
+
+  it('runs next() with no context when no userId can be resolved (catalog routes)', () => {
+    const req = mockReq();
+    const next = vi.fn(() => {
+      expect(getRequestUserId()).toBeUndefined();
+    });
+    requestContext(req, mockRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('always calls next exactly once', () => {
+    const next = vi.fn();
+    requestContext(mockReq({ authenticatedUserId: 'u' }), mockRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -22,6 +22,7 @@ import { createSessionsRouter } from './routes/sessions.js';
 import { createAuditRouter } from './routes/audit.js';
 import { sessionAuth } from './middleware/session-auth.js';
 import { requireOwnership } from './middleware/require-ownership.js';
+import { requestContext } from './middleware/request-context.js';
 import { createPoliciesRouter } from './routes/policies.js';
 import { createActivityRouter } from './routes/activity.js';
 import { createMempalaceRouter } from './routes/mempalace.js';
@@ -312,51 +313,51 @@ app.get('/metrics', async (_req, res, next) => {
 
 // Routes
 // Protected routes
-app.use('/api/events', sessionAuth, requireOwnership, createEventsRouter());
-app.use('/api/twin', sessionAuth, requireOwnership, createTwinRouter());
-app.use('/api/decisions', sessionAuth, requireOwnership, createDecisionsRouter());
-app.use('/api/activity', sessionAuth, requireOwnership, createActivityRouter());
-app.use('/api/approvals', sessionAuth, requireOwnership, createApprovalsRouter());
-app.use('/api/feedback', sessionAuth, requireOwnership, createFeedbackRouter());
+app.use('/api/events', sessionAuth, requireOwnership, requestContext, createEventsRouter());
+app.use('/api/twin', sessionAuth, requireOwnership, requestContext, createTwinRouter());
+app.use('/api/decisions', sessionAuth, requireOwnership, requestContext, createDecisionsRouter());
+app.use('/api/activity', sessionAuth, requireOwnership, requestContext, createActivityRouter());
+app.use('/api/approvals', sessionAuth, requireOwnership, requestContext, createApprovalsRouter());
+app.use('/api/feedback', sessionAuth, requireOwnership, requestContext, createFeedbackRouter());
 app.use('/api/oauth', createOAuthRouter()); // manages its own public callback
-app.use('/api/evals', sessionAuth, requireOwnership, createEvalsRouter());
+app.use('/api/evals', sessionAuth, requireOwnership, requestContext, createEvalsRouter());
 app.use('/api/users', createUsersRouter());
-app.use('/api/proposals', sessionAuth, requireOwnership, createProposalsRouter());
-app.use('/api/v1/twin', sessionAuth, requireOwnership, createAskRouter());
-app.use('/api/v1/briefings', sessionAuth, requireOwnership, createBriefingsRouter());
-app.use('/api/v1/skill-gaps', sessionAuth, requireOwnership, createSkillGapsRouter());
-app.use('/api/settings', sessionAuth, requireOwnership, createSettingsRouter());
+app.use('/api/proposals', sessionAuth, requireOwnership, requestContext, createProposalsRouter());
+app.use('/api/v1/twin', sessionAuth, requireOwnership, requestContext, createAskRouter());
+app.use('/api/v1/briefings', sessionAuth, requireOwnership, requestContext, createBriefingsRouter());
+app.use('/api/v1/skill-gaps', sessionAuth, requireOwnership, requestContext, createSkillGapsRouter());
+app.use('/api/settings', sessionAuth, requireOwnership, requestContext, createSettingsRouter());
 app.use('/api/sessions', createSessionsRouter()); // POST pairing is public; others are protected in-router
-app.use('/api/audit', sessionAuth, requireOwnership, createAuditRouter());
-app.use('/api/policies', sessionAuth, requireOwnership, createPoliciesRouter());
-app.use('/api/mempalace', sessionAuth, requireOwnership, createMempalaceRouter());
-app.use('/api/memory-config', sessionAuth, requireOwnership, createMemoryConfigRouter());
-app.use('/api/assistant', sessionAuth, requireOwnership, createAssistantRouter());
-app.use('/api/credentials', sessionAuth, requireOwnership, createCredentialsRouter());
-app.use('/api/routines', sessionAuth, requireOwnership, createRoutinesRouter());
+app.use('/api/audit', sessionAuth, requireOwnership, requestContext, createAuditRouter());
+app.use('/api/policies', sessionAuth, requireOwnership, requestContext, createPoliciesRouter());
+app.use('/api/mempalace', sessionAuth, requireOwnership, requestContext, createMempalaceRouter());
+app.use('/api/memory-config', sessionAuth, requireOwnership, requestContext, createMemoryConfigRouter());
+app.use('/api/assistant', sessionAuth, requireOwnership, requestContext, createAssistantRouter());
+app.use('/api/credentials', sessionAuth, requireOwnership, requestContext, createCredentialsRouter());
+app.use('/api/routines', sessionAuth, requireOwnership, requestContext, createRoutinesRouter());
 app.use('/api/v1/demo', createDemoRouter()); // public — onboarding tour discovery
-app.use('/api/capabilities', sessionAuth, requireOwnership, createCapabilitiesRouter());
-app.use('/api/risk-profile', sessionAuth, requireOwnership, createRiskProfileRouter());
-app.use('/api/about-me', sessionAuth, requireOwnership, createAboutMeRouter());
-app.use('/api/twin-briefings', sessionAuth, requireOwnership, createTwinBriefingsRouter());
-app.use('/api/onboarding', sessionAuth, requireOwnership, createOnboardingRouter());
-app.use('/api/external-agents', sessionAuth, requireOwnership, createExternalAgentsRouter());
-app.use('/api/credential-vault', sessionAuth, requireOwnership, createCredentialVaultRouter());
-app.use('/api/dxt', sessionAuth, requireOwnership, createDxtRouter());
-app.use('/api/lifebooks', sessionAuth, requireOwnership, createLifebooksRouter());
-app.use('/api/federation', sessionAuth, createFederationRouter()); // userId-param ownership applied in-router
+app.use('/api/capabilities', sessionAuth, requireOwnership, requestContext, createCapabilitiesRouter());
+app.use('/api/risk-profile', sessionAuth, requireOwnership, requestContext, createRiskProfileRouter());
+app.use('/api/about-me', sessionAuth, requireOwnership, requestContext, createAboutMeRouter());
+app.use('/api/twin-briefings', sessionAuth, requireOwnership, requestContext, createTwinBriefingsRouter());
+app.use('/api/onboarding', sessionAuth, requireOwnership, requestContext, createOnboardingRouter());
+app.use('/api/external-agents', sessionAuth, requireOwnership, requestContext, createExternalAgentsRouter());
+app.use('/api/credential-vault', sessionAuth, requireOwnership, requestContext, createCredentialVaultRouter());
+app.use('/api/dxt', sessionAuth, requireOwnership, requestContext, createDxtRouter());
+app.use('/api/lifebooks', sessionAuth, requireOwnership, requestContext, createLifebooksRouter());
+app.use('/api/federation', sessionAuth, requestContext, createFederationRouter()); // userId-param ownership applied in-router
 // /api/voice — `requireOwnership` enforces body/path/query userId matches the
 // authenticated session. POST /transcribe + /synthesize take userId in the
 // body, so the in-router :userId middleware alone wasn't sufficient — caught
 // by Copilot on PR #255.
-app.use('/api/voice', sessionAuth, requireOwnership, createVoiceRouter());
-app.use('/api/crisis-modes', sessionAuth, createCrisisModesRouter()); // userId-param ownership in-router
-app.use('/api/connectors', sessionAuth, createConnectorsRouter()); // #377 — per-user OAuth re-auth surface
-app.use('/api/embedded-llm', sessionAuth, createEmbeddedLlmRouter()); // catalog endpoints; no userId in path
+app.use('/api/voice', sessionAuth, requireOwnership, requestContext, createVoiceRouter());
+app.use('/api/crisis-modes', sessionAuth, requestContext, createCrisisModesRouter()); // userId-param ownership in-router
+app.use('/api/connectors', sessionAuth, requestContext, createConnectorsRouter()); // #377 — per-user OAuth re-auth surface
+app.use('/api/embedded-llm', sessionAuth, requestContext, createEmbeddedLlmRouter()); // catalog endpoints; no userId in path
 // #310: promotion-offer durable surface. GET takes :userId in the path
 // (require-ownership enforces); POST takes offerId in the path with
 // userId in the body (cross-checked in-router).
-app.use('/api/promotion-offers', sessionAuth, createPromotionOffersRouter());
+app.use('/api/promotion-offers', sessionAuth, requestContext, createPromotionOffersRouter());
 
 // Error handling middleware
 //

--- a/apps/api/src/middleware/request-context.ts
+++ b/apps/api/src/middleware/request-context.ts
@@ -1,0 +1,60 @@
+import type { Request, Response, NextFunction } from 'express';
+import { runWithRequestContext } from '@skytwin/db';
+
+/**
+ * Resolve the authoritative userId for a request from the request itself.
+ *
+ * Order of preference:
+ *   1. `req.authenticatedUserId` — set by `sessionAuth` from the validated
+ *      session. This is the trusted identity in real-auth mode.
+ *   2. The `:userId` route param — used in dev-bypass mode, where there is no
+ *      authenticated identity but ownership middleware has already verified the
+ *      param is acceptable (or is being skipped because bypass is active).
+ *
+ * Body/query userId are deliberately NOT used here: those are arbitrary caller
+ * input, and binding the request context to attacker-controlled values would
+ * defeat the purpose of the assertion in `@skytwin/db`. When neither source is
+ * available (e.g. catalog endpoints with no user scope) we return undefined and
+ * the request runs with no context — the db-layer assertion fails open in that
+ * case, which is correct: there is no user to mismatch against.
+ */
+function resolveContextUserId(req: Request): string | undefined {
+  if (typeof req.authenticatedUserId === 'string' && req.authenticatedUserId) {
+    return req.authenticatedUserId;
+  }
+  const params = req.params ?? {};
+  if (typeof params['userId'] === 'string' && params['userId']) {
+    return params['userId'];
+  }
+  return undefined;
+}
+
+/**
+ * Middleware that installs the request-scoped `AsyncLocalStorage` context
+ * (#408) for the remainder of the request when a userId can be resolved.
+ *
+ * MUST be mounted AFTER `sessionAuth` (so `req.authenticatedUserId` is set) and
+ * AFTER `requireOwnership` (so a cross-user request has already been rejected
+ * with a 403 before we'd ever install a context). With those upstream, the
+ * context this installs is the user the request is legitimately acting as, and
+ * any deep db callee handed a different userId trips `assertUserContext`.
+ *
+ * The downstream chain — including the async route handlers and every repo call
+ * they make — is invoked inside `runWithRequestContext`, so `next()` and all of
+ * its continuations observe the context. When no userId resolves, we simply
+ * `next()` with no context installed (catalog / unscoped routes).
+ */
+export function requestContext(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  const userId = resolveContextUserId(req);
+  if (!userId) {
+    next();
+    return;
+  }
+  runWithRequestContext({ userId }, () => {
+    next();
+  });
+}

--- a/packages/db/src/__tests__/request-context.test.ts
+++ b/packages/db/src/__tests__/request-context.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+  runWithRequestContext,
+  getRequestContext,
+  getRequestUserId,
+  assertUserContext,
+  UserContextMismatchError,
+} from '../request-context.js';
+
+describe('request-context store (#408)', () => {
+  it('exposes the userId to callees within the run scope', () => {
+    runWithRequestContext({ userId: 'user-a' }, () => {
+      expect(getRequestUserId()).toBe('user-a');
+      expect(getRequestContext()).toEqual({ userId: 'user-a' });
+    });
+  });
+
+  it('carries the userId across async boundaries (await inside the scope)', async () => {
+    await runWithRequestContext({ userId: 'user-async' }, async () => {
+      // Force a microtask + macrotask hop; AsyncLocalStorage must survive both.
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(getRequestUserId()).toBe('user-async');
+    });
+  });
+
+  it('returns undefined outside any run scope (worker / migration / unit test)', () => {
+    expect(getRequestContext()).toBeUndefined();
+    expect(getRequestUserId()).toBeUndefined();
+  });
+
+  it('nested scopes shadow the outer context only for their own subtree', () => {
+    runWithRequestContext({ userId: 'outer' }, () => {
+      expect(getRequestUserId()).toBe('outer');
+      runWithRequestContext({ userId: 'inner' }, () => {
+        expect(getRequestUserId()).toBe('inner');
+      });
+      // Back in the outer subtree.
+      expect(getRequestUserId()).toBe('outer');
+    });
+  });
+});
+
+describe('assertUserContext (#408)', () => {
+  it('is a no-op when there is no active context (fail-open for workers/seeds)', () => {
+    // No surrounding runWithRequestContext — must not throw.
+    expect(() => assertUserContext('any-user')).not.toThrow();
+  });
+
+  it('passes when the passed userId matches the active context', () => {
+    runWithRequestContext({ userId: 'user-a' }, () => {
+      expect(() => assertUserContext('user-a')).not.toThrow();
+    });
+  });
+
+  it('throws UserContextMismatchError on a cross-user attempt', () => {
+    runWithRequestContext({ userId: 'user-a' }, () => {
+      // A deep callee handed user-b's id while user-a's request is in flight.
+      expect(() => assertUserContext('user-b')).toThrow(UserContextMismatchError);
+    });
+  });
+
+  it('mismatch error carries both ids for server-side logging but the message is generic-safe', () => {
+    runWithRequestContext({ userId: 'ctx-user' }, () => {
+      try {
+        assertUserContext('other-user');
+        throw new Error('expected assertUserContext to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(UserContextMismatchError);
+        const mismatch = err as UserContextMismatchError;
+        expect(mismatch.expectedUserId).toBe('ctx-user');
+        expect(mismatch.actualUserId).toBe('other-user');
+      }
+    });
+  });
+
+  it('does not fire on an empty userId — that is the caller/route validation concern', () => {
+    runWithRequestContext({ userId: 'user-a' }, () => {
+      expect(() => assertUserContext('')).not.toThrow();
+    });
+  });
+
+  it('survives an async hop before the assertion fires', async () => {
+    await runWithRequestContext({ userId: 'user-a' }, async () => {
+      await Promise.resolve();
+      expect(() => assertUserContext('user-b')).toThrow(UserContextMismatchError);
+    });
+  });
+});

--- a/packages/db/src/__tests__/twin-repository.test.ts
+++ b/packages/db/src/__tests__/twin-repository.test.ts
@@ -8,6 +8,9 @@ vi.mock('../connection.js', () => ({
 }));
 
 const { twinRepository } = await import('../repositories/twin-repository.js');
+const { runWithRequestContext, UserContextMismatchError } = await import(
+  '../request-context.js'
+);
 
 describe('twinRepository.isDraftsEnabled (#302)', () => {
   beforeEach(() => {
@@ -203,5 +206,48 @@ describe('twinRepository.clearDraftsEvalPass (#301)', () => {
   it('returns null when the user has no twin_profiles row', async () => {
     mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
     expect(await twinRepository.clearDraftsEvalPass('u-missing')).toBeNull();
+  });
+});
+
+describe('twinRepository request-context isolation (#408)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('AC-3: a cross-user query attempt under an active context throws before touching the DB', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ drafts_enabled: true }], rowCount: 1 });
+
+    // Request context is user-a; a deep callee asks for user-b's profile.
+    await runWithRequestContext({ userId: 'user-a' }, async () => {
+      await expect(twinRepository.getProfile('user-b')).rejects.toBeInstanceOf(
+        UserContextMismatchError,
+      );
+    });
+
+    // The assertion must fire BEFORE the query — no DB round-trip on a
+    // blocked cross-user read.
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('allows the matching userId under an active context (happy path)', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ user_id: 'user-a' }], rowCount: 1 });
+    await runWithRequestContext({ userId: 'user-a' }, async () => {
+      const profile = await twinRepository.getProfile('user-a');
+      expect(profile).toEqual({ user_id: 'user-a' });
+    });
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes are guarded too — a cross-user updateProfile throws before the transaction', async () => {
+    await runWithRequestContext({ userId: 'user-a' }, async () => {
+      await expect(
+        twinRepository.updateProfile('user-b', { preferences: [] }),
+      ).rejects.toBeInstanceOf(UserContextMismatchError);
+    });
+  });
+
+  it('stays a no-op with no active context (worker / seed path unaffected)', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ drafts_enabled: false }], rowCount: 1 });
+    await expect(twinRepository.isDraftsEnabled('user-anything')).resolves.toBe(false);
   });
 });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -8,6 +8,18 @@
 export { getPool, query, withTransaction, healthCheck, closePool, getPoolStats } from './connection.js';
 export type { DatabaseConfig } from './connection.js';
 
+// Request-scoped context (#408): AsyncLocalStorage carries the authoritative
+// userId across async boundaries so deep callees — including this repository
+// layer — can assert they're operating in the right user's context.
+export {
+  runWithRequestContext,
+  getRequestContext,
+  getRequestUserId,
+  assertUserContext,
+  UserContextMismatchError,
+} from './request-context.js';
+export type { RequestContext } from './request-context.js';
+
 // Idempotent seed/provision helper (spec 10 Part B) — shared by the launch
 // demo fixture (spec 09) and any re-runnable seed path.
 export { seedUpsert, buildUpsertSql, type UpsertSpec, type Queryable } from './seeds/upsert.js';

--- a/packages/db/src/repositories/twin-repository.ts
+++ b/packages/db/src/repositories/twin-repository.ts
@@ -1,4 +1,5 @@
 import { query, withTransaction } from '../connection.js';
+import { assertUserContext } from '../request-context.js';
 import type { TwinProfileRow, TwinProfileVersionRow } from '../types.js';
 
 /**
@@ -27,6 +28,7 @@ export const twinRepository = {
    * yet) — fail-closed.
    */
   async isDraftsEnabled(userId: string): Promise<boolean> {
+    assertUserContext(userId);
     const result = await query<{ drafts_enabled: boolean }>(
       'SELECT drafts_enabled FROM twin_profiles WHERE user_id = $1',
       [userId],
@@ -44,6 +46,7 @@ export const twinRepository = {
     userId: string,
     enabled: boolean,
   ): Promise<TwinProfileRow | null> {
+    assertUserContext(userId);
     const result = await query<TwinProfileRow>(
       `UPDATE twin_profiles
        SET drafts_enabled = $1, updated_at = now()
@@ -64,6 +67,7 @@ export const twinRepository = {
    * default rather than letting an unbounded number of calls through.
    */
   async getDraftsDailyCallCap(userId: string): Promise<number> {
+    assertUserContext(userId);
     const result = await query<{ drafts_daily_call_cap: number }>(
       'SELECT drafts_daily_call_cap FROM twin_profiles WHERE user_id = $1',
       [userId],
@@ -80,6 +84,7 @@ export const twinRepository = {
     userId: string,
     cap: number,
   ): Promise<TwinProfileRow | null> {
+    assertUserContext(userId);
     if (!Number.isInteger(cap) || cap < 0) {
       throw new Error(
         `drafts_daily_call_cap must be a non-negative integer; got ${cap}`,
@@ -108,6 +113,7 @@ export const twinRepository = {
    * without joining the full `draft_email_eval_runs` history.
    */
   async isDraftsEvalPassed(userId: string): Promise<boolean> {
+    assertUserContext(userId);
     const result = await query<{ drafts_eval_passed_at: Date | null }>(
       'SELECT drafts_eval_passed_at FROM twin_profiles WHERE user_id = $1',
       [userId],
@@ -120,6 +126,7 @@ export const twinRepository = {
    * ran, or null if no passing run exists.
    */
   async getDraftsEvalPassedAt(userId: string): Promise<Date | null> {
+    assertUserContext(userId);
     const result = await query<{ drafts_eval_passed_at: Date | null }>(
       'SELECT drafts_eval_passed_at FROM twin_profiles WHERE user_id = $1',
       [userId],
@@ -134,6 +141,7 @@ export const twinRepository = {
    * timestamp on pass); this is the manual-override write side.
    */
   async clearDraftsEvalPass(userId: string): Promise<TwinProfileRow | null> {
+    assertUserContext(userId);
     const result = await query<TwinProfileRow>(
       `UPDATE twin_profiles
        SET drafts_eval_passed_at = NULL, updated_at = now()
@@ -148,6 +156,7 @@ export const twinRepository = {
    * Get the current twin profile for a user.
    */
   async getProfile(userId: string): Promise<TwinProfileRow | null> {
+    assertUserContext(userId);
     const result = await query<TwinProfileRow>(
       'SELECT * FROM twin_profiles WHERE user_id = $1',
       [userId],
@@ -163,6 +172,7 @@ export const twinRepository = {
     userId: string,
     initial?: Partial<UpdateProfileInput>,
   ): Promise<TwinProfileRow> {
+    assertUserContext(userId);
     const result = await query<TwinProfileRow>(
       `INSERT INTO twin_profiles (
         user_id, preferences, inferences, risk_tolerance,
@@ -202,6 +212,7 @@ export const twinRepository = {
     updates: UpdateProfileInput,
     reason?: string,
   ): Promise<TwinProfileRow | null> {
+    assertUserContext(userId);
     return withTransaction(async (client) => {
       // Get the current profile
       const currentResult = await client.query<TwinProfileRow>(
@@ -290,6 +301,7 @@ export const twinRepository = {
     userId: string,
     limit = 50,
   ): Promise<TwinProfileVersionRow[]> {
+    assertUserContext(userId);
     const result = await query<TwinProfileVersionRow>(
       `SELECT tpv.*
        FROM twin_profile_versions tpv
@@ -309,6 +321,7 @@ export const twinRepository = {
     userId: string,
     version: number,
   ): Promise<TwinProfileVersionRow | null> {
+    assertUserContext(userId);
     const result = await query<TwinProfileVersionRow>(
       `SELECT tpv.*
        FROM twin_profile_versions tpv

--- a/packages/db/src/request-context.ts
+++ b/packages/db/src/request-context.ts
@@ -1,0 +1,109 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Request-scoped context that travels across async boundaries.
+ *
+ * This is the cross-cutting "who is this request acting as?" signal. The API
+ * sets it once per request (after `sessionAuth` + ownership middleware have
+ * resolved the userId) and any deep callee — including the `@skytwin/db`
+ * repository layer — can read it to answer "am I in the right user's
+ * context?" without threading `userId` through every intermediate function.
+ *
+ * #408: defense-in-depth for multi-user isolation. The primary boundary is
+ * still the route-layer ownership middleware (`require-ownership.ts`); this
+ * store is a backstop that catches a deep callee that was handed the wrong
+ * `userId` (a mis-wired service, a swapped variable) while a different user's
+ * request is in flight.
+ */
+export interface RequestContext {
+  /**
+   * The userId this request is authoritatively acting as. Resolved from the
+   * validated session (or the trusted route param in dev bypass), NOT from
+   * arbitrary request input.
+   */
+  userId: string;
+}
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+/**
+ * Run `fn` with `context` installed as the active request context. The context
+ * is visible to every async continuation spawned within `fn` and is torn down
+ * automatically when `fn` settles. Nesting is allowed — an inner call shadows
+ * the outer context for its own subtree only.
+ */
+export function runWithRequestContext<T>(
+  context: RequestContext,
+  fn: () => T,
+): T {
+  return storage.run(context, fn);
+}
+
+/**
+ * The active request context, or `undefined` when running outside any request
+ * scope (background workers, migrations, seeds, most unit tests).
+ */
+export function getRequestContext(): RequestContext | undefined {
+  return storage.getStore();
+}
+
+/**
+ * The userId of the active request context, or `undefined` when running
+ * outside any request scope.
+ */
+export function getRequestUserId(): string | undefined {
+  return storage.getStore()?.userId;
+}
+
+/**
+ * Thrown when a user-scoped DB operation is invoked with a `userId` that does
+ * not match the active request context. This is a cross-user access attempt —
+ * a programming error or an exploit, never an expected failure mode — so it is
+ * a thrown error (a hard stop), not a typed result object. The message
+ * deliberately does NOT echo the expected/actual userIds to the response layer;
+ * callers that surface errors to clients must map this to a generic 403/500
+ * (the API's global error handler already does — it never leaks `err.message`).
+ */
+export class UserContextMismatchError extends Error {
+  readonly expectedUserId: string;
+  readonly actualUserId: string;
+
+  constructor(expectedUserId: string, actualUserId: string) {
+    super(
+      `Cross-user access blocked: operation for userId ${actualUserId} ran inside the request context of userId ${expectedUserId}.`,
+    );
+    this.name = 'UserContextMismatchError';
+    this.expectedUserId = expectedUserId;
+    this.actualUserId = actualUserId;
+  }
+}
+
+/**
+ * Assert that a user-scoped operation's `userId` matches the active request
+ * context.
+ *
+ * Fail-OPEN when there is no active context: background workers, migrations,
+ * seeds, and the bulk of the unit-test suite legitimately run with no request
+ * scope, and a user-scoped repository call there is not a cross-user attempt.
+ * Adding the context is what arms the check — so this is purely additive and
+ * cannot break those code paths.
+ *
+ * Fail-CLOSED when a context IS active and the `userId` mismatches: that is a
+ * deep callee operating on the wrong user while another user's request is in
+ * flight. Throws {@link UserContextMismatchError}.
+ *
+ * An empty/missing `userId` argument is left to the caller's own validation
+ * (the UUID validator middleware and per-route checks) — this assertion only
+ * speaks to cross-user mismatch, not to absent input.
+ */
+export function assertUserContext(userId: string): void {
+  const ctx = storage.getStore();
+  // No active request context → not a request-scoped call → nothing to assert.
+  if (ctx === undefined) return;
+  // Caller passed no userId → not this assertion's concern; let route/UUID
+  // validation handle absent input rather than firing a misleading mismatch.
+  if (!userId) return;
+  if (ctx.userId !== userId) {
+    throw new UserContextMismatchError(ctx.userId, userId);
+  }
+}


### PR DESCRIPTION
## What changed

Adds defense-in-depth for multi-user isolation via a request-scoped `AsyncLocalStorage` store (#408, parent #357).

- **`packages/db/src/request-context.ts`** (new) — `runWithRequestContext` / `getRequestContext` / `getRequestUserId` / `assertUserContext` + `UserContextMismatchError`. The store carries the authoritative `userId` across async boundaries so any deep callee — the repository layer included — can verify it's operating in the right user's context without threading `userId` through every intermediate function. Exported from `@skytwin/db`'s index.
- **`packages/db/src/repositories/twin-repository.ts`** — `assertUserContext(userId)` is now the first line of every user-scoped method. It **fails open** when there is no active context (workers, migrations, seeds, and the bulk of the unit suite run with no request scope — so the check is purely additive and cannot break those paths) and **fails closed** — throwing `UserContextMismatchError` *before any DB round-trip* — when a context is active and a deep callee was handed a different `userId`.
- **`apps/api/src/middleware/request-context.ts`** (new) + **`apps/api/src/index.ts`** — a `requestContext` middleware installs the context once per request. Mounted **after** `sessionAuth` + `requireOwnership`, so a genuine cross-user request is already rejected with a 403 before any context is set. The context's `userId` is taken only from the validated session (`req.authenticatedUserId`) or, in dev-bypass, the trusted `:userId` route param — **never** from body/query input.

## Safety notes

- Provenance / injection-guard, policy checks, trust tiers, spend limits, reversibility — none touched. This is additive isolation only.
- `assertUserContext` is a hard throw (a thrown error, not a typed result) because a cross-user mismatch is a programming error / exploit, never an expected failure mode. The API's existing global error handler maps any throw to a generic 500 and never leaks `err.message`; the error object carries both ids for server-side logging only.
- The primary multi-user boundary remains the route-layer ownership middleware; this store is a backstop.

## Acceptance criteria

- [x] **`AsyncLocalStorage` carries userId across async boundaries in API** — store + `requestContext` middleware; async-hop survival covered by tests.
- [x] **Repositories assert context matches passed userId** — `assertUserContext` wired into every user-scoped `twinRepository` method.
- [x] **Vitest: simulate cross-user query attempt → assertion fires** — `twin-repository.test.ts` AC-3 test: under an active `user-a` context, `getProfile('user-b')` rejects with `UserContextMismatchError` and the DB query is never called.

## Tests added

- `packages/db/src/__tests__/request-context.test.ts` (10) — store + assertion semantics, async-hop survival, nested scopes, fail-open / fail-closed, empty-userId no-op.
- `packages/db/src/__tests__/twin-repository.test.ts` (+4) — cross-user read blocked before query (AC-3), matching-user happy path, cross-user write guard, no-context no-op.
- `apps/api/src/__tests__/request-context-middleware.test.ts` (6) — identity precedence (auth > param), body/query distrust, unscoped-route pass-through, `next()` exactly once.

Verified locally: full `@skytwin/db` suite (351 passed / 19 e2e skipped) green; `@skytwin/api` middleware + session-auth tests green; both packages `tsc --noEmit` clean.

Closes #408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)