### PR TITLE
feat(worker): dead-letter queue for background jobs (#407)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -43,6 +43,7 @@ import { createFederationRouter } from './routes/federation.js';
 import { createVoiceRouter } from './routes/voice.js';
 import { createCrisisModesRouter } from './routes/crisis-modes.js';
 import { createConnectorsRouter } from './routes/connectors.js';
+import { createAdminDlqRouter } from './routes/admin-dlq.js';
 import { createEmbeddedLlmRouter } from './routes/embedded-llm.js';
 import {
   createPromotionOffersRouter,
@@ -353,6 +354,7 @@ app.use('/api/federation', sessionAuth, requestContext, createFederationRouter()
 app.use('/api/voice', sessionAuth, requireOwnership, requestContext, createVoiceRouter());
 app.use('/api/crisis-modes', sessionAuth, requestContext, createCrisisModesRouter()); // userId-param ownership in-router
 app.use('/api/connectors', sessionAuth, requestContext, createConnectorsRouter()); // #377 — per-user OAuth re-auth surface
+app.use('/api/admin', sessionAuth, requestContext, createAdminDlqRouter()); // #407 — worker dead-letter queue (operator-only; rows are process-global)
 app.use('/api/embedded-llm', sessionAuth, requestContext, createEmbeddedLlmRouter()); // catalog endpoints; no userId in path
 // #310: promotion-offer durable surface. GET takes :userId in the path
 // (require-ownership enforces); POST takes offerId in the path with

--- a/apps/api/src/routes/admin-dlq.ts
+++ b/apps/api/src/routes/admin-dlq.ts
@@ -1,0 +1,169 @@
+import { Router } from 'express';
+import { createLogger } from '@skytwin/core';
+import {
+  workerDeadLetterRepository,
+  type WorkerDeadLetterRow,
+  type WorkerDeadLetterStatus,
+} from '@skytwin/db';
+
+/**
+ * Operator-facing dead-letter-queue admin surface (#407, parent #357).
+ *
+ * The worker routes a background job to `worker_dead_letter` after it
+ * exceeds its retry budget (see apps/worker/src/dead-letter.ts). This
+ * router lets the operator inspect that queue and resolve each row —
+ * either `replayed` (re-queue the job by clearing the retry streak and
+ * letting the next worker cycle pick it up) or `discarded` (dismiss it).
+ *
+ * SkyTwin is single-owner: there is no separate admin role, so the
+ * session-authenticated owner IS the operator. Mounted under
+ * `sessionAuth` only (no `requireOwnership` — these rows are
+ * process-global, not user-scoped).
+ *
+ * NOTE on "replay": the worker's jobs are cadence-driven and idempotent
+ * (embedding backfill drains a SELECT FOR UPDATE SKIP LOCKED queue,
+ * domain extraction / briefings re-read live state, promotion-eligibility
+ * is ON CONFLICT-guarded). Marking a row `replayed` therefore does NOT
+ * re-execute the job synchronously — it records the operator's intent and
+ * clears the row from the actionable queue. The job re-runs on its normal
+ * cadence (now that the underlying cause is presumably fixed). A future
+ * follow-up could add a worker IPC channel to force an immediate re-run;
+ * for v1 the cadence is the replay mechanism and this endpoint is the
+ * acknowledgement.
+ */
+
+const log = createLogger('api:admin-dlq');
+
+const VALID_RESOLUTIONS: ReadonlySet<string> = new Set(['replayed', 'discarded']);
+
+interface DeadLetterDTO {
+  id: string;
+  jobName: string;
+  errorMessage: string;
+  attempts: number;
+  context: unknown;
+  status: WorkerDeadLetterStatus;
+  deadLetteredAt: string;
+  resolvedAt: string | null;
+}
+
+function rowToDTO(row: WorkerDeadLetterRow): DeadLetterDTO {
+  return {
+    id: row.id,
+    jobName: row.job_name,
+    errorMessage: row.error_message,
+    attempts: row.attempts,
+    context: row.context,
+    status: row.status,
+    deadLetteredAt: row.dead_lettered_at.toISOString(),
+    resolvedAt: row.resolved_at ? row.resolved_at.toISOString() : null,
+  };
+}
+
+export function createAdminDlqRouter(): Router {
+  const router = Router();
+
+  /**
+   * GET /api/admin/dead-letter
+   *
+   * Query params (all optional):
+   *   status  — 'pending' (default) | 'replayed' | 'discarded' | 'all'
+   *   jobName — narrow to a single job
+   *   limit   — page size (default 100, capped at 500 by the repo)
+   *
+   * Returns the rows plus a `pendingCount` badge so the dashboard can
+   * render the queue size without a second round-trip.
+   */
+  router.get('/dead-letter', async (req, res, next) => {
+    try {
+      const rawStatus = typeof req.query['status'] === 'string' ? req.query['status'] : undefined;
+      const jobName = typeof req.query['jobName'] === 'string' ? req.query['jobName'] : undefined;
+      const rawLimit = typeof req.query['limit'] === 'string' ? Number(req.query['limit']) : undefined;
+
+      // Map the public query value to the repository's `status` option.
+      // 'all' → null (include resolved history); a specific status passes
+      // through; anything else (including omitted) → 'pending'.
+      let status: WorkerDeadLetterStatus | null;
+      if (rawStatus === 'all') {
+        status = null;
+      } else if (
+        rawStatus === 'pending' ||
+        rawStatus === 'replayed' ||
+        rawStatus === 'discarded'
+      ) {
+        status = rawStatus;
+      } else {
+        status = 'pending';
+      }
+
+      const limit = rawLimit !== undefined && Number.isFinite(rawLimit) ? rawLimit : undefined;
+
+      const rows = await workerDeadLetterRepository.list({
+        status,
+        ...(jobName ? { jobName } : {}),
+        ...(limit !== undefined ? { limit } : {}),
+      });
+      const pendingCount = await workerDeadLetterRepository.countPending();
+
+      res.json({ deadLetters: rows.map(rowToDTO), pendingCount });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  /**
+   * POST /api/admin/dead-letter/:id/resolve
+   *
+   * Body: { resolution: 'replayed' | 'discarded' }
+   *
+   * Transitions a still-pending row to the given resolution. Race-safe
+   * in the repository (only `pending` rows transition), so a 409 means
+   * the row was already resolved by a concurrent request.
+   */
+  router.post('/dead-letter/:id/resolve', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      const { resolution } = (req.body ?? {}) as { resolution?: string };
+      if (!id) {
+        res.status(400).json({ error: 'Missing id parameter' });
+        return;
+      }
+      if (!resolution || !VALID_RESOLUTIONS.has(resolution)) {
+        res.status(400).json({
+          error: `Invalid resolution. Expected one of: ${Array.from(VALID_RESOLUTIONS).join(', ')}`,
+        });
+        return;
+      }
+
+      const updated = await workerDeadLetterRepository.markResolved(
+        id,
+        resolution as 'replayed' | 'discarded',
+      );
+      if (!updated) {
+        // Either the row doesn't exist or it was already resolved.
+        // Distinguish so the operator gets an accurate message.
+        const existing = await workerDeadLetterRepository.findById(id);
+        if (!existing) {
+          res.status(404).json({ error: 'Dead-letter row not found' });
+          return;
+        }
+        res.status(409).json({
+          error: 'Dead-letter row already resolved',
+          status: existing.status,
+        });
+        return;
+      }
+
+      log.info('Dead-letter row resolved', {
+        id,
+        jobName: updated.job_name,
+        resolution,
+      });
+      res.json({ ok: true, deadLetter: rowToDTO(updated) });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/apps/worker/src/__tests__/dead-letter.test.ts
+++ b/apps/worker/src/__tests__/dead-letter.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the workspace deps so the tracker can be unit-tested in isolation
+// without the full pnpm workspace resolution. The tests always inject
+// `record`, so the real repository is never exercised here.
+vi.mock('@skytwin/core', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+vi.mock('@skytwin/db', () => ({
+  workerDeadLetterRepository: { record: vi.fn() },
+}));
+
+const { DeadLetterTracker } = await import('../dead-letter.js');
+
+describe('DeadLetterTracker', () => {
+  describe('run', () => {
+    it('returns the result and clears the streak on success', async () => {
+      const record = vi.fn().mockResolvedValue({ id: 'x' });
+      const tracker = new DeadLetterTracker({ maxRetries: 3, record });
+
+      const result = await tracker.run('job-a', async () => 42);
+      expect(result).toBe(42);
+      expect(tracker.getFailureStreak('job-a')).toBe(0);
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('does NOT dead-letter before the retry budget is exhausted', async () => {
+      const record = vi.fn().mockResolvedValue({ id: 'x' });
+      const tracker = new DeadLetterTracker({ maxRetries: 3, record });
+      const fail = async () => {
+        throw new Error('boom');
+      };
+
+      await tracker.run('job-b', fail);
+      await tracker.run('job-b', fail);
+      expect(record).not.toHaveBeenCalled();
+      expect(tracker.getFailureStreak('job-b')).toBe(2);
+    });
+
+    it('dead-letters once the failure streak reaches maxRetries, then resets', async () => {
+      const record = vi.fn().mockResolvedValue({ id: 'dlq-1' });
+      const tracker = new DeadLetterTracker({ maxRetries: 3, record });
+      const fail = async () => {
+        throw new Error('CRDB unreachable');
+      };
+
+      await tracker.run('job-c', fail);
+      await tracker.run('job-c', fail);
+      await tracker.run('job-c', fail); // 3rd consecutive failure → dead-letter
+
+      expect(record).toHaveBeenCalledTimes(1);
+      expect(record).toHaveBeenCalledWith({
+        jobName: 'job-c',
+        errorMessage: 'CRDB unreachable',
+        attempts: 3,
+        context: undefined,
+      });
+      // Streak resets so the DLQ isn't spammed with a row every tick.
+      expect(tracker.getFailureStreak('job-c')).toBe(0);
+    });
+
+    it('does not spam the DLQ: after dead-lettering it takes another full streak', async () => {
+      const record = vi.fn().mockResolvedValue({ id: 'dlq' });
+      const tracker = new DeadLetterTracker({ maxRetries: 2, record });
+      const fail = async () => {
+        throw new Error('still broken');
+      };
+
+      // First streak of 2 → one DLQ row.
+      await tracker.run('job-d', fail);
+      await tracker.run('job-d', fail);
+      expect(record).toHaveBeenCalledTimes(1);
+
+      // Next tick starts a fresh streak; one failure is not enough.
+      await tracker.run('job-d', fail);
+      expect(record).toHaveBeenCalledTimes(1);
+
+      // Second failure of the new streak → second DLQ row.
+      await tracker.run('job-d', fail);
+      expect(record).toHaveBeenCalledTimes(2);
+    });
+
+    it('a success in the middle of a failure streak resets it', async () => {
+      const record = vi.fn().mockResolvedValue({ id: 'dlq' });
+      const tracker = new DeadLetterTracker({ maxRetries: 3, record });
+      const fail = async () => {
+        throw new Error('flaky');
+      };
+
+      await tracker.run('job-e', fail);
+      await tracker.run('job-e', fail);
+      await tracker.run('job-e', async () => 'ok'); // recovers
+      expect(tracker.getFailureStreak('job-e')).toBe(0);
+
+      // One more failure should NOT dead-letter (streak restarted at 1).
+      await tracker.run('job-e', fail);
+      expect(record).not.toHaveBeenCalled();
+      expect(tracker.getFailureStreak('job-e')).toBe(1);
+    });
+
+    it('never rejects even when the DLQ write itself throws', async () => {
+      const record = vi.fn().mockRejectedValue(new Error('DLQ write failed'));
+      const tracker = new DeadLetterTracker({ maxRetries: 1, record });
+      const fail = async () => {
+        throw new Error('boom');
+      };
+
+      // maxRetries=1 → first failure dead-letters; record() throws but
+      // run() must still resolve (undefined), not reject.
+      await expect(tracker.run('job-f', fail)).resolves.toBeUndefined();
+      expect(record).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the job context through to the DLQ row', async () => {
+      const record = vi.fn().mockResolvedValue({ id: 'dlq' });
+      const tracker = new DeadLetterTracker({ maxRetries: 1, record });
+      await tracker.run(
+        'job-g',
+        async () => {
+          throw new Error('boom');
+        },
+        { cadence: 'weekly' },
+      );
+      expect(record).toHaveBeenCalledWith(
+        expect.objectContaining({ context: { cadence: 'weekly' } }),
+      );
+    });
+  });
+
+  describe('recordOutcome (fire-and-forget jobs)', () => {
+    it('clears the streak when passed a null/undefined error (success)', async () => {
+      const record = vi.fn().mockResolvedValue({ id: 'dlq' });
+      const tracker = new DeadLetterTracker({ maxRetries: 3, record });
+      await tracker.recordOutcome('job-h', new Error('x'));
+      await tracker.recordOutcome('job-h', null);
+      expect(tracker.getFailureStreak('job-h')).toBe(0);
+    });
+
+    it('dead-letters once consecutive failures reach maxRetries', async () => {
+      const record = vi.fn().mockResolvedValue({ id: 'dlq' });
+      const tracker = new DeadLetterTracker({ maxRetries: 2, record });
+      await tracker.recordOutcome('job-i', new Error('fail 1'));
+      expect(record).not.toHaveBeenCalled();
+      await tracker.recordOutcome('job-i', new Error('fail 2'), { cadence: 'daily' });
+      expect(record).toHaveBeenCalledWith({
+        jobName: 'job-i',
+        errorMessage: 'fail 2',
+        attempts: 2,
+        context: { cadence: 'daily' },
+      });
+      expect(tracker.getFailureStreak('job-i')).toBe(0);
+    });
+
+    it('stringifies non-Error throwables', async () => {
+      const record = vi.fn().mockResolvedValue({ id: 'dlq' });
+      const tracker = new DeadLetterTracker({ maxRetries: 1, record });
+      await tracker.recordOutcome('job-j', 'plain string failure');
+      expect(record).toHaveBeenCalledWith(
+        expect.objectContaining({ errorMessage: 'plain string failure' }),
+      );
+    });
+
+    it('never rejects when the DLQ write throws', async () => {
+      const record = vi.fn().mockRejectedValue(new Error('write failed'));
+      const tracker = new DeadLetterTracker({ maxRetries: 1, record });
+      await expect(
+        tracker.recordOutcome('job-k', new Error('boom')),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/apps/worker/src/dead-letter.ts
+++ b/apps/worker/src/dead-letter.ts
@@ -1,0 +1,164 @@
+import { createLogger } from '@skytwin/core';
+import { workerDeadLetterRepository } from '@skytwin/db';
+
+const log = createLogger('worker:dead-letter');
+
+/**
+ * Dead-letter wrapper for the worker's global background jobs (#407).
+ *
+ * The worker loop runs each global job (domain extraction, embedding
+ * backfill, briefing generation, federation sync, …) on a cadence and
+ * historically did `await runX().catch(log.warn)` — a job that fails on
+ * EVERY tick logged a warning forever with no retry budget and no
+ * operator visibility.
+ *
+ * `DeadLetterTracker` adds a per-job consecutive-failure counter. When a
+ * job's failure streak reaches `maxRetries`, the tracker writes one row
+ * to `worker_dead_letter` capturing the final error + attempt count, then
+ * resets the streak so the table isn't spammed with a row per tick. A
+ * subsequent success clears the streak — a job that recovers on its own
+ * never reaches the DLQ.
+ *
+ * The wrapper NEVER throws: a failure to write the DLQ row is logged and
+ * swallowed, exactly like the prior `.catch()` behaviour. Worker
+ * resilience is the invariant — the DLQ is observability layered on top,
+ * not a new failure mode in the poll loop.
+ */
+export interface DeadLetterTrackerOptions {
+  /**
+   * Consecutive failures before a job is dead-lettered. Default 3 —
+   * matches the per-user circuit breaker's `failureThreshold` so a job
+   * gets the same "three strikes" budget as a flaky connector.
+   */
+  maxRetries?: number;
+  /**
+   * Sink for recording a dead-lettered job. Injectable so tests don't
+   * touch the DB. Defaults to the real repository.
+   */
+  record?: (input: {
+    jobName: string;
+    errorMessage: string;
+    attempts: number;
+    context?: unknown;
+  }) => Promise<unknown>;
+}
+
+export class DeadLetterTracker {
+  private readonly maxRetries: number;
+  private readonly record: NonNullable<DeadLetterTrackerOptions['record']>;
+  /** Per-job consecutive-failure streak. */
+  private readonly failureStreaks = new Map<string, number>();
+
+  constructor(opts: DeadLetterTrackerOptions = {}) {
+    this.maxRetries = Math.max(1, opts.maxRetries ?? 3);
+    this.record =
+      opts.record ??
+      ((input) => workerDeadLetterRepository.record(input));
+  }
+
+  /**
+   * Run `fn` (one execution of a job). On success, clears the job's
+   * failure streak and returns the result. On failure, increments the
+   * streak, logs, and — once the streak reaches `maxRetries` — writes a
+   * dead-letter row and resets the streak.
+   *
+   * Always resolves (never rejects): mirrors the worker loop's existing
+   * "catch and continue" contract. Returns `undefined` on failure so the
+   * caller can branch on a defined result if it cares.
+   */
+  async run<T>(
+    jobName: string,
+    fn: () => Promise<T>,
+    context?: unknown,
+  ): Promise<T | undefined> {
+    try {
+      const result = await fn();
+      // Recovered (or never failing): clear the streak so a future
+      // failure starts counting fresh.
+      this.failureStreaks.delete(jobName);
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const attempts = (this.failureStreaks.get(jobName) ?? 0) + 1;
+      this.failureStreaks.set(jobName, attempts);
+
+      if (attempts >= this.maxRetries) {
+        log.error(
+          `Job "${jobName}" failed ${attempts}x consecutively — dead-lettering`,
+          { error: message },
+        );
+        try {
+          await this.record({
+            jobName,
+            errorMessage: message,
+            attempts,
+            context,
+          });
+        } catch (recordErr) {
+          // DLQ write failed — log and swallow. The worker keeps running;
+          // we simply lose the operator-visible record this once.
+          log.error('Failed to write dead-letter row — continuing', {
+            jobName,
+            error:
+              recordErr instanceof Error
+                ? recordErr.message
+                : String(recordErr),
+          });
+        }
+        // Reset so we don't write a row every tick once over threshold.
+        this.failureStreaks.delete(jobName);
+      } else {
+        log.warn(
+          `Job "${jobName}" failed (${attempts}/${this.maxRetries}) — will retry next cycle`,
+          { error: message },
+        );
+      }
+      return undefined;
+    }
+  }
+
+  /**
+   * Record a job outcome when success/failure is observed OUTSIDE `run()`
+   * — i.e. the fire-and-forget jobs whose success lands in `.then()` and
+   * failure in `.catch()` (relationship-tier backfill, briefing generator,
+   * promotion-eligibility). Pass the caught error to count a failure, or
+   * `null`/`undefined` to clear the streak on success.
+   *
+   * Like `run()`, this never throws: a DLQ write failure is logged and
+   * swallowed.
+   */
+  async recordOutcome(jobName: string, error: unknown, context?: unknown): Promise<void> {
+    if (error === null || error === undefined) {
+      this.failureStreaks.delete(jobName);
+      return;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    const attempts = (this.failureStreaks.get(jobName) ?? 0) + 1;
+    this.failureStreaks.set(jobName, attempts);
+
+    if (attempts >= this.maxRetries) {
+      log.error(
+        `Job "${jobName}" failed ${attempts}x consecutively — dead-lettering`,
+        { error: message },
+      );
+      try {
+        await this.record({ jobName, errorMessage: message, attempts, context });
+      } catch (recordErr) {
+        log.error('Failed to write dead-letter row — continuing', {
+          jobName,
+          error:
+            recordErr instanceof Error ? recordErr.message : String(recordErr),
+        });
+      }
+      this.failureStreaks.delete(jobName);
+    }
+    // Below threshold: streak already incremented; the caller logged its
+    // own warn (it has job-specific context). Stay quiet to avoid double-
+    // logging the same failure.
+  }
+
+  /** Current consecutive-failure streak for a job (0 if none). Test/diagnostic. */
+  getFailureStreak(jobName: string): number {
+    return this.failureStreaks.get(jobName) ?? 0;
+  }
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -20,6 +20,7 @@ import {
   ironClawToolRepository,
   serviceCredentialRepository,
   accessLogRepository,
+  workerDeadLetterRepository,
 } from '@skytwin/db';
 import { withRetry, RetryableHttpError, CircuitBreaker, createLogger } from '@skytwin/core';
 import { KeyCache } from '@skytwin/credential-vault';
@@ -35,9 +36,20 @@ import { runRelationshipTierBackfillBatch } from './jobs/relationship-tier-sched
 import { runBriefingGeneratorJob } from './jobs/briefing-generator.js';
 import { runPromotionEligibilityCheckJob } from './jobs/promotion-eligibility-check.js';
 import { extractErrorCode } from './oauth-error-code.js';
+import { DeadLetterTracker } from './dead-letter.js';
 
 const config = loadConfig();
 const log = createLogger('worker');
+
+/**
+ * Dead-letter tracker for the global background jobs (#407). A job that
+ * fails on `maxRetries` consecutive cycles is routed to `worker_dead_letter`
+ * for operator inspection/replay instead of logging a warning forever.
+ */
+const deadLetterTracker = new DeadLetterTracker();
+
+/** Resolved dead-letter rows are GC'd after 30 days (#407). */
+const DEAD_LETTER_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 /** Per-user circuit breakers to skip users with persistent failures. */
 const userCircuitBreakers = new Map<string, CircuitBreaker>();
@@ -641,20 +653,19 @@ async function main(): Promise<void> {
     pollCount++;
 
     // Drain in-memory metrics buffer to DB at most once per minute (#183).
+    // Wrapped in the dead-letter tracker (#407): a metrics-rollup that fails
+    // on every cycle (e.g. CRDB unreachable) is now routed to the DLQ after
+    // the retry budget instead of crashing the loop on an unhandled throw.
     const nowMs = Date.now();
     if (nowMs - lastMetricsRollupAt >= METRICS_ROLLUP_INTERVAL_MS) {
-      await runMetricsRollupJob();
+      await deadLetterTracker.run('metrics-rollup', () => runMetricsRollupJob());
       lastMetricsRollupAt = nowMs;
     }
 
     // Sweep MCP server changelogs weekly (#184 AC#2).
     // Individual server errors are caught inside the job — never propagate here.
     if (nowMs - lastChangelogPollAt >= CHANGELOG_POLL_INTERVAL_MS) {
-      await runChangelogPollJob().catch((err) => {
-        log.warn('Changelog poll job failed', {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
+      await deadLetterTracker.run('changelog-poll', () => runChangelogPollJob());
       lastChangelogPollAt = nowMs;
     }
 
@@ -662,21 +673,13 @@ async function main(): Promise<void> {
     // LlmClient is available — extraction is LLM-dependent. Per-user errors
     // are absorbed inside the job.
     if (nowMs - lastDomainExtractionAt >= DOMAIN_EXTRACTION_INTERVAL_MS) {
-      await runDomainExtractionJob().catch((err) => {
-        log.warn('Domain extraction job failed', {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
+      await deadLetterTracker.run('domain-extraction', () => runDomainExtractionJob());
       lastDomainExtractionAt = nowMs;
     }
 
     // Push federation deltas to active peers hourly (#194 Child 1).
     if (nowMs - lastFederationSyncAt >= FEDERATION_SYNC_INTERVAL_MS) {
-      await runFederationSyncJob().catch((err) => {
-        log.warn('Federation sync job failed', {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
+      await deadLetterTracker.run('federation-sync', () => runFederationSyncJob());
       lastFederationSyncAt = nowMs;
     }
 
@@ -685,22 +688,14 @@ async function main(): Promise<void> {
     // this catches them up. SELECT FOR UPDATE SKIP LOCKED makes it safe
     // under multiple worker instances.
     if (nowMs - lastEmbeddingBackfillAt >= EMBEDDING_BACKFILL_INTERVAL_MS) {
-      await runEmbeddingBackfillJob().catch((err) => {
-        log.warn('Embedding backfill job failed', {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
+      await deadLetterTracker.run('embedding-backfill', () => runEmbeddingBackfillJob());
       lastEmbeddingBackfillAt = nowMs;
     }
 
     // Backfill authoringTier on pre-Layer-1 pages (#251 follow-up).
     // Hourly; converges to no-op once the corpus is fully tagged.
     if (nowMs - lastTierBackfillAt >= TIER_BACKFILL_INTERVAL_MS) {
-      await runTierBackfillJob().catch((err) => {
-        log.warn('Tier backfill job failed', {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
+      await deadLetterTracker.run('tier-backfill', () => runTierBackfillJob());
       lastTierBackfillAt = nowMs;
     }
 
@@ -732,6 +727,8 @@ async function main(): Promise<void> {
             users: userIds.length,
             ...batchSummary,
           });
+          // #407: success clears the failure streak.
+          void deadLetterTracker.recordOutcome('relationship-tier-backfill', null);
         })
         .catch((err) => {
           // Scheduler-level failure (per-user errors are caught inside
@@ -741,6 +738,9 @@ async function main(): Promise<void> {
             error: err instanceof Error ? err.message : String(err),
           });
           lastRelationshipTierBackfillAt = previousLastAt;
+          // #407: feed the failure streak so a persistently broken batch
+          // lands in the DLQ after the retry budget.
+          void deadLetterTracker.recordOutcome('relationship-tier-backfill', err);
         })
         .finally(() => {
           relationshipTierBackfillInFlight = false;
@@ -764,11 +764,17 @@ async function main(): Promise<void> {
       const previousLastAt = lastBriefingDailyAt;
       lastBriefingDailyAt = nowMs;
       void runBriefingGeneratorJob({ cadence: 'daily' })
+        .then(() => {
+          void deadLetterTracker.recordOutcome('briefing-generator-daily', null);
+        })
         .catch((err) => {
           log.warn('Daily briefing generator failed', {
             error: err instanceof Error ? err.message : String(err),
           });
           lastBriefingDailyAt = previousLastAt;
+          void deadLetterTracker.recordOutcome('briefing-generator-daily', err, {
+            cadence: 'daily',
+          });
         })
         .finally(() => {
           briefingDailyInFlight = false;
@@ -783,11 +789,17 @@ async function main(): Promise<void> {
       const previousLastAt = lastBriefingWeeklyAt;
       lastBriefingWeeklyAt = nowMs;
       void runBriefingGeneratorJob({ cadence: 'weekly' })
+        .then(() => {
+          void deadLetterTracker.recordOutcome('briefing-generator-weekly', null);
+        })
         .catch((err) => {
           log.warn('Weekly briefing generator failed', {
             error: err instanceof Error ? err.message : String(err),
           });
           lastBriefingWeeklyAt = previousLastAt;
+          void deadLetterTracker.recordOutcome('briefing-generator-weekly', err, {
+            cadence: 'weekly',
+          });
         })
         .finally(() => {
           briefingWeeklyInFlight = false;
@@ -811,12 +823,14 @@ async function main(): Promise<void> {
           if (summary.offered > 0 || summary.alreadyPending > 0) {
             log.info('Promotion eligibility tick complete', { ...summary });
           }
+          void deadLetterTracker.recordOutcome('promotion-eligibility-check', null);
         })
         .catch((err) => {
           log.warn('Promotion eligibility check failed', {
             error: err instanceof Error ? err.message : String(err),
           });
           lastPromotionEligibilityAt = previousLastAt;
+          void deadLetterTracker.recordOutcome('promotion-eligibility-check', err);
         })
         .finally(() => {
           promotionEligibilityInFlight = false;
@@ -850,6 +864,23 @@ async function main(): Promise<void> {
             error instanceof Error ? error.message : error,
           );
         }
+      }
+
+      // #407: purge resolved (replayed/discarded) dead-letter rows older
+      // than 30 days so the table doesn't grow unbounded. Pending rows are
+      // never purged — they're the operator's actionable queue. Best-effort:
+      // a failure here must not block the poll loop.
+      try {
+        const purged = await workerDeadLetterRepository.purgeResolvedOlderThan(
+          DEAD_LETTER_RETENTION_MS,
+        );
+        if (purged > 0) {
+          log.info(`Purged ${purged} resolved worker_dead_letter row(s)`);
+        }
+      } catch (error) {
+        log.warn('worker_dead_letter purge failed — continuing', {
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
     }
 

--- a/packages/db/src/__tests__/worker-dead-letter-repository.test.ts
+++ b/packages/db/src/__tests__/worker-dead-letter-repository.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockQuery = vi.fn();
+
+vi.mock('../connection.js', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+const { workerDeadLetterRepository } = await import(
+  '../repositories/worker-dead-letter-repository.js'
+);
+
+const ROW = {
+  id: '11111111-1111-1111-1111-111111111111',
+  job_name: 'embedding-backfill',
+  error_message: 'CRDB unreachable',
+  attempts: 3,
+  context: { batchSize: 25 },
+  status: 'pending' as const,
+  dead_lettered_at: new Date('2026-06-14T12:00:00Z'),
+  resolved_at: null,
+};
+
+describe('workerDeadLetterRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+  });
+
+  describe('record', () => {
+    it('inserts job_name + error + attempts and serializes context to JSON', async () => {
+      mockQuery.mockResolvedValue({ rows: [ROW], rowCount: 1 });
+      const row = await workerDeadLetterRepository.record({
+        jobName: 'embedding-backfill',
+        errorMessage: 'CRDB unreachable',
+        attempts: 3,
+        context: { batchSize: 25 },
+      });
+      const [sql, args] = mockQuery.mock.calls[0]!;
+      expect(sql).toContain('INSERT INTO worker_dead_letter');
+      expect(sql).toContain('RETURNING');
+      expect(args).toEqual([
+        'embedding-backfill',
+        'CRDB unreachable',
+        3,
+        JSON.stringify({ batchSize: 25 }),
+      ]);
+      expect(row).toEqual(ROW);
+    });
+
+    it('defaults attempts to 1 and context to null when omitted', async () => {
+      mockQuery.mockResolvedValue({ rows: [ROW], rowCount: 1 });
+      await workerDeadLetterRepository.record({
+        jobName: 'domain-extraction',
+        errorMessage: 'LLM timeout',
+      });
+      const [, args] = mockQuery.mock.calls[0]!;
+      expect(args[2]).toBe(1); // attempts default
+      expect(args[3]).toBeNull(); // context default
+    });
+
+    it('does not double-encode a context that is already an object', async () => {
+      mockQuery.mockResolvedValue({ rows: [ROW], rowCount: 1 });
+      await workerDeadLetterRepository.record({
+        jobName: 'briefing-generator-daily',
+        errorMessage: 'boom',
+        context: { cadence: 'daily' },
+      });
+      const [, args] = mockQuery.mock.calls[0]!;
+      // Single JSON.stringify, not nested-quoted.
+      expect(args[3]).toBe('{"cadence":"daily"}');
+    });
+  });
+
+  describe('list', () => {
+    it('defaults to pending status, newest first, with a default limit', async () => {
+      mockQuery.mockResolvedValue({ rows: [ROW], rowCount: 1 });
+      await workerDeadLetterRepository.list();
+      const [sql, args] = mockQuery.mock.calls[0]!;
+      expect(sql).toContain("status = $1");
+      expect(sql).toContain('ORDER BY dead_lettered_at DESC');
+      expect(args[0]).toBe('pending');
+      expect(args[args.length - 1]).toBe(100); // default limit
+    });
+
+    it('omits the status filter when status is null (include resolved history)', async () => {
+      await workerDeadLetterRepository.list({ status: null });
+      const [sql, args] = mockQuery.mock.calls[0]!;
+      expect(sql).not.toContain('status =');
+      // Only the limit param remains.
+      expect(args).toEqual([100]);
+    });
+
+    it('filters by jobName when provided', async () => {
+      await workerDeadLetterRepository.list({ jobName: 'embedding-backfill', status: 'pending' });
+      const [sql, args] = mockQuery.mock.calls[0]!;
+      expect(sql).toContain('job_name = $2');
+      expect(args).toEqual(['pending', 'embedding-backfill', 100]);
+    });
+
+    it('hard-caps the limit at 500', async () => {
+      await workerDeadLetterRepository.list({ limit: 100000 });
+      const [, args] = mockQuery.mock.calls[0]!;
+      expect(args[args.length - 1]).toBe(500);
+    });
+
+    it('floors the limit at 1', async () => {
+      await workerDeadLetterRepository.list({ limit: 0 });
+      const [, args] = mockQuery.mock.calls[0]!;
+      expect(args[args.length - 1]).toBe(1);
+    });
+  });
+
+  describe('findById', () => {
+    it('returns the row when present', async () => {
+      mockQuery.mockResolvedValue({ rows: [ROW], rowCount: 1 });
+      const row = await workerDeadLetterRepository.findById(ROW.id);
+      expect(row).toEqual(ROW);
+      const [sql, args] = mockQuery.mock.calls[0]!;
+      expect(sql).toContain('WHERE id = $1');
+      expect(args).toEqual([ROW.id]);
+    });
+
+    it('returns null when absent', async () => {
+      mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+      expect(await workerDeadLetterRepository.findById('nope')).toBeNull();
+    });
+  });
+
+  describe('markResolved', () => {
+    it('only transitions a pending row (race-safe) and returns the updated row', async () => {
+      const resolved = { ...ROW, status: 'replayed' as const, resolved_at: new Date() };
+      mockQuery.mockResolvedValue({ rows: [resolved], rowCount: 1 });
+      const row = await workerDeadLetterRepository.markResolved(ROW.id, 'replayed');
+      const [sql, args] = mockQuery.mock.calls[0]!;
+      expect(sql).toContain("WHERE id = $1 AND status = 'pending'");
+      expect(sql).toContain('resolved_at = now()');
+      expect(args).toEqual([ROW.id, 'replayed']);
+      expect(row).toEqual(resolved);
+    });
+
+    it('returns null when the row was already resolved (no rows updated)', async () => {
+      mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+      expect(await workerDeadLetterRepository.markResolved(ROW.id, 'discarded')).toBeNull();
+    });
+  });
+
+  describe('countPending', () => {
+    it('returns the numeric count', async () => {
+      mockQuery.mockResolvedValue({ rows: [{ count: '4' }], rowCount: 1 });
+      expect(await workerDeadLetterRepository.countPending()).toBe(4);
+      const [sql] = mockQuery.mock.calls[0]!;
+      expect(sql).toContain("status = 'pending'");
+    });
+
+    it('returns 0 when no rows', async () => {
+      mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+      expect(await workerDeadLetterRepository.countPending()).toBe(0);
+    });
+  });
+
+  describe('purgeResolvedOlderThan', () => {
+    it('deletes only resolved rows past the TTL and returns the count', async () => {
+      mockQuery.mockResolvedValue({ rows: [], rowCount: 7 });
+      const purged = await workerDeadLetterRepository.purgeResolvedOlderThan(
+        30 * 24 * 60 * 60 * 1000,
+      );
+      const [sql, args] = mockQuery.mock.calls[0]!;
+      expect(sql).toContain("status IN ('replayed', 'discarded')");
+      expect(sql).toContain('resolved_at IS NOT NULL');
+      expect(args[0]).toBe('2592000 seconds');
+      expect(purged).toBe(7);
+    });
+
+    it('never lets the interval go below 1 second', async () => {
+      await workerDeadLetterRepository.purgeResolvedOlderThan(0);
+      const [, args] = mockQuery.mock.calls[0]!;
+      expect(args[0]).toBe('1 seconds');
+    });
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -118,11 +118,15 @@ export {
   patternRepository,
   executionRepository,
   connectorHealthRepository,
+  workerDeadLetterRepository,
   userPurgeRepository,
   accessLogRepository,
 } from './repositories/index.js';
 export type {
   ConnectorHealthRow,
+  WorkerDeadLetterRow,
+  WorkerDeadLetterStatus,
+  RecordDeadLetterInput,
   PurgeUserResult,
   AccessLogRow,
   RecordAccessInput,

--- a/packages/db/src/migrations/065-worker-dead-letter.sql
+++ b/packages/db/src/migrations/065-worker-dead-letter.sql
@@ -1,0 +1,47 @@
+-- 065-worker-dead-letter.sql
+-- Dead-letter queue for worker background jobs (#407, parent #357).
+--
+-- The worker's global background jobs (domain extraction, embedding
+-- backfill, briefing generation, federation sync, tier backfill, …)
+-- catch their own errors and continue. That keeps the poll loop alive
+-- through a transient failure, but it also means a job that fails on
+-- EVERY tick has no retry budget and no operator visibility — it just
+-- logs a warning and silently never makes progress.
+--
+-- This table is the dead-letter sink. After a job exceeds its retry
+-- budget (consecutive failures across poll cycles), the worker writes
+-- one row here capturing the job name, the final error, the attempt
+-- count, and a JSON `context` blob (the job's input, if any). An
+-- operator inspects the queue via GET /api/admin/dead-letter and can
+-- mark a row replayed once the underlying cause is fixed.
+--
+-- NOT user-scoped: these are process-global jobs with no single owner
+-- user (embedding backfill drains a shared queue; domain extraction
+-- iterates all users). `context` may name a user when one applies, but
+-- the row's identity is (job_name, dead_lettered_at), not a user.
+--
+-- `status` is a narrow union: 'pending' (awaiting operator action),
+-- 'replayed' (operator re-queued it), 'discarded' (operator dismissed
+-- it as not worth replaying). Only 'pending' rows surface in the
+-- default admin list.
+CREATE TABLE IF NOT EXISTS worker_dead_letter (
+    id                UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    job_name          STRING NOT NULL,
+    error_message     STRING NOT NULL,
+    attempts          INT NOT NULL DEFAULT 1,
+    context           JSONB,
+    status            STRING NOT NULL DEFAULT 'pending'
+                          CHECK (status IN ('pending', 'replayed', 'discarded')),
+    dead_lettered_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    resolved_at       TIMESTAMPTZ
+);
+
+-- The admin list query is "newest pending first"; this partial index
+-- keeps that scan cheap as discarded/replayed history accumulates.
+CREATE INDEX IF NOT EXISTS worker_dead_letter_pending_idx
+    ON worker_dead_letter (dead_lettered_at DESC)
+    WHERE status = 'pending';
+
+-- Supports the per-job-name filter the admin endpoint accepts.
+CREATE INDEX IF NOT EXISTS worker_dead_letter_job_idx
+    ON worker_dead_letter (job_name, dead_lettered_at DESC);

--- a/packages/db/src/repositories/index.ts
+++ b/packages/db/src/repositories/index.ts
@@ -24,6 +24,12 @@ export { oauthRepository } from './oauth-repository.js';
 export { oauthPkcePendingRepository } from './oauth-pkce-pending-repository.js';
 export { connectorHealthRepository } from './connector-health-repository.js';
 export type { ConnectorHealthRow } from './connector-health-repository.js';
+export { workerDeadLetterRepository } from './worker-dead-letter-repository.js';
+export type {
+  WorkerDeadLetterRow,
+  WorkerDeadLetterStatus,
+  RecordDeadLetterInput,
+} from './worker-dead-letter-repository.js';
 export { userPurgeRepository } from './user-purge-repository.js';
 export type { PurgeUserResult } from './user-purge-repository.js';
 export { accessLogRepository } from './access-log-repository.js';

--- a/packages/db/src/repositories/worker-dead-letter-repository.ts
+++ b/packages/db/src/repositories/worker-dead-letter-repository.ts
@@ -1,0 +1,177 @@
+import { query } from '../connection.js';
+
+/**
+ * Status of a dead-letter row.
+ *   'pending'   — awaiting operator action (default; surfaces in the admin list)
+ *   'replayed'  — operator re-queued the job
+ *   'discarded' — operator dismissed it as not worth replaying
+ */
+export type WorkerDeadLetterStatus = 'pending' | 'replayed' | 'discarded';
+
+/** A single dead-lettered worker job. See migration 065 for rationale. */
+export interface WorkerDeadLetterRow {
+  id: string;
+  job_name: string;
+  error_message: string;
+  attempts: number;
+  /**
+   * Arbitrary job input snapshot (e.g. `{ cadence: 'daily' }`,
+   * `{ userId: '…' }`). `null` for jobs that take no input. Typed as
+   * `unknown` rather than a concrete shape because the worker writes
+   * heterogeneous job contexts here; consumers narrow at read time.
+   */
+  context: unknown;
+  status: WorkerDeadLetterStatus;
+  dead_lettered_at: Date;
+  resolved_at: Date | null;
+}
+
+export interface RecordDeadLetterInput {
+  jobName: string;
+  errorMessage: string;
+  /** Number of attempts that were made before dead-lettering. Defaults to 1. */
+  attempts?: number;
+  /** Optional JSON-serializable snapshot of the job's input. */
+  context?: unknown;
+}
+
+/**
+ * Dead-letter queue for worker background jobs (#407).
+ *
+ * The worker wraps each global background job in a retry counter
+ * (`runWithDeadLetter` in apps/worker). After the job exceeds its
+ * retry budget, the worker calls `record()` once with the final error
+ * and the accumulated attempt count. An operator inspects the queue
+ * via the admin API (`/api/admin/dead-letter`) and resolves each row
+ * (`replayed` or `discarded`).
+ *
+ * NOT user-scoped — these are process-global jobs with no single owner
+ * user. `context` may name a user when one applies, but the row's
+ * identity is `(job_name, dead_lettered_at)`.
+ */
+export const workerDeadLetterRepository = {
+  /**
+   * Record a dead-lettered job. Returns the inserted row so the worker
+   * can log its id. `context` is serialized to JSONB via the driver's
+   * parameter binding (pass a plain object, not a pre-stringified blob)
+   * — stringifying ourselves would double-encode it.
+   */
+  async record(input: RecordDeadLetterInput): Promise<WorkerDeadLetterRow> {
+    const result = await query<WorkerDeadLetterRow>(
+      `INSERT INTO worker_dead_letter (job_name, error_message, attempts, context)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id, job_name, error_message, attempts, context,
+                 status, dead_lettered_at, resolved_at`,
+      [
+        input.jobName,
+        input.errorMessage,
+        input.attempts ?? 1,
+        input.context === undefined ? null : JSON.stringify(input.context),
+      ],
+    );
+    // RETURNING always yields exactly one row for a single-row INSERT.
+    return result.rows[0]!;
+  },
+
+  /**
+   * List dead-letter rows, newest first. Defaults to only `pending`
+   * rows (the operator's actionable queue). Pass `status: null` to
+   * include resolved history, or a specific status to filter.
+   * `jobName` narrows to a single job; `limit` caps the page (default
+   * 100, hard-capped at 500 so a malformed query can't scan the world).
+   */
+  async list(opts: {
+    status?: WorkerDeadLetterStatus | null;
+    jobName?: string;
+    limit?: number;
+  } = {}): Promise<WorkerDeadLetterRow[]> {
+    const status = opts.status === undefined ? 'pending' : opts.status;
+    const limit = Math.min(Math.max(1, opts.limit ?? 100), 500);
+
+    const where: string[] = [];
+    const params: unknown[] = [];
+    let i = 1;
+    if (status !== null) {
+      where.push(`status = $${i++}`);
+      params.push(status);
+    }
+    if (opts.jobName) {
+      where.push(`job_name = $${i++}`);
+      params.push(opts.jobName);
+    }
+    params.push(limit);
+
+    const whereClause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
+    const result = await query<WorkerDeadLetterRow>(
+      `SELECT id, job_name, error_message, attempts, context,
+              status, dead_lettered_at, resolved_at
+         FROM worker_dead_letter
+         ${whereClause}
+        ORDER BY dead_lettered_at DESC
+        LIMIT $${i}`,
+      params,
+    );
+    return result.rows;
+  },
+
+  /** Fetch a single row by id, or null if it doesn't exist. */
+  async findById(id: string): Promise<WorkerDeadLetterRow | null> {
+    const result = await query<WorkerDeadLetterRow>(
+      `SELECT id, job_name, error_message, attempts, context,
+              status, dead_lettered_at, resolved_at
+         FROM worker_dead_letter
+        WHERE id = $1`,
+      [id],
+    );
+    return result.rows[0] ?? null;
+  },
+
+  /**
+   * Mark a row resolved (`replayed` or `discarded`). Race-safe: only
+   * transitions a row that is still `pending`, so two operators
+   * clicking at once can't both "win". Returns the updated row, or
+   * null if the row didn't exist or was already resolved.
+   */
+  async markResolved(
+    id: string,
+    status: Extract<WorkerDeadLetterStatus, 'replayed' | 'discarded'>,
+  ): Promise<WorkerDeadLetterRow | null> {
+    const result = await query<WorkerDeadLetterRow>(
+      `UPDATE worker_dead_letter
+          SET status = $2, resolved_at = now()
+        WHERE id = $1 AND status = 'pending'
+      RETURNING id, job_name, error_message, attempts, context,
+                status, dead_lettered_at, resolved_at`,
+      [id, status],
+    );
+    return result.rows[0] ?? null;
+  },
+
+  /**
+   * Count of pending rows — backs the admin badge. Cheap thanks to the
+   * partial index `worker_dead_letter_pending_idx`.
+   */
+  async countPending(): Promise<number> {
+    const result = await query<{ count: string }>(
+      `SELECT count(*)::INT AS count FROM worker_dead_letter WHERE status = 'pending'`,
+    );
+    return Number(result.rows[0]?.count ?? 0);
+  },
+
+  /**
+   * Drop resolved rows older than the TTL window so the table doesn't
+   * grow unbounded. Only `replayed` / `discarded` rows are purged —
+   * `pending` rows are never deleted (they're the actionable queue).
+   * Returns the number of rows removed.
+   */
+  async purgeResolvedOlderThan(ttlMs: number): Promise<number> {
+    const result = await query(
+      `DELETE FROM worker_dead_letter
+        WHERE status IN ('replayed', 'discarded')
+          AND resolved_at IS NOT NULL
+          AND resolved_at <= now() - ($1::INTERVAL)`,
+      [`${Math.max(1, Math.floor(ttlMs / 1000))} seconds`],
+    );
+    return result.rowCount ?? 0;
+  },
+};


### PR DESCRIPTION
## What changed

Worker background jobs (metrics rollup, changelog poll, domain extraction, federation sync, embedding backfill, tier backfill, relationship-tier backfill, daily/weekly briefings, promotion-eligibility check) used to `catch` their error and continue — a job failing on every cycle logged a warning forever with **no retry budget and no operator visibility**. This adds a dead-letter queue.

- **Migration `065-worker-dead-letter.sql`** — `worker_dead_letter` table. Process-global (not user-scoped; these jobs have no single owner). `status` CHECK `('pending'|'replayed'|'discarded')`, `attempts`, JSONB `context`, partial index on pending rows + a `(job_name, dead_lettered_at)` index.
- **`workerDeadLetterRepository`** (`@skytwin/db`) — `record` / `list` (filter by status/jobName, limit clamped 1–500) / `findById` / `markResolved` (race-safe: only transitions a still-`pending` row) / `countPending` / `purgeResolvedOlderThan`. All queries fully parameterized; JSONB bound via `JSON.stringify` per existing repo convention (risk-profile-repository).
- **`DeadLetterTracker`** (`apps/worker/src/dead-letter.ts`) — per-job consecutive-failure streak; routes to the DLQ after `maxRetries` (default **3**, matching the per-user circuit-breaker `failureThreshold`), then resets the streak so the table isn't spammed with a row per tick. A success at any point clears the streak. **Never throws** (a DLQ write failure is logged + swallowed) so the poll loop's catch-and-continue resilience is preserved. `run()` wraps the awaited jobs; `recordOutcome()` feeds the fire-and-forget jobs' `.then`/`.catch` paths (success clears, failure counts).
- **Admin endpoint** — `GET /api/admin/dead-letter` (inspect; `status`/`jobName` filters; `pendingCount` badge) and `POST /api/admin/dead-letter/:id/resolve` (`replayed` | `discarded`). SkyTwin is single-owner, so the session-authenticated owner is the operator; routes are process-global, mounted under `sessionAuth`. Replay is acknowledgement, not synchronous re-execution — the jobs are cadence-driven and idempotent, so a `replayed` row re-runs on its normal cadence (documented in the route; a forced-immediate-replay worker IPC channel is a noted follow-up).
- Worker GCs resolved DLQ rows after 30 days.

## Acceptance criteria

- [x] **Failed jobs land in `worker_dead_letter` after N retries.** `DeadLetterTracker` records after 3 consecutive failures.
- [x] **Admin endpoint to inspect and replay.** `GET /api/admin/dead-letter` + `POST .../:id/resolve`.

## Tests added

- `packages/db/src/__tests__/worker-dead-letter-repository.test.ts` — 16 cases (insert/JSON-encode, defaults, status/jobName filters, limit clamp 1–500, race-safe resolve returning null, purge TTL floor).
- `apps/worker/src/__tests__/dead-letter.test.ts` — 11 cases (happy path, no dead-letter before budget, dead-letter at threshold + reset, no-spam after dead-letter, mid-streak success resets, DLQ-write-failure never rejects, context passthrough, `recordOutcome` success/failure/non-Error).

**Verification:** `@skytwin/db` full suite green (353 passed incl. the 16 new); worker tracker suite green (11 passed). New files type-check clean under strict mode (`noUncheckedIndexedAccess`, `noUnusedLocals/Parameters`). Could not run `pnpm build`/full `pnpm test` (shared machine, per task constraints) — verified per-file with `tsc` against the workspace source graph.

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)