### PR TITLE
feat(digest): wire entity cross-linking into cluster dedup (#478)

### DIFF
--- a/apps/api/src/__tests__/live-digest-helpers.test.ts
+++ b/apps/api/src/__tests__/live-digest-helpers.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { needsYou, sourceLabel, normalizeUrgency, urgencyReasonFor, bareAddress } from '../services/live-digest.js';
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  needsYou,
+  sourceLabel,
+  normalizeUrgency,
+  urgencyReasonFor,
+  bareAddress,
+  entityLinkingEnabled,
+} from '../services/live-digest.js';
 
 /**
  * The to-do/FYI split (spec 01) and source labels (spec 07) that drive the
@@ -105,5 +112,28 @@ describe('bareAddress (pin/hide join key, #270/#485)', () => {
     expect(bareAddress(null)).toBeNull();
     expect(bareAddress(undefined)).toBeNull();
     expect(bareAddress('   ')).toBeNull();
+  });
+});
+
+describe('entityLinkingEnabled (spec 05, #478 rollback switch)', () => {
+  afterEach(() => {
+    delete process.env['ENTITY_LINKING'];
+  });
+
+  it('is ON by default (env unset)', () => {
+    delete process.env['ENTITY_LINKING'];
+    expect(entityLinkingEnabled()).toBe(true);
+  });
+
+  it('is OFF only for the exact rollback value "off"', () => {
+    process.env['ENTITY_LINKING'] = 'off';
+    expect(entityLinkingEnabled()).toBe(false);
+  });
+
+  it('stays ON for any other value (fail toward the shipped behavior)', () => {
+    process.env['ENTITY_LINKING'] = 'on';
+    expect(entityLinkingEnabled()).toBe(true);
+    process.env['ENTITY_LINKING'] = '';
+    expect(entityLinkingEnabled()).toBe(true);
   });
 });

--- a/apps/api/src/services/live-digest.ts
+++ b/apps/api/src/services/live-digest.ts
@@ -21,13 +21,25 @@ import {
   buildDigestItemDetail,
   computeCoverage,
   extractCommitments,
+  linkEntitiesAcrossSignals,
   toSignalText,
   type Commitment,
   type DigestItem,
   type Digest,
+  type ResolvedEntity,
   type SignalText,
   type SignalVisibilityMeta,
 } from '@skytwin/decision-engine';
+
+/**
+ * Cross-signal entity linking (spec 05, #478) collapse switch. Default ON;
+ * `ENTITY_LINKING=off` is the rollback path from the issue's rollback plan —
+ * with it off, no entities are extracted and the digest keeps the un-collapsed
+ * spec-04 clustering (possible cross-cluster repetition of one matter).
+ */
+export function entityLinkingEnabled(): boolean {
+  return process.env['ENTITY_LINKING'] !== 'off';
+}
 
 /** Most-recent decisions scanned to assemble one digest (perf + relevance bound). */
 const RECENT_DECISIONS_WINDOW = 30;
@@ -392,7 +404,12 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
   const detailByRef = new Map<string, ReturnType<typeof buildDigestItemDetail>>();
 
   const commitmentsOn = commitmentExtractionEnabled();
+  // Per-signal text kept by ref so cross-signal entity linking (#478) can run
+  // over the same SignalText the digest text is read from — no re-parse.
+  const signalTextByRef = new Map<string, SignalText>();
 
+  // flatMap (not map): a decision can yield its own item PLUS any commitment
+  // to-dos extracted from its authored content (#475).
   const items: DigestItem[] = decisions.rows.flatMap((r) => {
     // Reconstruct the RawSignal the decision was made from and read its text
     // through the spec-07 accessor (source-agnostic title/body/source).
@@ -412,6 +429,7 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
       data,
       timestamp: r.created_at instanceof Date ? r.created_at : new Date(r.created_at),
     });
+    signalTextByRef.set(r.id, signalText);
     const text =
       signalText.title.trim() ||
       signalText.body.trim() ||
@@ -509,7 +527,18 @@ export async function buildLiveDigest(userId: string): Promise<LiveDigest | null
   );
 
   const handledCount = decisions.rows.filter((r) => r.auto_executed === true).length;
-  const digest = buildDigest(items); // maxTodos defaults to 7
+
+  // Cross-signal entity linking (spec 05, #478): resolve people/orgs that recur
+  // across this window's signals so buildDigest can collapse one matter that
+  // would otherwise repeat across clusters into a single line with multiple
+  // citations. Gated by ENTITY_LINKING (default on; `off` = rollback to the
+  // un-collapsed spec-04 behavior).
+  const entityLinks: ResolvedEntity[] = entityLinkingEnabled()
+    ? linkEntitiesAcrossSignals(
+        [...signalTextByRef.entries()].map(([ref, signal]) => ({ ref, signal })),
+      )
+    : [];
+  const digest = buildDigest(items, { entityLinks }); // maxTodos defaults to 7
 
   // Attach power-view detail (spec 14) to each surfaced todo/topic item by ref.
   for (const todo of digest.todos) {

--- a/packages/decision-engine/src/__tests__/digest.test.ts
+++ b/packages/decision-engine/src/__tests__/digest.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { buildDigest, type DigestItem } from '../digest.js';
+import type { ResolvedEntity } from '../entity-linking.js';
+
+function entity(p: Partial<ResolvedEntity> & Pick<ResolvedEntity, 'entityId' | 'signalRefs'>): ResolvedEntity {
+  return {
+    kind: 'person',
+    normalized: p.entityId,
+    surfaces: [],
+    confidence: 0.9,
+    ...p,
+  };
+}
 
 function item(p: Partial<DigestItem> & Pick<DigestItem, 'ref'>): DigestItem {
   return {
@@ -107,5 +118,98 @@ describe('buildDigest (spec 01)', () => {
     );
     const finance = d.topics.find((t) => t.domain === 'finance')!;
     expect(finance.items.map((i) => i.ref).sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('buildDigest — entity collapse (spec 05, #478 AC5)', () => {
+  it('collapses one matter spanning 3 signals across 2 clusters into one line with 3 citations', () => {
+    const items = [
+      item({ ref: 's1', domain: 'work', text: 'Acme contract' }),
+      item({ ref: 's2', domain: 'finance', text: 'Acme invoice' }),
+      item({ ref: 's3', domain: 'work', text: 'Acme call notes' }),
+    ];
+    const entityLinks = [entity({ entityId: 'org:acme', kind: 'org', signalRefs: ['s1', 's2', 's3'] })];
+
+    const d = buildDigest(items, { knownDomains: ['work', 'finance'], entityLinks });
+
+    // The matter renders exactly once, not once per cluster.
+    const allItems = d.topics.flatMap((t) => t.items);
+    expect(allItems).toHaveLength(1);
+    // ...with all three signals as citations.
+    expect(allItems[0]!.signalRefs.sort()).toEqual(['s1', 's2', 's3']);
+    // The canonical line is the first occurrence (work cluster comes first).
+    expect(allItems[0]!.ref).toBe('s1');
+    // No empty "husk" cluster left behind once finance's only signal collapsed.
+    expect(d.topics.every((t) => t.items.length > 0)).toBe(true);
+  });
+
+  it('does NOT collapse when no entityLinks are supplied (ENTITY_LINKING=off parity)', () => {
+    const items = [
+      item({ ref: 's1', domain: 'work', text: 'Acme contract' }),
+      item({ ref: 's2', domain: 'finance', text: 'Acme invoice' }),
+    ];
+    const d = buildDigest(items, { knownDomains: ['work', 'finance'] });
+    expect(d.topics.flatMap((t) => t.items)).toHaveLength(2);
+  });
+
+  it('does NOT collapse signals linked only to a singleton entity (no false merge)', () => {
+    const items = [
+      item({ ref: 's1', domain: 'work', text: 'Acme contract' }),
+      item({ ref: 's2', domain: 'work', text: 'Globex proposal' }),
+    ];
+    // Each entity touches exactly one signal — nothing to collapse.
+    const entityLinks = [
+      entity({ entityId: 'org:acme', kind: 'org', signalRefs: ['s1'] }),
+      entity({ entityId: 'org:globex', kind: 'org', signalRefs: ['s2'] }),
+    ];
+    const d = buildDigest(items, { knownDomains: ['work'], entityLinks });
+    expect(d.topics.flatMap((t) => t.items)).toHaveLength(2);
+  });
+
+  it('never collapses to-dos — each action-required item stays its own line', () => {
+    const items = [
+      item({ ref: 't1', actionRequired: true, urgency: 'high', text: 'Reply to Acme' }),
+      item({ ref: 't2', actionRequired: true, urgency: 'high', text: 'Sign Acme contract' }),
+    ];
+    const entityLinks = [entity({ entityId: 'org:acme', kind: 'org', signalRefs: ['t1', 't2'] })];
+    const d = buildDigest(items, { entityLinks });
+    expect(d.todos.map((t) => t.ref).sort()).toEqual(['t1', 't2']);
+    expect(d.todos.every((t) => t.signalRefs.length === 1)).toBe(true);
+  });
+
+  it('a PINNED mention is never collapsed away — it leads + owns the matter (#485 × #478)', () => {
+    // Same matter, one cluster. Without a pin, s1 (first) would be the canonical
+    // line. s2 is PINNED, so it sorts first, becomes the canonical line, and s1
+    // folds INTO it — the user's pinned signal is never the one dropped.
+    const items = [
+      item({ ref: 's1', domain: 'work', text: 'Acme contract' }),
+      item({ ref: 's2', domain: 'work', text: 'Acme invoice', meta: { userOverride: 'pinned' } }),
+    ];
+    const entityLinks = [entity({ entityId: 'org:acme', kind: 'org', signalRefs: ['s1', 's2'] })];
+    const d = buildDigest(items, { knownDomains: ['work'], entityLinks });
+    const allItems = d.topics.flatMap((t) => t.items);
+    // Matter still renders once, but the canonical line is the PINNED signal.
+    expect(allItems).toHaveLength(1);
+    expect(allItems[0]!.ref).toBe('s2');
+    expect(allItems[0]!.signalRefs.sort()).toEqual(['s1', 's2']);
+  });
+
+  it('picks the higher-citation entity as primary when a signal touches two', () => {
+    const items = [
+      item({ ref: 's1', domain: 'work', text: 'Acme + Bob' }),
+      item({ ref: 's2', domain: 'work', text: 'Acme renewal' }),
+      item({ ref: 's3', domain: 'finance', text: 'Bob lunch' }),
+    ];
+    // s1 touches both Acme (3 signals) and Bob (2 signals). Acme wins primary.
+    const entityLinks = [
+      entity({ entityId: 'org:acme', kind: 'org', signalRefs: ['s1', 's2', 's3'] }),
+      entity({ entityId: 'person:bob@x', kind: 'person', signalRefs: ['s1', 's3'] }),
+    ];
+    const d = buildDigest(items, { knownDomains: ['work', 'finance'], entityLinks });
+    const allItems = d.topics.flatMap((t) => t.items);
+    // All three collapse under Acme (the 3-signal entity), one canonical line.
+    expect(allItems).toHaveLength(1);
+    expect(allItems[0]!.ref).toBe('s1');
+    expect(allItems[0]!.signalRefs.sort()).toEqual(['s1', 's2', 's3']);
   });
 });

--- a/packages/decision-engine/src/digest.ts
+++ b/packages/decision-engine/src/digest.ts
@@ -27,6 +27,7 @@ import {
 } from './visibility-filter.js';
 import type { DigestItemDetail } from './digest-detail.js';
 import type { SourceCoverage } from './source-coverage.js';
+import type { ResolvedEntity } from './entity-linking.js';
 
 export interface DigestItem {
   ref: string;
@@ -83,6 +84,15 @@ export interface BuildDigestOptions {
   knownDomains?: string[];
   maxTodos?: number;
   maxClusters?: number;
+  /**
+   * Resolved cross-signal entities (spec 05, #478). When supplied, FYI topic
+   * items that share a primary entity are collapsed into ONE topic item with
+   * the other mentions attached as additional citations (`signalRefs[]`),
+   * instead of repeating the same matter across multiple domain clusters.
+   * Omit (or pass `[]`) to keep the un-collapsed spec-04 behavior — the
+   * `ENTITY_LINKING=off` rollback path passes nothing here.
+   */
+  entityLinks?: ResolvedEntity[];
 }
 
 const URGENCY_RANK: Record<NonNullable<DigestItem['urgency']>, number> = {
@@ -91,6 +101,41 @@ const URGENCY_RANK: Record<NonNullable<DigestItem['urgency']>, number> = {
   medium: 2,
   low: 3,
 };
+
+/**
+ * Build a `signalRef -> primary entityId` map from resolved entities so the
+ * digest can collapse signals that share one matter. A signal's PRIMARY entity
+ * is the entity (touching >= 2 signals) with the most citations that the signal
+ * is linked to — ties broken by `entityId` for determinism. Only multi-signal
+ * entities are considered: a singleton entity can never cause a collapse, so it
+ * is never a "primary" for collapse purposes. People rank ahead of orgs at an
+ * equal citation count — a person key (email) is a strong, exact match, while
+ * an org key is fuzzy and the issue treats a false org merge as the worst case.
+ */
+function primaryEntityByRef(entities: ResolvedEntity[]): Map<string, string> {
+  // Candidate entities: only those linking 2+ distinct signals can collapse.
+  const linking = entities.filter((e) => new Set(e.signalRefs).size >= 2);
+
+  // Rank: more citations first; person before org on a tie; entityId last for
+  // a total, deterministic order.
+  const kindRank = (kind: ResolvedEntity['kind']): number => (kind === 'person' ? 0 : 1);
+  const ranked = [...linking].sort((a, b) => {
+    const byCount = new Set(b.signalRefs).size - new Set(a.signalRefs).size;
+    if (byCount !== 0) return byCount;
+    const byKind = kindRank(a.kind) - kindRank(b.kind);
+    if (byKind !== 0) return byKind;
+    return a.entityId < b.entityId ? -1 : a.entityId > b.entityId ? 1 : 0;
+  });
+
+  const byRef = new Map<string, string>();
+  for (const e of ranked) {
+    for (const ref of e.signalRefs) {
+      // First (highest-ranked) entity to claim a ref wins it as the primary.
+      if (!byRef.has(ref)) byRef.set(ref, e.entityId);
+    }
+  }
+  return byRef;
+}
 
 /**
  * Partition digest items into the to-do and topic buckets. Hidden items are
@@ -135,14 +180,54 @@ export function buildDigest(items: DigestItem[], opts: BuildDigestOptions = {}):
     fyi.map((i) => ({ ref: i.ref, domain: i.domain, subject: i.text })),
     { knownDomains: opts.knownDomains, maxClusters: opts.maxClusters },
   );
-  const topics: DigestTopic[] = clusters.map((c) => ({
-    domain: c.domain,
-    title: c.title,
-    items: sortPinnedFirst(c.signalRefs, (ref) => byRef.get(ref)?.meta ?? null).map((ref) => {
+  // Entity collapse (spec 05, #478 AC5): a matter (a single primary entity)
+  // spanning multiple FYI signals — possibly across DIFFERENT clusters —
+  // renders ONCE with every mention as a citation, not repeated per cluster.
+  // The first occurrence (clusters are confidence-ordered) is the canonical
+  // line; later mentions fold their refs into it. EXCEPTION (#485): a PINNED
+  // item is never collapsed away — the user pinned that signal, so it always
+  // stands on its own line.
+  const primaryByRef = primaryEntityByRef(opts.entityLinks ?? []);
+  // entityId -> the canonical topic item that owns this matter. A later
+  // mention (in this or any subsequent cluster) attaches to it as a citation.
+  const canonicalItemForEntity = new Map<string, DigestTopicItem>();
+
+  const topics: DigestTopic[] = [];
+  for (const c of clusters) {
+    const clusterItems: DigestTopicItem[] = [];
+    // Pinned FYI items lead within their cluster (#485) — iterate pinned-first
+    // so a pinned-but-routine item isn't buried, and (being first) it becomes
+    // the canonical owner of its matter rather than being folded into another.
+    for (const ref of sortPinnedFirst(c.signalRefs, (r) => byRef.get(r)?.meta ?? null)) {
       const it = byRef.get(ref);
-      return { ref, text: it?.text ?? '', body: it?.body, sourceType: it?.sourceType, signalRefs: [ref] };
-    }),
-  }));
+      const pinned = isPinned(it?.meta ?? null);
+      const entityId = primaryByRef.get(ref);
+      // A pinned signal is never collapsed into another matter's line; it
+      // always renders. (It can still OWN a matter — later non-pinned mentions
+      // fold into it — because pinned items are iterated first above.)
+      if (entityId !== undefined && !pinned) {
+        const canonical = canonicalItemForEntity.get(entityId);
+        if (canonical) {
+          // This matter already has a canonical line (possibly in an earlier
+          // cluster). Attach this signal as a citation (de-duped) and skip it.
+          if (!canonical.signalRefs.includes(ref)) canonical.signalRefs.push(ref);
+          continue;
+        }
+      }
+      const item: DigestTopicItem = {
+        ref,
+        text: it?.text ?? '',
+        body: it?.body,
+        sourceType: it?.sourceType,
+        signalRefs: [ref],
+      };
+      if (entityId !== undefined) canonicalItemForEntity.set(entityId, item);
+      clusterItems.push(item);
+    }
+    // A cluster can end up empty if every one of its signals collapsed into a
+    // canonical line living in an earlier cluster. Drop the empty husk.
+    if (clusterItems.length > 0) topics.push({ domain: c.domain, title: c.title, items: clusterItems });
+  }
 
   return { todos, topics };
 }


### PR DESCRIPTION
## What changed

`linkEntitiesAcrossSignals` (people-by-email + conservative org-by-token-overlap) was already built and tested in `packages/decision-engine/src/entity-linking.ts` but was never consumed in the live digest path — the last open #484 child for the live path. This PR wires it in so a single matter that recurs across signals collapses into one digest line instead of repeating across topic clusters (the reference AI-inbox product's "same thing listed twice" bug).

- **`packages/decision-engine/src/digest.ts`** — `buildDigest` gains an optional `entityLinks?: ResolvedEntity[]`. A signal's **primary entity** is the highest-citation entity touching ≥2 signals (people ranked ahead of fuzzy org keys on a tie, `entityId` last for determinism). When 2+ FYI signals share a primary entity they render as **one** topic item with every mention attached as a `signalRefs[]` citation — even across different domain clusters. The first occurrence (clusters are confidence-ordered) is the canonical line; later mentions fold in as citations. Empty clusters left by a collapse are dropped. **To-dos are never collapsed** — each escalated action stays its own line.
- **`apps/api/src/services/live-digest.ts`** — runs the linker over the same `SignalText` the digest text is read from (no re-parse), feeds the result to `buildDigest`. Gated by **`ENTITY_LINKING`** (default on; `ENTITY_LINKING=off` is the issue's documented rollback to the un-collapsed spec-04 clustering). New exported `entityLinkingEnabled()` helper.

## ACs satisfied

This PR delivers the scope hint — the briefing/cluster-dedup half of #478:

- **AC5** — one matter spanning 3 signals across 2 clusters renders once with 3 citations, no cross-cluster repetition. (Covered by a direct unit test.)
- **AC8** — tests written and passing; no degradation of existing functionality.

ACs 1–3 (resolution: email-merge, name-collision split, fuzzy-bar reject) were already satisfied by the pre-existing `entity-linking.ts` + its tests. The MemoryPort persistence surface (AC4 `getSignalsForEntity`, AC6 entity-record provenance, AC7 gbrain+mempalace parity) is a separate, larger piece outside this PR's scope hint and is **not** included here.

## Safety

Read-only and provenance-safe: the linker mints a new entity on doubt rather than risk a false merge, never auto-executes, and touches no policy/trust/spend path. Provenance is unchanged.

## Tests

- `packages/decision-engine/src/__tests__/digest.test.ts` — **+5** collapse cases: 3-signals-across-2-clusters → 1 line + 3 citations; no-`entityLinks` parity (= `ENTITY_LINKING=off`); singleton entity never collapses; to-dos never collapse; higher-citation entity wins primary when a signal touches two.
- `apps/api/src/__tests__/live-digest-helpers.test.ts` — **+3** `entityLinkingEnabled` flag cases (default on, `off` switch, fail-toward-on for other values).

Verified locally: full `@skytwin/decision-engine` suite (303 tests) green + `tsc` clean; `@skytwin/api` live-digest suite (25 tests) green + `live-digest.ts` `tsc`-clean against the rebuilt decision-engine types. (Per CLAUDE.md, the worktree's stale decision-engine `dist` surfaces a known TS2353 on a full app build; CI's fresh build is unaffected.)

Addresses #478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)