### PR TITLE
feat(digest): enforce hide/pin in the live digest (#485 read-path gate)

### DIFF
--- a/apps/api/src/__tests__/live-digest-helpers.test.ts
+++ b/apps/api/src/__tests__/live-digest-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { needsYou, sourceLabel, normalizeUrgency, urgencyReasonFor } from '../services/live-digest.js';
+import { needsYou, sourceLabel, normalizeUrgency, urgencyReasonFor, bareAddress } from '../services/live-digest.js';
 
 /**
  * The to-do/FYI split (spec 01) and source labels (spec 07) that drive the
@@ -89,5 +89,21 @@ describe('urgencyReasonFor', () => {
 
   it('never returns the generic "Default for" placeholder', () => {
     expect(urgencyReasonFor({ situation_type: 'email_triage', urgency: 'normal' })).not.toMatch(/default for/i);
+  });
+});
+
+describe('bareAddress (pin/hide join key, #270/#485)', () => {
+  it('extracts the bare address from a "Name <addr>" header', () => {
+    expect(bareAddress('Acme Billing <Billing@Acme.com>')).toBe('billing@acme.com');
+  });
+
+  it('lowercases a plain address (matches the write-time normalization)', () => {
+    expect(bareAddress('No-Reply@Example.COM')).toBe('no-reply@example.com');
+  });
+
+  it('returns null for empty / nullish input (no override applied)', () => {
+    expect(bareAddress(null)).toBeNull();
+    expect(bareAddress(undefined)).toBeNull();
+    expect(bareAddress('   ')).toBeNull();
   });
 });

--- a/apps/api/src/__tests__/live-digest.test.ts
+++ b/apps/api/src/__tests__/live-digest.test.ts
@@ -49,6 +49,7 @@ describe('buildLiveDigest', () => {
   it('maps a security decision to a to-do with meaningful power-view detail', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [decisionRow()] }) // decisions+outcomes
+      .mockResolvedValueOnce({ rows: [] }) // brain_pages pin/hide overrides
       .mockResolvedValueOnce({ rows: [] }); // connected_accounts
 
     const d = await buildLiveDigest('u1');
@@ -95,7 +96,8 @@ describe('buildLiveDigest', () => {
           }),
         ],
       })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] }) // brain_pages overrides
+      .mockResolvedValueOnce({ rows: [] }); // connected_accounts
 
     const d = await buildLiveDigest('u1');
     // calendar_invite is a to-do (needs RSVP)
@@ -122,7 +124,8 @@ describe('buildLiveDigest', () => {
           }),
         ],
       })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] }) // brain_pages overrides
+      .mockResolvedValueOnce({ rows: [] }); // connected_accounts
 
     const d = await buildLiveDigest('u1');
     const item = d!.topics.flatMap((t) => t.items)[0];
@@ -149,7 +152,8 @@ describe('buildLiveDigest', () => {
           }),
         ],
       })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] }) // brain_pages overrides
+      .mockResolvedValueOnce({ rows: [] }); // connected_accounts
 
     const d = await buildLiveDigest('u1');
     expect(d!.todos).toHaveLength(0);
@@ -173,7 +177,8 @@ describe('buildLiveDigest', () => {
           }),
         ],
       })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] }) // brain_pages overrides
+      .mockResolvedValueOnce({ rows: [] }); // connected_accounts
 
     const d = await buildLiveDigest('u1');
     const item = d!.topics.flatMap((t) => t.items)[0];
@@ -197,7 +202,8 @@ describe('buildLiveDigest', () => {
           }),
         ],
       })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] }) // brain_pages overrides
+      .mockResolvedValueOnce({ rows: [] }); // connected_accounts
 
     const d = await buildLiveDigest('u1');
     const item = d!.topics.flatMap((t) => t.items)[0];
@@ -242,7 +248,8 @@ describe('buildLiveDigest', () => {
           ),
         ],
       })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] }) // brain_pages pin/hide overrides (#485)
+      .mockResolvedValueOnce({ rows: [] }); // connected_accounts
 
     const d = await buildLiveDigest('u1');
     expect(d).not.toBeNull();
@@ -284,7 +291,8 @@ describe('buildLiveDigest', () => {
           }),
         ],
       })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] }) // brain_pages pin/hide overrides (#485)
+      .mockResolvedValueOnce({ rows: [] }); // connected_accounts
 
     const d = await buildLiveDigest('u1');
     // No commitment to-do; the inbound email is a routine FYI topic.
@@ -300,7 +308,8 @@ describe('buildLiveDigest', () => {
           ),
         ],
       })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] }) // brain_pages pin/hide overrides (#485)
+      .mockResolvedValueOnce({ rows: [] }); // connected_accounts
 
     const d = await buildLiveDigest('u1');
     expect(d!.todos).toHaveLength(1);
@@ -315,7 +324,8 @@ describe('buildLiveDigest', () => {
         .mockResolvedValueOnce({
           rows: [authoredEmailRow("I'll send over the draft tomorrow.")],
         })
-        .mockResolvedValueOnce({ rows: [] });
+        .mockResolvedValueOnce({ rows: [] }) // brain_pages pin/hide overrides (#485)
+        .mockResolvedValueOnce({ rows: [] }); // connected_accounts
 
       const d = await buildLiveDigest('u1');
       expect(d!.todos).toHaveLength(0);
@@ -334,9 +344,103 @@ describe('buildLiveDigest', () => {
           decisionRow({ id: 'c', auto_executed: null, requires_approval: false, situation_type: 'email_triage', urgency: 'low', escalation_reason: null }),
         ],
       })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] }) // brain_pages overrides
+      .mockResolvedValueOnce({ rows: [] }); // connected_accounts
 
     const d = await buildLiveDigest('u1');
     expect(d!.handledCount).toBe(1);
+  });
+
+  it('drops a hidden sender end-to-end (#270/#485): hidden item never surfaces', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          // Visible routine item from one sender.
+          decisionRow({
+            id: 'visible',
+            situation_type: 'email_triage',
+            urgency: 'low',
+            requires_approval: false,
+            escalation_reason: null,
+            raw_event: { source: 'gmail', type: 'message', data: { subject: 'Keep me', from: 'ok@x.example' } },
+          }),
+          // Item from a sender the user hid (bulk-hide stamped userOverride=hidden
+          // on brain_pages keyed by fromAddress).
+          decisionRow({
+            id: 'hidden',
+            situation_type: 'email_triage',
+            urgency: 'high', // would normally be a to-do
+            requires_approval: false,
+            escalation_reason: null,
+            raw_event: { source: 'gmail', type: 'message', data: { subject: 'Hide me', from: 'Spammy <SPAM@x.example>' } },
+          }),
+        ],
+      })
+      // brain_pages overrides: the hidden sender (normalized, lowercased).
+      .mockResolvedValueOnce({
+        rows: [{ from_address: 'spam@x.example', user_override: 'hidden' }],
+      })
+      .mockResolvedValueOnce({ rows: [] }); // connected_accounts
+
+    const d = await buildLiveDigest('u1');
+    const allRefs = [
+      ...d!.todos.map((t) => t.ref),
+      ...d!.topics.flatMap((t) => t.items.map((i) => i.ref)),
+    ];
+    expect(allRefs).toContain('visible');
+    expect(allRefs).not.toContain('hidden');
+  });
+
+  it('passes through items when the brain has no overrides (pre-#485 parity)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          decisionRow({
+            id: 'keep',
+            situation_type: 'email_triage',
+            urgency: 'low',
+            requires_approval: false,
+            escalation_reason: null,
+            raw_event: { source: 'gmail', type: 'message', data: { subject: 'Normal', from: 'a@x.example' } },
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] }) // brain_pages overrides — empty
+      .mockResolvedValueOnce({ rows: [] }); // connected_accounts
+
+    const d = await buildLiveDigest('u1');
+    const allRefs = [
+      ...d!.todos.map((t) => t.ref),
+      ...d!.topics.flatMap((t) => t.items.map((i) => i.ref)),
+    ];
+    expect(allRefs).toContain('keep');
+  });
+
+  it('degrades to no overrides when the brain_pages query fails (resilience)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          decisionRow({
+            id: 'still-here',
+            situation_type: 'email_triage',
+            urgency: 'low',
+            requires_approval: false,
+            escalation_reason: null,
+            raw_event: { source: 'gmail', type: 'message', data: { subject: 'Hi', from: 'a@x.example' } },
+          }),
+        ],
+      })
+      // brain_pages overrides query throws (e.g. table absent on a
+      // mempalace-only deploy) — must not error the whole digest.
+      .mockRejectedValueOnce(new Error('relation "brain_pages" does not exist'))
+      .mockResolvedValueOnce({ rows: [] }); // connected_accounts
+
+    const d = await buildLiveDigest('u1');
+    expect(d).not.toBeNull();
+    const allRefs = [
+      ...d!.todos.map((t) => t.ref),
+      ...d!.topics.flatMap((t) => t.items.map((i) => i.ref)),
+    ];
+    expect(allRefs).toContain('still-here');
   });
 });

--- a/apps/api/src/services/live-digest.ts
+++ b/apps/api/src/services/live-digest.ts
@@ -26,6 +26,7 @@ import {
   type DigestItem,
   type Digest,
   type SignalText,
+  type SignalVisibilityMeta,
 } from '@skytwin/decision-engine';
 
 /** Most-recent decisions scanned to assemble one digest (perf + relevance bound). */
@@ -176,6 +177,70 @@ function senderRef(data: Record<string, unknown>): string | null {
   return null;
 }
 
+/**
+ * Normalize a raw sender ref ("Name <a@b>" or "a@b") to the bare, lowercased
+ * address used as the join key against `brain_pages.metadata.fromAddress`. This
+ * MUST match the write-time normalization in
+ * `@skytwin/memory-gbrain`'s embedded port (angle-bracket extraction + lower),
+ * or the pin/hide override won't line up with the digest item.
+ */
+export function bareAddress(raw: string | null | undefined): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const angle = trimmed.match(/<([^>]+)>/);
+  const bare = (angle?.[1] ? angle[1].trim() : trimmed).toLowerCase();
+  return bare.length > 0 ? bare : null;
+}
+
+interface SenderOverrideRow {
+  from_address: string;
+  user_override: string;
+}
+
+/**
+ * Per-sender pin/hide overrides (#270) keyed by the bare `fromAddress`, read
+ * from the canonical `brain_pages.metadata` store the pin/hide controls write
+ * to. When a sender has BOTH 'hidden' and 'pinned' pages (e.g. a bulk-hide
+ * after an individual pin), 'hidden' wins — fail safe toward not surfacing
+ * content the user asked to hide.
+ *
+ * Returns an empty map (not an error) on a missing/empty brain — the digest
+ * simply applies no overrides, identical to pre-#485 behavior.
+ */
+async function fetchSenderOverrides(userId: string): Promise<Map<string, SignalVisibilityMeta>> {
+  const map = new Map<string, SignalVisibilityMeta>();
+  let rows: { rows: SenderOverrideRow[] };
+  try {
+    rows = await query<SenderOverrideRow>(
+      `SELECT lower(metadata->>'fromAddress') AS from_address,
+              metadata->>'userOverride'       AS user_override
+         FROM brain_pages
+        WHERE user_id = $1
+          AND metadata->>'fromAddress' IS NOT NULL
+          AND metadata->>'userOverride' IN ('hidden', 'pinned')`,
+      [userId],
+    );
+  } catch {
+    // brain_pages may not exist on a mempalace-only deployment, or the brain
+    // may be transiently unavailable. Degrade to no overrides so the digest
+    // still renders rather than erroring the whole briefing (resilience
+    // intent of #485). The memory retrieval layer independently applies its
+    // own hide gate at search time, so this is a second filter, not the only
+    // one — failing it open does not surface content the search layer hid.
+    return map;
+  }
+  for (const r of rows.rows) {
+    if (!r.from_address) continue;
+    const existing = map.get(r.from_address);
+    // 'hidden' is the dominant signal — once a sender is hidden, a later
+    // 'pinned' row for the same sender must not un-hide it.
+    if (existing?.userOverride === 'hidden') continue;
+    map.set(r.from_address, { userOverride: r.user_override });
+  }
+  return map;
+}
+
 /** Friendly "where it's from" when there's no concrete sender. */
 const SOURCE_FRIENDLY: Record<string, string> = {
   email: 'your inbox',
@@ -316,6 +381,12 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
   );
   if (decisions.rows.length === 0) return null;
 
+  // Per-sender pin/hide overrides (#270/#485) from the canonical
+  // brain_pages.metadata store. Read alongside the decisions so buildDigest's
+  // filterVisible can drop hidden senders and surface pinned ones. A brain
+  // that's empty (no gbrain pages yet) yields an empty map → no overrides.
+  const senderOverrides = await fetchSenderOverrides(userId);
+
   // Power-view detail (spec 14) is attached to each todo/topic by ref AFTER
   // buildDigest (the generator's job — buildDigest itself leaves it unset).
   const detailByRef = new Map<string, ReturnType<typeof buildDigestItemDetail>>();
@@ -379,6 +450,13 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
         : r.created_at
           ? String(r.created_at)
           : undefined;
+    // Resolve the sender's pin/hide override (#270/#485) so buildDigest's
+    // filterVisible drops hidden senders and surfaces pinned ones. No sender
+    // (e.g. a voice note or file) or no override → undefined (no effect).
+    const senderKey = bareAddress(sender);
+    const meta: SignalVisibilityMeta | undefined = senderKey
+      ? senderOverrides.get(senderKey)
+      : undefined;
     detailByRef.set(
       r.id,
       buildDigestItemDetail({
@@ -404,6 +482,7 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
       domain: r.domain,
       sourceType,
       urgency,
+      ...(meta ? { meta } : {}),
     };
 
     // #475 / spec 02: surface the user's OWN stated commitments from authored

--- a/packages/decision-engine/src/__tests__/digest.test.ts
+++ b/packages/decision-engine/src/__tests__/digest.test.ts
@@ -53,6 +53,37 @@ describe('buildDigest (spec 01)', () => {
     expect(allRefs).not.toContain('hidden-fyi');
   });
 
+  it('surfaces a pinned to-do ahead of higher-urgency unpinned ones (#270/#485)', () => {
+    const items = [
+      item({ ref: 'crit', actionRequired: true, urgency: 'critical' }),
+      item({ ref: 'pinned-low', actionRequired: true, urgency: 'low', meta: { userOverride: 'pinned' } }),
+      item({ ref: 'high', actionRequired: true, urgency: 'high' }),
+    ];
+    const d = buildDigest(items);
+    // Pinned-first is the primary key; urgency only breaks ties within a group.
+    expect(d.todos.map((t) => t.ref)).toEqual(['pinned-low', 'crit', 'high']);
+  });
+
+  it('keeps urgency order among to-dos when none are pinned (no regression)', () => {
+    const items = [
+      item({ ref: 'low', actionRequired: true, urgency: 'low' }),
+      item({ ref: 'crit', actionRequired: true, urgency: 'critical' }),
+    ];
+    const d = buildDigest(items);
+    expect(d.todos.map((t) => t.ref)).toEqual(['crit', 'low']);
+  });
+
+  it('surfaces a pinned FYI item ahead of unpinned ones in its topic (#270)', () => {
+    const items = [
+      item({ ref: 'a', domain: 'finance' }),
+      item({ ref: 'pinned', domain: 'finance', meta: { userOverride: 'pinned' } }),
+      item({ ref: 'b', domain: 'finance' }),
+    ];
+    const d = buildDigest(items, { knownDomains: ['finance'] });
+    const finance = d.topics.find((t) => t.domain === 'finance')!;
+    expect(finance.items[0]!.ref).toBe('pinned');
+  });
+
   it('carries sourceType + deadline onto to-dos (spec 07/03 for the UI)', () => {
     const d = buildDigest([
       item({ ref: 'x', actionRequired: true, sourceType: 'voice', deadline: '2026-03-05' }),

--- a/packages/decision-engine/src/__tests__/visibility-filter.test.ts
+++ b/packages/decision-engine/src/__tests__/visibility-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isHidden, filterVisible } from '../visibility-filter.js';
+import { isHidden, isPinned, filterVisible, sortPinnedFirst } from '../visibility-filter.js';
 
 describe('isHidden (spec 11)', () => {
   it('true for userOverride=hidden', () => {
@@ -17,6 +17,22 @@ describe('isHidden (spec 11)', () => {
   });
 });
 
+describe('isPinned (#270)', () => {
+  it('true only for userOverride=pinned', () => {
+    expect(isPinned({ userOverride: 'pinned' })).toBe(true);
+  });
+  it('false for non-pinned, null, or undefined meta', () => {
+    expect(isPinned({})).toBe(false);
+    expect(isPinned({ userOverride: 'hidden' })).toBe(false);
+    expect(isPinned(null)).toBe(false);
+    expect(isPinned(undefined)).toBe(false);
+  });
+  it('hidden always wins over a stray pinned signal (fail safe)', () => {
+    // A page that is both hidden_at AND userOverride=pinned must not be pinned.
+    expect(isPinned({ userOverride: 'pinned', hidden_at: 1 })).toBe(false);
+  });
+});
+
 describe('filterVisible (spec 11)', () => {
   it('drops hidden items and preserves order', () => {
     const items = [
@@ -27,5 +43,29 @@ describe('filterVisible (spec 11)', () => {
     ];
     const visible = filterVisible(items, (i) => i.meta);
     expect(visible.map((i) => i.ref)).toEqual(['a', 'd']);
+  });
+});
+
+describe('sortPinnedFirst (#270)', () => {
+  it('moves pinned items to the front, preserving order within each group', () => {
+    const items = [
+      { ref: 'a', meta: {} },
+      { ref: 'b', meta: { userOverride: 'pinned' } },
+      { ref: 'c', meta: {} },
+      { ref: 'd', meta: { userOverride: 'pinned' } },
+    ];
+    const sorted = sortPinnedFirst(items, (i) => i.meta);
+    expect(sorted.map((i) => i.ref)).toEqual(['b', 'd', 'a', 'c']);
+  });
+  it('is a no-op when nothing is pinned', () => {
+    const items = [{ ref: 'a', meta: {} }, { ref: 'b', meta: null }];
+    const sorted = sortPinnedFirst(items, (i) => i.meta);
+    expect(sorted.map((i) => i.ref)).toEqual(['a', 'b']);
+  });
+  it('does not mutate the input array', () => {
+    const items = [{ ref: 'a', meta: {} }, { ref: 'b', meta: { userOverride: 'pinned' } }];
+    const before = items.map((i) => i.ref);
+    sortPinnedFirst(items, (i) => i.meta);
+    expect(items.map((i) => i.ref)).toEqual(before);
   });
 });

--- a/packages/decision-engine/src/digest.ts
+++ b/packages/decision-engine/src/digest.ts
@@ -19,7 +19,12 @@
  */
 
 import { clusterSignals } from './topic-clusterer.js';
-import { filterVisible, type SignalVisibilityMeta } from './visibility-filter.js';
+import {
+  filterVisible,
+  isPinned,
+  sortPinnedFirst,
+  type SignalVisibilityMeta,
+} from './visibility-filter.js';
 import type { DigestItemDetail } from './digest-detail.js';
 import type { SourceCoverage } from './source-coverage.js';
 
@@ -89,19 +94,29 @@ const URGENCY_RANK: Record<NonNullable<DigestItem['urgency']>, number> = {
 
 /**
  * Partition digest items into the to-do and topic buckets. Hidden items are
- * dropped first (spec 11). To-dos are urgency-ordered and capped; topics are
- * domain clusters (spec 04). No item appears in both buckets.
+ * dropped first (spec 11/#485); pinned items (#270) are surfaced ahead of
+ * unpinned ones of the same kind. To-dos are urgency-ordered and capped; topics
+ * are domain clusters (spec 04). No item appears in both buckets.
  */
 export function buildDigest(items: DigestItem[], opts: BuildDigestOptions = {}): Digest {
   const maxTodos = opts.maxTodos ?? 7;
 
-  // spec 11: never surface content the user hid.
+  // spec 11 / #485: never surface content the user hid.
   const visible = filterVisible(items, (i) => i.meta ?? null);
 
-  // To-dos: action-required, urgency-ordered, capped.
+  // To-dos: action-required. Pinned items (#270) lead, then urgency order. The
+  // capped slice runs AFTER pinned-first ordering so a pin can rescue an item
+  // from being truncated off the end of a long to-do list.
   const todos: DigestTodo[] = visible
     .filter((i) => i.actionRequired)
-    .sort((a, b) => URGENCY_RANK[a.urgency ?? 'low'] - URGENCY_RANK[b.urgency ?? 'low'])
+    // Pinned-first is the primary key; urgency is the tiebreaker within each
+    // group. Array.prototype.sort is stable in every supported runtime, so
+    // equal-key items keep their input order.
+    .sort((a, b) => {
+      const pinDelta = Number(isPinned(b.meta ?? null)) - Number(isPinned(a.meta ?? null));
+      if (pinDelta !== 0) return pinDelta;
+      return URGENCY_RANK[a.urgency ?? 'low'] - URGENCY_RANK[b.urgency ?? 'low'];
+    })
     .slice(0, maxTodos)
     .map((i) => ({
       ref: i.ref,
@@ -112,7 +127,8 @@ export function buildDigest(items: DigestItem[], opts: BuildDigestOptions = {}):
       signalRefs: [i.ref],
     }));
 
-  // Topics: everything else, clustered by domain.
+  // Topics: everything else, clustered by domain. Pinned FYI items lead within
+  // their cluster so a pinned-but-routine item isn't buried.
   const fyi = visible.filter((i) => !i.actionRequired);
   const byRef = new Map(fyi.map((i) => [i.ref, i]));
   const clusters = clusterSignals(
@@ -122,7 +138,7 @@ export function buildDigest(items: DigestItem[], opts: BuildDigestOptions = {}):
   const topics: DigestTopic[] = clusters.map((c) => ({
     domain: c.domain,
     title: c.title,
-    items: c.signalRefs.map((ref) => {
+    items: sortPinnedFirst(c.signalRefs, (ref) => byRef.get(ref)?.meta ?? null).map((ref) => {
       const it = byRef.get(ref);
       return { ref, text: it?.text ?? '', body: it?.body, sourceType: it?.sourceType, signalRefs: [ref] };
     }),

--- a/packages/decision-engine/src/index.ts
+++ b/packages/decision-engine/src/index.ts
@@ -71,7 +71,9 @@ export {
 } from './source-coverage.js';
 export {
   isHidden,
+  isPinned,
   filterVisible,
+  sortPinnedFirst,
   type SignalVisibilityMeta,
 } from './visibility-filter.js';
 export { resolveLanguage, resolveTimezone, isNonEnglish } from './locale.js';

--- a/packages/decision-engine/src/visibility-filter.ts
+++ b/packages/decision-engine/src/visibility-filter.ts
@@ -26,10 +26,39 @@ export function isHidden(meta: SignalVisibilityMeta | null | undefined): boolean
   return false;
 }
 
+/**
+ * True when the user has pinned this content (#270). Pinned content is surfaced
+ * higher than unpinned content of the same kind. Null/undefined meta → not
+ * pinned. A 'hidden' override always wins (hidden content is never pinned).
+ */
+export function isPinned(meta: SignalVisibilityMeta | null | undefined): boolean {
+  if (!meta) return false;
+  if (isHidden(meta)) return false;
+  return meta.userOverride === 'pinned';
+}
+
 /** Drop items the user has hidden, per `getMeta`. Preserves order. */
 export function filterVisible<T>(
   items: T[],
   getMeta: (item: T) => SignalVisibilityMeta | null | undefined,
 ): T[] {
   return items.filter((item) => !isHidden(getMeta(item)));
+}
+
+/**
+ * Stable-partition items so pinned ones (#270) lead, otherwise preserving the
+ * caller's order within each group. The caller decides how `getMeta` resolves
+ * an item's visibility metadata. Pure — does not mutate `items`.
+ */
+export function sortPinnedFirst<T>(
+  items: T[],
+  getMeta: (item: T) => SignalVisibilityMeta | null | undefined,
+): T[] {
+  const pinned: T[] = [];
+  const rest: T[] = [];
+  for (const item of items) {
+    if (isPinned(getMeta(item))) pinned.push(item);
+    else rest.push(item);
+  }
+  return [...pinned, ...rest];
 }


### PR DESCRIPTION
## What changed

The live digest never consulted the user's hide/pin choices, so content a user explicitly hid still appeared in the briefing and pinned senders weren't surfaced. The machinery existed (`filterVisible`/`isHidden` in `visibility-filter.ts`, `DigestItem.meta`, the canonical `brain_pages.metadata.userOverride` store written by the #270 pin/hide controls and `hideAllPagesFromSender`) but `buildLiveDigest` never populated `DigestItem.meta`, so `filterVisible` always saw `null` and dropped nothing.

This wires the read-path gate end-to-end:

- **`apps/api/src/services/live-digest.ts`** — `fetchSenderOverrides()` reads per-sender `userOverride` (`'hidden'`/`'pinned'`) from `brain_pages`, keyed by the bare, lowercased `fromAddress` (the same normalization the gbrain embedded port stamps at write time, mirrored here as `bareAddress()`). Each digest item's sender is resolved and its override attached as `DigestItem.meta`. Hidden wins over pinned for the same sender (fail safe). The `brain_pages` read **degrades to "no overrides, digest still renders"** if the table is absent (mempalace-only deploy) or transiently unavailable, rather than erroring the whole briefing.
- **`packages/decision-engine/src/visibility-filter.ts`** — new `isPinned()` + `sortPinnedFirst()`, reusing the **one shared** `isHidden` predicate (no second definition of "hidden").
- **`packages/decision-engine/src/digest.ts`** — `buildDigest` now surfaces pinned to-dos ahead of unpinned ones (urgency is the tiebreaker within a group) and pinned FYI items first within their topic cluster. No behavior change when nothing is pinned.

## ACs satisfied (read-path subset of #485)

- **AC1** — a hidden sender no longer appears in the digest (verified end-to-end with a hidden fixture in `live-digest.test.ts`).
- **AC2** — the hide predicate is the SAME shared `isHidden` the memory layer's definition mirrors; both `digest.ts` and `live-digest.ts` route through `visibility-filter.ts` (one function, asserted by both call sites importing it).
- **AC8 (partial)** — tests written and passing; no degradation of existing functionality (urgency-only ordering preserved when nothing is pinned).

The scope hint from the launch-readiness audit was specifically the **hide/pin enforcement in the live digest** (`live-digest.ts` + `digest.ts`). The write-path **scope gate** (AC3-5, #475-adjacent) and **revoked-token resilience** (AC6) remain open under #485 — they touch the decision-engine candidate generator and the worker briefing path, out of this scope.

## Tests added

- decision-engine (`visibility-filter.test.ts`, `digest.test.ts`): `isPinned`, `sortPinnedFirst` (front-load, no-op, no-mutation), hidden-wins-over-pinned fail safe, pinned to-do surfaced ahead of higher-urgency unpinned, pinned FYI surfaced within its cluster, urgency-only no-regression. 27 pass.
- api (`live-digest.test.ts`, `live-digest-helpers.test.ts`): hidden sender excluded end-to-end through the real `buildDigest`, empty-brain parity, `brain_pages` query-failure resilience, `bareAddress` normalization (angle-bracket extraction + lowercase + null). 28 pass.

Addresses #485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)