### PR TITLE
feat(lifebooks): inline fact-edit recorder for extracted facts (#319)

### DIFF
--- a/apps/api/src/__tests__/lifebook-fact-edit-route.test.ts
+++ b/apps/api/src/__tests__/lifebook-fact-edit-route.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for PATCH /api/lifebooks/:userId/:domainName/facts/:index —
+ * issue #319 inline fact-edit recorder.
+ *
+ * Coverage:
+ *   1. Happy path — edits the fact, records a user-corrected provenance
+ *      node, returns { lifebook, correction } with before/after.
+ *   2. 404 when the lifebook doesn't exist (findByDomain null).
+ *   3. 404 when the index is out of range (editSampleSignal null but
+ *      lifebook exists).
+ *   4. 400 on non-integer / negative index.
+ *   5. 400 on blank text.
+ *   6. Provenance write failure is non-fatal — the edit still succeeds,
+ *      correction.provenanceNodeId is null (fail-soft audit trail).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import type { Express } from 'express';
+
+const {
+  mockFindByDomain,
+  mockEditSampleSignal,
+  mockWriteNode,
+} = vi.hoisted(() => ({
+  mockFindByDomain: vi.fn(),
+  mockEditSampleSignal: vi.fn(),
+  mockWriteNode: vi.fn(),
+}));
+
+vi.mock('@skytwin/db', () => ({
+  lifebookRepository: {
+    listVisible: vi.fn(),
+    listAll: vi.fn(),
+    findByDomain: mockFindByDomain,
+    hide: vi.fn(),
+    unhide: vi.fn(),
+    setImportanceOverride: vi.fn(),
+    clearImportanceOverride: vi.fn(),
+    editSampleSignal: mockEditSampleSignal,
+  },
+  mempalaceRepository: {
+    getRooms: vi.fn(),
+    getDrawers: vi.fn(),
+  },
+  aiProviderRepository: {
+    getEnabledForUser: vi.fn(),
+  },
+  provenanceRepository: {
+    writeNode: mockWriteNode,
+  },
+}));
+
+vi.mock('@skytwin/policy-prompts', () => ({
+  runPrompt: vi.fn(),
+}));
+
+vi.mock('@skytwin/llm-client', async () => {
+  const actual = await vi.importActual<typeof import('@skytwin/llm-client')>(
+    '@skytwin/llm-client',
+  );
+  return {
+    ...actual,
+    LlmClient: vi.fn().mockImplementation(() => ({})),
+  };
+});
+
+vi.mock('../middleware/require-ownership.js', () => ({
+  bindUserIdParamOwnership: vi.fn(),
+}));
+
+import { createLifebooksRouter } from '../routes/lifebooks.js';
+
+const USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/lifebooks', createLifebooksRouter());
+  return app;
+}
+
+async function request(
+  app: Express,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close();
+        reject(new Error('Could not determine port'));
+        return;
+      }
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      })
+        .then(async (res) => {
+          const json = await res.json().catch(() => null);
+          server.close();
+          resolve({ status: res.status, body: json });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+function fakeLifebook(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'lb-1',
+    user_id: USER_ID,
+    domain_name: 'Health',
+    importance: 'core' as const,
+    sample_signals: ['Appointment on 2026-06-01', 'Refill prescription'],
+    suggested_capabilities: ['google-calendar-mcp'],
+    wing_id: 'wing-1',
+    detected_at: new Date(),
+    last_seen_at: new Date(),
+    hidden_at: null,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PATCH /api/lifebooks/:userId/:domainName/facts/:index — #319', () => {
+  it('edits the fact and records a user-corrected provenance node', async () => {
+    mockFindByDomain.mockResolvedValue(fakeLifebook());
+    mockEditSampleSignal.mockResolvedValue(
+      fakeLifebook({ sample_signals: ['Appointment on 2026-06-08', 'Refill prescription'] }),
+    );
+    mockWriteNode.mockResolvedValue({ id: 'node-1' });
+
+    const res = await request(
+      buildApp(),
+      'PATCH',
+      `/api/lifebooks/${USER_ID}/Health/facts/0`,
+      { text: 'Appointment on 2026-06-08' },
+    );
+
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      lifebook: { sampleSignals: string[] };
+      correction: {
+        factIndex: number;
+        previousText: string;
+        correctedText: string;
+        provenanceNodeId: string | null;
+      };
+    };
+    expect(body.lifebook.sampleSignals[0]).toBe('Appointment on 2026-06-08');
+    expect(body.correction.factIndex).toBe(0);
+    expect(body.correction.previousText).toBe('Appointment on 2026-06-01');
+    expect(body.correction.correctedText).toBe('Appointment on 2026-06-08');
+    expect(body.correction.provenanceNodeId).toBe('node-1');
+
+    // Provenance is recorded as explicitly user-corrected — never inferred.
+    expect(mockWriteNode).toHaveBeenCalledTimes(1);
+    const nodeArg = mockWriteNode.mock.calls[0]![0];
+    expect(nodeArg.nodeType).toBe('feedback');
+    expect(nodeArg.refTable).toBe('lifebooks');
+    expect(nodeArg.refId).toBe('lb-1');
+    expect(nodeArg.wingId).toBe('wing-1');
+    expect(nodeArg.payload.kind).toBe('fact_correction');
+    expect(nodeArg.payload.userCorrected).toBe(true);
+    expect(nodeArg.payload.factIndex).toBe(0);
+    expect(nodeArg.payload.previousText).toBe('Appointment on 2026-06-01');
+    expect(nodeArg.payload.correctedText).toBe('Appointment on 2026-06-08');
+  });
+
+  it('returns 404 when the lifebook does not exist (no edit attempted)', async () => {
+    mockFindByDomain.mockResolvedValue(null);
+    const res = await request(
+      buildApp(),
+      'PATCH',
+      `/api/lifebooks/${USER_ID}/NoSuchDomain/facts/0`,
+      { text: 'whatever' },
+    );
+    expect(res.status).toBe(404);
+    expect(mockEditSampleSignal).not.toHaveBeenCalled();
+    expect(mockWriteNode).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the index is out of range (lifebook exists, edit returns null)', async () => {
+    mockFindByDomain.mockResolvedValue(fakeLifebook());
+    mockEditSampleSignal.mockResolvedValue(null);
+    const res = await request(
+      buildApp(),
+      'PATCH',
+      `/api/lifebooks/${USER_ID}/Health/facts/99`,
+      { text: 'whatever' },
+    );
+    expect(res.status).toBe(404);
+    const body = res.body as { error: string };
+    expect(body.error).toContain('index 99');
+    expect(mockWriteNode).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on a non-integer index', async () => {
+    const res = await request(
+      buildApp(),
+      'PATCH',
+      `/api/lifebooks/${USER_ID}/Health/facts/3abc`,
+      { text: 'whatever' },
+    );
+    expect(res.status).toBe(400);
+    expect(mockFindByDomain).not.toHaveBeenCalled();
+    expect(mockEditSampleSignal).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on blank text', async () => {
+    const res = await request(
+      buildApp(),
+      'PATCH',
+      `/api/lifebooks/${USER_ID}/Health/facts/0`,
+      { text: '   ' },
+    );
+    expect(res.status).toBe(400);
+    expect(mockEditSampleSignal).not.toHaveBeenCalled();
+  });
+
+  it('edit still succeeds when provenance write fails (fail-soft audit trail)', async () => {
+    mockFindByDomain.mockResolvedValue(fakeLifebook());
+    mockEditSampleSignal.mockResolvedValue(
+      fakeLifebook({ sample_signals: ['Corrected', 'Refill prescription'] }),
+    );
+    mockWriteNode.mockRejectedValue(new Error('provenance table locked'));
+
+    const res = await request(
+      buildApp(),
+      'PATCH',
+      `/api/lifebooks/${USER_ID}/Health/facts/0`,
+      { text: 'Corrected' },
+    );
+
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      lifebook: { sampleSignals: string[] };
+      correction: { provenanceNodeId: string | null };
+    };
+    expect(body.lifebook.sampleSignals[0]).toBe('Corrected');
+    // The fact edit stands; the audit node id is null because the write failed.
+    expect(body.correction.provenanceNodeId).toBeNull();
+  });
+
+  it('trims and caps the corrected text before persisting', async () => {
+    mockFindByDomain.mockResolvedValue(fakeLifebook());
+    mockEditSampleSignal.mockResolvedValue(fakeLifebook());
+    mockWriteNode.mockResolvedValue({ id: 'node-2' });
+
+    const longText = `  ${'x'.repeat(5000)}  `;
+    await request(
+      buildApp(),
+      'PATCH',
+      `/api/lifebooks/${USER_ID}/Health/facts/1`,
+      { text: longText },
+    );
+
+    const editArgs = mockEditSampleSignal.mock.calls[0]!;
+    // userId, domainName, index, correctedText
+    expect(editArgs[2]).toBe(1);
+    expect(editArgs[3]).toHaveLength(2000); // trimmed then capped at 2000
+    expect(editArgs[3].startsWith('x')).toBe(true);
+  });
+});

--- a/apps/api/src/routes/lifebooks.ts
+++ b/apps/api/src/routes/lifebooks.ts
@@ -3,6 +3,7 @@ import {
   aiProviderRepository,
   lifebookRepository,
   mempalaceRepository,
+  provenanceRepository,
 } from '@skytwin/db';
 import type { LifebookImportance } from '@skytwin/db';
 import { LlmClient } from '@skytwin/llm-client';
@@ -145,6 +146,7 @@ const GENERIC_LAYOUT = {
  *   GET    /api/lifebooks/:userId/all                          — list all (including hidden)
  *   GET    /api/lifebooks/:userId/:domainName                  — single lifebook + wing summary
  *   GET    /api/lifebooks/:userId/:domainName/layout           — adaptive layout (#319)
+ *   PATCH  /api/lifebooks/:userId/:domainName/facts/:index     — inline fact-edit + correction (#319)
  *   POST   /api/lifebooks/:userId/:domainName/hide             — hide from dashboards
  *   POST   /api/lifebooks/:userId/:domainName/unhide           — restore visibility
  *   POST   /api/lifebooks/:userId/:domainName/importance       — set override (#321)
@@ -364,6 +366,141 @@ export function createLifebooksRouter(): Router {
         wingId: updated.wing_id,
       });
       res.json({ lifebook: rowToJson(updated) });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  /**
+   * #319: PATCH /:userId/:domainName/facts/:index — inline fact-edit.
+   *
+   * The twin extracted a fact that's wrong (a Health appointment date, a
+   * misread recruiter name) and the user fixed it inline on the detail
+   * page. We replace `sample_signals[index]` with the corrected text AND
+   * write a provenance `feedback` node so the correction is recorded as
+   * user-authored — the extractor can later down-weight whatever it
+   * extracted there, and the provenance graph shows the human in the loop.
+   *
+   * Body: { text: string }
+   *
+   * Status codes:
+   *   - 400 — missing params, missing/blank `text`, or a non-integer /
+   *     negative `index`.
+   *   - 404 — the lifebook doesn't exist OR the index is out of range
+   *     for the current `sample_signals` array (the repo update is
+   *     index-bounds-checked in SQL and returns null in both cases; we
+   *     re-fetch to disambiguate the 404 message).
+   *   - 200 — `{ lifebook, correction }` where `correction` echoes the
+   *     before/after and the provenance node id.
+   *
+   * This is a content mutation, not an action the twin executes, so it
+   * does NOT flow through the policy engine — there's no autonomous
+   * action, no spend, and no external side effect. It's the user
+   * correcting the twin's reading of their own memory. Provenance is
+   * still recorded (the feedback node) so the correction is auditable.
+   */
+  router.patch('/:userId/:domainName/facts/:index', async (req, res, next) => {
+    try {
+      const { userId, domainName, index } = req.params;
+      if (!userId || !domainName || index === undefined) {
+        res.status(400).json({ error: 'Missing userId, domainName, or index' });
+        return;
+      }
+      // `index` arrives as a string path segment — accept only a
+      // non-negative integer. parseInt would silently accept '3abc'
+      // → 3; use a strict integer regex first.
+      if (!/^\d+$/.test(index)) {
+        res.status(400).json({ error: 'index must be a non-negative integer' });
+        return;
+      }
+      const factIndex = Number.parseInt(index, 10);
+      if (!Number.isSafeInteger(factIndex)) {
+        res.status(400).json({ error: 'index out of range' });
+        return;
+      }
+      const body = req.body as { text?: unknown } | undefined;
+      if (typeof body?.text !== 'string' || body.text.trim().length === 0) {
+        res.status(400).json({ error: 'text must be a non-empty string' });
+        return;
+      }
+      // Cap the corrected fact length so a runaway client can't write a
+      // multi-MB string into the JSONB array.
+      const correctedText = body.text.trim().slice(0, 2000);
+
+      // Decode the path segment once (every sibling route does this): the
+      // frontend encodeURIComponent's the domain, so multi-word domains like
+      // "Aging Parents" arrive as "Aging%20Parents". Passing the raw segment
+      // to findByDomain/editSampleSignal would never match → silent 404.
+      const decodedDomain = decodeURIComponent(domainName);
+
+      // Snapshot the pre-edit value so the provenance node + response
+      // can echo the before/after. A missing lifebook → 404.
+      const before = await lifebookRepository.findByDomain(userId, decodedDomain);
+      if (!before) {
+        res.status(404).json({ error: 'Lifebook not found' });
+        return;
+      }
+      const previousText =
+        Array.isArray(before.sample_signals) && factIndex < before.sample_signals.length
+          ? before.sample_signals[factIndex]
+          : undefined;
+
+      const updated = await lifebookRepository.editSampleSignal(
+        userId,
+        decodedDomain,
+        factIndex,
+        correctedText,
+      );
+      if (!updated) {
+        // Lifebook exists (we fetched it above) but the index was out
+        // of range — the SQL bounds-check returned no row.
+        res.status(404).json({
+          error: `No extracted fact at index ${factIndex} for this Lifebook`,
+        });
+        return;
+      }
+
+      // Record the correction as a user-authored provenance node. This
+      // is best-effort: if provenance write fails, the fact edit still
+      // stands (the correction is the user's intent; losing the audit
+      // trail is the lesser harm). Source provenance is explicit
+      // `userCorrected: true` — never inferred from absence.
+      let correctionNodeId: string | null = null;
+      try {
+        const node = await provenanceRepository.writeNode({
+          userId,
+          nodeType: 'feedback',
+          refTable: 'lifebooks',
+          refId: updated.id,
+          wingId: updated.wing_id,
+          payload: {
+            kind: 'fact_correction',
+            domainName: updated.domain_name,
+            factIndex,
+            previousText: previousText ?? null,
+            correctedText,
+            userCorrected: true,
+          },
+        });
+        correctionNodeId = node.id;
+      } catch (err) {
+        log.warn('failed to write fact-correction provenance node', {
+          userId,
+          domainName,
+          factIndex,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      res.json({
+        lifebook: rowToJson(updated),
+        correction: {
+          factIndex,
+          previousText: previousText ?? null,
+          correctedText,
+          provenanceNodeId: correctionNodeId,
+        },
+      });
     } catch (err) {
       next(err);
     }

--- a/apps/web/public/js/api-client.js
+++ b/apps/web/public/js/api-client.js
@@ -1001,6 +1001,23 @@ export function fetchLifebookLayout(userId, domainName) {
   );
 }
 
+/**
+ * #319: inline fact-edit. Correct an extracted fact at `index` in the
+ * Lifebook's `sample_signals`. Records a user-authored provenance
+ * correction node server-side. Returns `{ lifebook, correction }`.
+ */
+export function editLifebookFact(userId, domainName, index, text) {
+  return fetchJSON(
+    `${API}/lifebooks/${encodeURIComponent(userId)}/${encodeURIComponent(
+      domainName,
+    )}/facts/${encodeURIComponent(index)}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ text }),
+    },
+  );
+}
+
 export function hideLifebook(userId, domainName) {
   return fetchJSON(
     `${API}/lifebooks/${encodeURIComponent(userId)}/${encodeURIComponent(domainName)}/hide`,

--- a/apps/web/public/js/pages/lifebook.js
+++ b/apps/web/public/js/pages/lifebook.js
@@ -5,6 +5,7 @@ import {
   hideLifebook,
   setLifebookImportance,
   clearLifebookImportance,
+  editLifebookFact,
   escapeHtml,
 } from '../api-client.js';
 import { showSavedToast, showErrorToast } from '../toast.js';
@@ -356,10 +357,7 @@ function renderLayoutSection(section, lb, domainName) {
         'Per-Lifebook upcoming-events view lands with the calendar-filter slice.',
       );
     case 'inline_edit':
-      return emptyCard(
-        title,
-        'Inline fact-edit is the follow-up to this PR. The layout prompt is forward-compatible with it.',
-      );
+      return renderInlineEditCard(title, lb, domainName);
     default:
       // Forward-compatible default. Surfaces unknown types loudly so
       // they're visible to the next developer rather than silently
@@ -369,6 +367,52 @@ function renderLayoutSection(section, lb, domainName) {
         `Unsupported section type <code>${escapeHtml(String(section?.type ?? 'unknown'))}</code> — frontend needs an update.`,
       );
   }
+}
+
+/**
+ * #319: inline fact-edit section. Renders each extracted fact
+ * (`sampleSignals`) with an Edit affordance. Clicking Edit reveals an
+ * inline input (toggled by the delegated handler via the `hidden`
+ * attribute — no inline onclick); Save PATCHes the fact and records a
+ * user-authored provenance correction server-side.
+ *
+ * Every row carries `data-fact-index` so the delegated handler knows
+ * which fact to PATCH without closing over per-render state.
+ */
+function renderInlineEditCard(title, lb, domainName) {
+  const signals = Array.isArray(lb.sampleSignals) ? lb.sampleSignals : [];
+  if (signals.length === 0) {
+    return emptyCard(
+      title,
+      `Nothing extracted for ${escapeHtml(domainName)} yet — once the twin reads signals into this Lifebook, you'll be able to correct anything it gets wrong here.`,
+    );
+  }
+  const rows = signals
+    .map((s, i) => {
+      const safe = escapeHtml(s);
+      return `
+        <li data-fact-index="${i}" style="margin-bottom:0.6rem;list-style:none;">
+          <div data-fact-display="${i}" style="display:flex;align-items:flex-start;justify-content:space-between;gap:0.5rem;">
+            <span style="flex:1;">${safe}</span>
+            <button class="btn btn-outline btn-sm" data-action="edit-fact" data-fact-index="${i}">Edit</button>
+          </div>
+          <div data-fact-editor="${i}" hidden style="margin-top:0.4rem;display:flex;gap:0.4rem;align-items:center;">
+            <input type="text" data-fact-input="${i}" value="${safe}" maxlength="2000"
+              style="flex:1;padding:6px 8px;border:1px solid var(--border);border-radius:6px;font-size:0.9rem;" />
+            <button class="btn btn-primary btn-sm" data-action="save-fact" data-fact-index="${i}">Save</button>
+            <button class="btn btn-outline btn-sm" data-action="cancel-fact" data-fact-index="${i}">Cancel</button>
+          </div>
+        </li>
+      `;
+    })
+    .join('');
+  return `
+    <div class="card">
+      <div class="card-header"><span class="card-title">${escapeHtml(title)}</span></div>
+      <div class="card-subtitle">Wrong date, misread name? Fix any extracted fact — your correction is recorded.</div>
+      <ul style="margin:0.6rem 0 0;padding-left:0;">${rows}</ul>
+    </div>
+  `;
 }
 
 function emptyCard(title, htmlBody) {
@@ -444,6 +488,17 @@ function ensureLifebookListener() {
     const target = e.target instanceof Element ? e.target : null;
     if (!target) return;
 
+    // #319 inline fact-edit affordances (edit/save/cancel). Read userId +
+    // domain inside the handler (not closed over) so a dev "Switch user"
+    // doesn't leave stale-id listeners firing under the next user.
+    const factBtn = target.closest(
+      '[data-action="edit-fact"],[data-action="save-fact"],[data-action="cancel-fact"]',
+    );
+    if (factBtn) {
+      await handleFactAction(factBtn);
+      return;
+    }
+
     const hideBtn = target.closest('[data-action="hide-lifebook"]');
     if (hideBtn) {
       const domain = hideBtn.getAttribute('data-domain');
@@ -513,6 +568,59 @@ async function applyImportanceChange(btn, apiCall, successMessage) {
       } catch {
         /* re-render is best-effort; the toast already reported success/failure */
       }
+    }
+  }
+}
+
+/**
+ * #319: dispatch the three inline fact-edit actions. Edit/Cancel only
+ * toggle the row's display vs editor blocks (no network). Save PATCHes
+ * the corrected fact and re-renders the page so the new value + any
+ * server-side normalization (trim/cap) is reflected.
+ */
+async function handleFactAction(btn) {
+  const action = btn.getAttribute('data-action');
+  const index = btn.getAttribute('data-fact-index');
+  if (index === null) return;
+  const li = btn.closest('[data-fact-index]');
+  if (!li) return;
+  const display = li.querySelector(`[data-fact-display="${index}"]`);
+  const editor = li.querySelector(`[data-fact-editor="${index}"]`);
+  const input = li.querySelector(`[data-fact-input="${index}"]`);
+
+  if (action === 'edit-fact') {
+    if (display) display.setAttribute('hidden', '');
+    if (editor) editor.removeAttribute('hidden');
+    if (input instanceof HTMLInputElement) input.focus();
+    return;
+  }
+  if (action === 'cancel-fact') {
+    if (editor) editor.setAttribute('hidden', '');
+    if (display) display.removeAttribute('hidden');
+    return;
+  }
+  if (action === 'save-fact') {
+    if (!(input instanceof HTMLInputElement)) return;
+    const text = input.value.trim();
+    if (text.length === 0) {
+      showErrorToast('Fact text cannot be empty.');
+      return;
+    }
+    const domain = parseLifebookRoute();
+    const userId = getCurrentUserId();
+    if (!domain || !userId) {
+      showErrorToast('Could not determine which Lifebook to edit.');
+      return;
+    }
+    try {
+      await editLifebookFact(userId, domain, index, text);
+      showSavedToast('Fact corrected');
+      // Re-render so the corrected value shows everywhere it appears
+      // (signals, timeline, inline-edit) from a single source of truth.
+      const container = document.getElementById('page-content');
+      if (container) await renderLifebook(container);
+    } catch (err) {
+      showErrorToast(`Couldn't save: ${err?.message ?? 'unknown error'}`);
     }
   }
 }

--- a/packages/db/src/__tests__/lifebook-repository.test.ts
+++ b/packages/db/src/__tests__/lifebook-repository.test.ts
@@ -117,6 +117,37 @@ describe('lifebookRepository.setImportanceOverride — #321', () => {
   });
 });
 
+describe('lifebookRepository.editSampleSignal — #319 inline fact-edit', () => {
+  it('updates the targeted array element via jsonb_set with an index-bounds guard', async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ id: 'lb-1', sample_signals: ['fixed', 'b'] }],
+      rowCount: 1,
+    });
+    const result = await lifebookRepository.editSampleSignal('u-1', 'Health', 0, 'fixed');
+    expect(result).toBeTruthy();
+    const [sql, params] = mockQuery.mock.calls[0]!;
+    // jsonb_set targets ARRAY[index] and replaces it with the corrected
+    // text. The WHERE clause bounds-checks the index IN SQL so a stale
+    // out-of-range index updates nothing (race-safe vs the extractor).
+    expect(sql).toContain('UPDATE lifebooks');
+    expect(sql).toContain('jsonb_set');
+    expect(sql).toContain('ARRAY[$3::int::string]');
+    expect(sql).toContain('to_jsonb($4::string)');
+    expect(sql).toContain('$3::int >= 0');
+    expect(sql).toContain('$3::int < jsonb_array_length(sample_signals)');
+    expect(params).toEqual(['u-1', 'Health', 0, 'fixed']);
+  });
+
+  it('returns null when no row matches — covers both missing lifebook AND out-of-range index', async () => {
+    // The SQL bounds-check means an out-of-range index produces zero
+    // updated rows, indistinguishable here from a missing lifebook; the
+    // route layer disambiguates via a prior findByDomain.
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    const result = await lifebookRepository.editSampleSignal('u-1', 'Health', 99, 'x');
+    expect(result).toBeNull();
+  });
+});
+
 describe('lifebookRepository.clearImportanceOverride — #321', () => {
   it('strips the importanceOverride key from metadata via JSONB minus operator', async () => {
     mockQuery.mockResolvedValue({

--- a/packages/db/src/repositories/lifebook-repository.ts
+++ b/packages/db/src/repositories/lifebook-repository.ts
@@ -334,6 +334,49 @@ export const lifebookRepository = {
   },
 
   /**
+   * #319: inline fact-edit. Replace the extracted `sample_signals[index]`
+   * fact with a user-supplied correction. Used by the per-Lifebook detail
+   * page's inline edit affordance — the user spotted a wrong extracted
+   * fact (a Health appointment date, a misread recruiter name) and fixed
+   * it in place.
+   *
+   * The write is index-targeted and bounds-checked IN SQL so it stays
+   * race-free against a concurrent extractor upsert that may have just
+   * reordered/replaced the array: `jsonb_set` only touches the targeted
+   * element, and the `jsonb_array_length` guard in the WHERE clause means
+   * an out-of-range index updates nothing (the caller distinguishes
+   * "lifebook missing" from "index out of range" via `findByDomain`).
+   *
+   * Returns the updated row, or null when the (user, domain) doesn't
+   * exist OR the index is out of range for the current array. The
+   * route layer is responsible for writing the provenance correction
+   * node — this method only mutates the fact text.
+   */
+  async editSampleSignal(
+    userId: string,
+    domainName: string,
+    index: number,
+    correctedText: string,
+  ): Promise<LifebookRow | null> {
+    const result = await query<LifebookRow>(
+      `UPDATE lifebooks
+       SET sample_signals = jsonb_set(
+             sample_signals,
+             ARRAY[$3::int::string],
+             to_jsonb($4::string),
+             false
+           )
+       WHERE user_id = $1
+         AND domain_name = $2
+         AND $3::int >= 0
+         AND $3::int < jsonb_array_length(sample_signals)
+       RETURNING *`,
+      [userId, domainName, index, correctedText],
+    );
+    return result.rows[0] ?? null;
+  },
+
+  /**
    * #321: clear an existing override. The `importance` column stays at
    * its current value (caller can manually set it back if they want
    * the extractor to recompute on the next run; otherwise the next


### PR DESCRIPTION
## What changed

Wires the per-Lifebook detail page's `inline_edit` section — previously a `'Inline fact-edit is the follow-up to this PR'` placeholder — to a real inline-edit affordance, and adds the backend to persist corrections with provenance. This is the inline-fact-edit slice the #319 reopen comment broke out as its own follow-up.

### Backend (`apps/api/src/routes/lifebooks.ts`, `packages/db`)
- **New `PATCH /api/lifebooks/:userId/:domainName/facts/:index`.** Replaces the targeted extracted fact (`sample_signals[index]`) with the user's correction and records the correction as a **user-authored provenance node** — `provenanceRepository.writeNode({ nodeType: 'feedback', refTable: 'lifebooks', payload: { kind: 'fact_correction', userCorrected: true, factIndex, previousText, correctedText } })`. The provenance flag is set **explicitly**, never inferred from absence (safety invariant #8).
- **New `lifebookRepository.editSampleSignal()`** does the write with an index-bounds guard **in SQL** (`jsonb_set` targets only `ARRAY[index]`; the `WHERE … AND $index < jsonb_array_length(sample_signals)` guard means a stale out-of-range index updates nothing) so it's race-safe against a concurrent extractor upsert.
- **Validation:** 400 on non-integer/negative index or blank text (corrected text trimmed + capped at 2000 chars); 404 disambiguates "lifebook missing" from "index out of range".
- **Policy engine:** intentionally NOT routed through it — this is the user correcting the twin's reading of their *own* memory; no autonomous action, spend, or external side effect. The provenance record is still written so the edit is auditable. (Documented inline.)
- **Fail-soft:** if the provenance write throws, the fact edit still stands and `correction.provenanceNodeId` is `null`.

### Frontend (`apps/web/public/js/pages/lifebook.js`, `api-client.js`)
- `renderInlineEditCard` renders each fact with Edit / Save / Cancel using **`data-action` attributes** (no inline `onclick`) handled by the existing **hash-gated singleton click delegator** (`_lifebookListenerWired`). `userId` + domain are read **inside** the handler, not closed over, so a dev "Switch user" doesn't leave stale-id listeners. Save PATCHes then re-renders the page from a single source of truth.
- New `editLifebookFact()` api-client helper.
- Domain-specific empty state when no facts are extracted yet.

## Acceptance criteria

This PR satisfies the **"Inline edit on extracted facts, with provenance recorded"** acceptance criterion from #319 (the slice the reopen comment carved out). The adaptive-layout backend/renderer, the `lifebook-layout` prompt + eval fixtures, the deterministic fallback, and the domain-specific empty state for the layout shipped earlier (#333); the remaining placeholder sections (entities/decisions/metrics/schedule) are separate follow-up slices per the reopen comment.

## Tests added

9 new tests, all green locally (`@skytwin/db` + `@skytwin/api` type-check clean):
- `packages/db/src/__tests__/lifebook-repository.test.ts` (+2): `editSampleSignal` SQL shape + bounds guard; null on no-match.
- `apps/api/src/__tests__/lifebook-fact-edit-route.test.ts` (+7): happy path (edit + user-corrected provenance node), 404 missing lifebook, 404 out-of-range index, 400 non-integer index, 400 blank text, fail-soft provenance, trim/cap.

Addresses #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)