### PR TITLE
fix(db): demo fixture forces a daily briefing after ingest (#482)

### DIFF
--- a/packages/db/src/__tests__/demo-fixture.test.ts
+++ b/packages/db/src/__tests__/demo-fixture.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for the demo-fixture briefing wiring (#482).
+ *
+ * The fixture must force a daily briefing for the demo user after ingest so
+ * `/api/twin-briefings/latest` is populated immediately (AC#1 / impl detail
+ * #7) — invoking the worker job as `{ cadence: 'daily', userIds: [DEMO_USER_ID] }`.
+ * The trigger is best-effort: a failed/unavailable worker degrades to a typed
+ * result, never an exception that aborts an already-ingested fixture.
+ *
+ * `runBriefing` is injectable so we can assert the exact wiring without a DB
+ * or a running worker.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { triggerDemoBriefing } from '../seeds/demo-briefing.js';
+import { DEMO_USER_ID } from '../seeds/demo-guard.js';
+
+describe('triggerDemoBriefing — forces a daily demo briefing (#482)', () => {
+  it('invokes the briefing runner with cadence=daily and the demo user only', async () => {
+    const runBriefing = vi.fn().mockResolvedValue(undefined);
+
+    const result = await triggerDemoBriefing({ userId: DEMO_USER_ID, runBriefing });
+
+    expect(result).toEqual({ ok: true });
+    expect(runBriefing).toHaveBeenCalledTimes(1);
+    expect(runBriefing).toHaveBeenCalledWith({
+      cadence: 'daily',
+      userIds: [DEMO_USER_ID],
+    });
+  });
+
+  it('scopes the briefing to exactly the passed userId (never a broad fan-out)', async () => {
+    const runBriefing = vi.fn().mockResolvedValue(undefined);
+
+    await triggerDemoBriefing({ userId: 'demo-123', runBriefing });
+
+    const arg = runBriefing.mock.calls[0]![0] as { userIds: string[] };
+    expect(arg.userIds).toEqual(['demo-123']);
+    expect(arg.userIds).toHaveLength(1);
+  });
+
+  it('degrades to a typed ok:false (does not throw) when the runner fails', async () => {
+    const runBriefing = vi.fn().mockRejectedValue(new Error('worker unavailable'));
+
+    const result = await triggerDemoBriefing({ userId: DEMO_USER_ID, runBriefing });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/worker unavailable/);
+  });
+
+  it('stringifies non-Error throwables into the failure reason', async () => {
+    const runBriefing = vi.fn().mockRejectedValue('boom');
+
+    const result = await triggerDemoBriefing({ userId: DEMO_USER_ID, runBriefing });
+
+    expect(result).toEqual({ ok: false, reason: 'boom' });
+  });
+});

--- a/packages/db/src/seeds/demo-briefing.ts
+++ b/packages/db/src/seeds/demo-briefing.ts
@@ -1,0 +1,80 @@
+/**
+ * Demo-fixture briefing trigger (#482).
+ *
+ * After the demo fixture ingests its synthetic signals, it forces a daily
+ * briefing for the demo user so `/api/twin-briefings/latest` returns a
+ * populated digest immediately — instead of waiting for the worker's 24h cron
+ * (#482 implementation detail #7 / AC#1).
+ *
+ * Kept in its own module (no DB imports) so the pure wiring is unit-testable
+ * without `pg`/a live database, and so `demo-fixture.ts` can stay the thin CLI
+ * orchestrator.
+ */
+
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+/** Result of attempting to force a demo briefing. Best-effort — never throws. */
+export type DemoBriefingResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * The shape of the worker's briefing job, narrowed to what the demo fixture
+ * needs. Declared locally (not imported) so `@skytwin/db` keeps a clean
+ * dependency graph — apps depend on packages, never the reverse.
+ */
+export type RunBriefing = (deps: {
+  cadence: 'daily' | 'weekly';
+  userIds: string[];
+}) => Promise<void>;
+
+/**
+ * Default briefing runner: resolves `apps/worker/src/jobs/briefing-generator.ts`
+ * at RUNTIME via a computed file URL and calls `runBriefingGeneratorJob`.
+ *
+ * Why a dynamic import rather than a static one: the worker job lives in an
+ * app, and `@skytwin/db` (this package) must not statically depend on an app
+ * — that would invert the monorepo dependency arrow (apps → packages) and
+ * break the build graph + tsc rootDir. The specifier is computed at runtime
+ * so tsc never resolves it; turbo's graph (driven by package.json) is
+ * untouched. The demo fixture is a dev-only `tsx` CLI, never bundled into the
+ * library `dist` other packages consume, so reaching "up" to the worker here
+ * is safe and intentional. The briefing job itself only depends on packages
+ * (@skytwin/{db,policy-prompts,llm-client,core}), so it loads fine in-process.
+ */
+async function defaultRunBriefing(deps: {
+  cadence: 'daily' | 'weekly';
+  userIds: string[];
+}): Promise<void> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // packages/db/src/seeds → repo root is four levels up.
+  const jobPath = resolve(here, '../../../../apps/worker/src/jobs/briefing-generator.ts');
+  const mod = (await import(pathToFileURL(jobPath).href)) as {
+    runBriefingGeneratorJob: RunBriefing;
+  };
+  await mod.runBriefingGeneratorJob(deps);
+}
+
+/**
+ * Force a daily briefing for the demo user so `/api/twin-briefings/latest`
+ * returns a populated digest immediately after ingest (#482 AC#1 / detail #7).
+ *
+ * Best-effort by design: a missing/failed worker job degrades to a typed
+ * `ok:false` result with the reason, never an exception that aborts the
+ * fixture after it has already ingested signals. `runBriefing` is injectable
+ * so the wiring can be unit-tested without spinning up the worker or a DB.
+ */
+export async function triggerDemoBriefing(opts: {
+  userId: string;
+  runBriefing?: RunBriefing;
+}): Promise<DemoBriefingResult> {
+  const run = opts.runBriefing ?? defaultRunBriefing;
+  try {
+    await run({ cadence: 'daily', userIds: [opts.userId] });
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/packages/db/src/seeds/demo-fixture.ts
+++ b/packages/db/src/seeds/demo-fixture.ts
@@ -12,6 +12,7 @@
  *   pnpm demo:fixture --i-understand-this-writes-demo-data   # allow non-local DB
  */
 
+import { pathToFileURL } from 'node:url';
 import { getPool, withTransaction, closePool } from '../connection.js';
 import { seedUpsert } from './upsert.js';
 import {
@@ -21,6 +22,7 @@ import {
   type DemoGuardEnv,
 } from './demo-guard.js';
 import { DEMO_SIGNALS } from './demo-fixtures/signals.js';
+import { triggerDemoBriefing } from './demo-briefing.js';
 
 async function main(): Promise<void> {
   const argv = process.argv.slice(2);
@@ -103,9 +105,18 @@ async function main(): Promise<void> {
   }
 
   if (ingested === DEMO_SIGNALS.length) {
+    // Force a daily briefing for the demo user so the digest is populated
+    // immediately (no 24h cron wait). Best-effort: if the worker job can't be
+    // loaded/run, fall back to guidance rather than aborting the fixture.
+    const briefing = await triggerDemoBriefing({ userId: DEMO_USER_ID });
+    const briefingLine = briefing.ok
+      ? '  daily briefing generated — /api/twin-briefings/latest is populated.\n'
+      : `  briefing not generated (${briefing.reason}).\n` +
+        '    Run the worker (./bin/skytwin-dev) and re-run, or wait for its cycle.\n';
     console.log(
       `[demo:fixture] done — demo user provisioned, ${ingested} synthetic signals ingested.\n` +
-        'Trigger the worker briefing (or wait for its cycle), then screenshot:\n' +
+        briefingLine +
+        'Then screenshot:\n' +
         '  • /briefing — to-dos vs topics, source chips, citations\n' +
         '  • dashboard — trust-tier progress, recent activity\n' +
         '  • mobile BriefingScreen',
@@ -120,7 +131,11 @@ async function main(): Promise<void> {
   await closePool();
 }
 
-main().catch((err) => {
-  console.error('[demo:fixture] failed:', err);
-  process.exit(1);
-});
+// Entry guard: only run as a CLI (pnpm demo:fixture), never on import. Tests
+// import this module to exercise triggerDemoBriefing without running main().
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error('[demo:fixture] failed:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## What changed

The launch demo fixture (`pnpm demo:fixture`, #482) provisioned the demo user and pushed the synthetic signal corpus through `POST /api/events/ingest`, but then only printed *"Trigger the worker briefing (or wait for its cycle)"*. So `/api/twin-briefings/latest` stayed **empty** until the worker's 24h cron interval elapsed — defeating the screenshot-now purpose the fixture exists for.

This wires the briefing trigger the issue asked for: after a fully-successful ingest, the fixture now invokes the worker job as

```ts
runBriefingGeneratorJob({ cadence: 'daily', userIds: [DEMO_USER_ID] })
```

so the digest is populated immediately.

### Files
- **New `packages/db/src/seeds/demo-briefing.ts`** — holds `triggerDemoBriefing(...)`. The default runner resolves `apps/worker/src/jobs/briefing-generator.ts` at **runtime** via a computed `pathToFileURL` rather than a static `import`. The worker job lives in an *app*, and `@skytwin/db` must not statically depend on an app — that would invert the monorepo's apps → packages dependency arrow and break the `tsc` rootDir / turbo graph. A runtime-computed specifier keeps the graph clean; the demo fixture is a dev-only `tsx` CLI, never bundled into the library `dist` other packages consume. The `runBriefing` runner is **injectable** so the wiring is unit-testable with no worker and no DB.
- **`packages/db/src/seeds/demo-fixture.ts`** — calls `triggerDemoBriefing` after ingest; logs whether the briefing was generated. Best-effort: a missing/failed worker degrades to a typed `{ ok:false, reason }` with guidance and never aborts an already-ingested fixture. Also added the standard `import.meta.url` entry guard (same pattern as `migrations/001-initial.ts`) so importing the module in tests doesn't run `main()`.
- **`packages/db/src/__tests__/demo-fixture.test.ts`** — 4 new vitest tests.
- **`CHANGELOG.md`** — `### Fixed (#482 follow-up)` entry under `[Unreleased]`.

## ACs this satisfies
- **AC#1 / implementation detail #7** — "after ingest, invoke `briefingGeneratorJob({ cadence: 'daily', userIds: [demoUserId] })` directly so `/api/twin-briefings/latest` returns a fully populated digest immediately (no 24h wait)." This was the one piece of #482 still unwired after the epic merged via #488.

The rest of #482 (guard, `is_demo` migration, synthetic corpus, `--reset`, idempotent `seedUpsert` writes) already shipped via #488, so this **Addresses #482** rather than closing it.

## Safety
- Invariant #0 untouched: the briefing trigger runs only inside the already-guarded fixture, after `assertDemoSafe` has passed and only for `DEMO_USER_ID`. It is never wired into `bin/skytwin-dev`, onboarding, or any startup path.
- The real briefing pipeline (policy checks, explanations, trust tiers) is unchanged — this only invokes the existing worker job for the demo user.

## Tests
- `triggerDemoBriefing` invokes the runner with exactly `{ cadence: 'daily', userIds: [DEMO_USER_ID] }` (happy path).
- Scopes the briefing to exactly the passed userId (length 1, no broad fan-out).
- Degrades to a typed `ok:false` (does not throw) when the runner rejects.
- Stringifies non-Error throwables into the failure reason.

`@skytwin/db` demo + upsert suites green (22 tests). Verified the package only — the worktree has no `node_modules`, so tests/typecheck were run via the repo-root vitest/tsc; `demo-briefing.ts` typechecks clean standalone (no workspace-dep imports). Did not run root `pnpm install`/`build`/`test` (shared machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)