### PR TITLE
feat(lifebooks): importance promote/demote ceremony UI + override episode recording (#321)

### DIFF
--- a/apps/api/src/__tests__/lifebook-importance-routes.test.ts
+++ b/apps/api/src/__tests__/lifebook-importance-routes.test.ts
@@ -9,9 +9,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import express from 'express';
 import type { Express } from 'express';
 
-const { mockSetImportanceOverride, mockClearImportanceOverride } = vi.hoisted(() => ({
+const {
+  mockSetImportanceOverride,
+  mockClearImportanceOverride,
+  mockCreateEpisode,
+  mockRecordEpisode,
+  mockGetMemoryPortForUser,
+} = vi.hoisted(() => ({
   mockSetImportanceOverride: vi.fn(),
   mockClearImportanceOverride: vi.fn(),
+  mockCreateEpisode: vi.fn(),
+  mockRecordEpisode: vi.fn(),
+  mockGetMemoryPortForUser: vi.fn(),
 }));
 
 vi.mock('@skytwin/db', () => ({
@@ -27,7 +36,12 @@ vi.mock('@skytwin/db', () => ({
   mempalaceRepository: {
     getRooms: vi.fn(),
     getDrawers: vi.fn(),
+    createEpisode: mockCreateEpisode,
   },
+}));
+
+vi.mock('../memory-setup.js', () => ({
+  getMemoryPortForUser: mockGetMemoryPortForUser,
 }));
 
 vi.mock('../middleware/require-ownership.js', () => ({
@@ -96,6 +110,13 @@ function fakeLifebookRow(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default happy-path episode recording so set/clear routes don't 500
+  // on the best-effort recorder. Individual tests override as needed.
+  mockCreateEpisode.mockResolvedValue({ id: 'episode-1' });
+  mockRecordEpisode.mockResolvedValue(undefined);
+  mockGetMemoryPortForUser.mockResolvedValue({
+    port: { recordEpisode: mockRecordEpisode },
+  });
 });
 
 describe('POST /api/lifebooks/:userId/:domainName/importance — #321', () => {
@@ -189,6 +210,66 @@ describe('POST /api/lifebooks/:userId/:domainName/importance — #321', () => {
       { value: 'core' },
     );
     expect(res.status).toBe(404);
+    // No row → no episode recorded.
+    expect(mockCreateEpisode).not.toHaveBeenCalled();
+  });
+
+  it('records the override as an episode in memory (#321 AC)', async () => {
+    mockSetImportanceOverride.mockResolvedValue(fakeLifebookRow({ wing_id: 'wing-9' }));
+    const res = await request(
+      buildApp(),
+      'POST',
+      `/api/lifebooks/${USER_ID}/Health/importance`,
+      { value: 'core', decayDays: 90 },
+    );
+    expect(res.status).toBe(200);
+    // Legacy episodic_memories write — domain-tagged, edit feedback.
+    expect(mockCreateEpisode).toHaveBeenCalledTimes(1);
+    const ep = mockCreateEpisode.mock.calls[0][0];
+    expect(ep.userId).toBe(USER_ID);
+    expect(ep.domain).toBe('Health');
+    expect(ep.situationType).toBe('lifebook_importance_override');
+    expect(ep.feedbackType).toBe('edit');
+    expect(ep.situationSummary).toContain('Core');
+    // Pluggable memory port also gets the episode.
+    expect(mockRecordEpisode).toHaveBeenCalledTimes(1);
+    const portEp = mockRecordEpisode.mock.calls[0][0];
+    expect(portEp.id).toBe('episode-1');
+    expect(portEp.wing).toBe('wing-9');
+    expect(portEp.metadata).toMatchObject({
+      kind: 'lifebook_importance_override',
+      action: 'set',
+      value: 'core',
+      decayDays: 90,
+    });
+  });
+
+  it('still returns 200 when episode recording throws (best-effort, never gates the write)', async () => {
+    mockSetImportanceOverride.mockResolvedValue(fakeLifebookRow());
+    mockCreateEpisode.mockRejectedValue(new Error('memory layer down'));
+    const res = await request(
+      buildApp(),
+      'POST',
+      `/api/lifebooks/${USER_ID}/Health/importance`,
+      { value: 'secondary' },
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as { lifebook: { domainName: string } };
+    expect(body.lifebook.domainName).toBe('Health');
+  });
+
+  it('still returns 200 when the memory-port recordEpisode throws (legacy table write already succeeded)', async () => {
+    mockSetImportanceOverride.mockResolvedValue(fakeLifebookRow());
+    mockRecordEpisode.mockRejectedValue(new Error('port unavailable'));
+    const res = await request(
+      buildApp(),
+      'POST',
+      `/api/lifebooks/${USER_ID}/Health/importance`,
+      { value: 'emerging' },
+    );
+    expect(res.status).toBe(200);
+    // Legacy write still attempted even though the port failed.
+    expect(mockCreateEpisode).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -291,5 +372,25 @@ describe('DELETE /api/lifebooks/:userId/:domainName/importance — #321', () => 
       `/api/lifebooks/${USER_ID}/NoSuchDomain/importance`,
     );
     expect(res.status).toBe(404);
+    expect(mockCreateEpisode).not.toHaveBeenCalled();
+  });
+
+  it('records a "cleared" episode so the twin knows the user reverted (#321 AC)', async () => {
+    mockClearImportanceOverride.mockResolvedValue(fakeLifebookRow({ metadata: {} }));
+    const res = await request(
+      buildApp(),
+      'DELETE',
+      `/api/lifebooks/${USER_ID}/Health/importance`,
+    );
+    expect(res.status).toBe(200);
+    expect(mockCreateEpisode).toHaveBeenCalledTimes(1);
+    const ep = mockCreateEpisode.mock.calls[0][0];
+    expect(ep.actionTaken).toBe('clear_importance_override');
+    expect(ep.situationSummary).toContain('cleared');
+    expect(mockRecordEpisode).toHaveBeenCalledTimes(1);
+    expect(mockRecordEpisode.mock.calls[0][0].metadata).toMatchObject({
+      action: 'clear',
+      value: null,
+    });
   });
 });

--- a/apps/api/src/routes/lifebooks.ts
+++ b/apps/api/src/routes/lifebooks.ts
@@ -4,16 +4,107 @@ import {
   lifebookRepository,
   mempalaceRepository,
 } from '@skytwin/db';
+import type { LifebookImportance } from '@skytwin/db';
 import { LlmClient } from '@skytwin/llm-client';
 import type { ProviderEntry } from '@skytwin/llm-client';
 import type { AIProviderName } from '@skytwin/shared-types';
-import type { LifebookImportance } from '@skytwin/db';
 import { runPrompt } from '@skytwin/policy-prompts';
 import { createLogger } from '@skytwin/core';
+import { getMemoryPortForUser } from '../memory-setup.js';
 import { bindUserIdParamOwnership } from '../middleware/require-ownership.js';
 import { bindUserIdParamValidator } from '../middleware/validate-uuid.js';
 
 const log = createLogger('api:lifebooks');
+
+const IMPORTANCE_LABEL: Record<LifebookImportance, string> = {
+  core: 'Core',
+  secondary: 'Secondary',
+  emerging: 'Emerging',
+};
+
+/**
+ * #321 AC: "Override is recorded as an episode in memory so the twin can
+ * reference it." Records a promote/demote (or a clear) as an episodic
+ * memory so a later decision/extraction can pull back "the user said
+ * Aging Parents is Core as of 2026-05-17" via the episodic-memory
+ * retrieval path.
+ *
+ * Best-effort by design — mirrors the approval-episode recorder in
+ * `approvals.ts`. A memory-layer hiccup must never fail the user-facing
+ * importance write that already committed. Writes to BOTH the legacy
+ * `episodic_memories` table (so the decision-engine's episodic boost
+ * sees it) AND the pluggable memory port (so the gbrain semantic index
+ * covers it), each swallowing its own error.
+ *
+ * `action` is the verb the user took. `previous` is the importance the
+ * Lifebook had BEFORE the change (read off the returned row's
+ * pre-change value by the caller), so the summary reads naturally and a
+ * promote vs demote can be told apart on retrieval.
+ */
+async function recordImportanceOverrideEpisode(params: {
+  userId: string;
+  domainName: string;
+  action: 'set' | 'clear';
+  value: LifebookImportance | null;
+  decayDays?: number;
+  wingId: string | null;
+}): Promise<void> {
+  const { userId, domainName, action, value, decayDays, wingId } = params;
+  const summary =
+    action === 'clear'
+      ? `User cleared the manual importance override for the "${domainName}" Lifebook — the weekly extractor will recompute its importance on the next run.`
+      : `User set the "${domainName}" Lifebook importance to ${IMPORTANCE_LABEL[value as LifebookImportance]}${
+          decayDays === 0 ? ' (no auto-decay)' : decayDays ? ` (decays after ${decayDays} days)` : ''
+        }.`;
+
+  try {
+    const episodeRow = await mempalaceRepository.createEpisode({
+      userId,
+      situationSummary: summary,
+      domain: domainName,
+      situationType: 'lifebook_importance_override',
+      contextSnapshot: { activePreferences: [], activePatterns: [] },
+      actionTaken: action === 'clear' ? 'clear_importance_override' : 'set_importance_override',
+      feedbackType: 'edit',
+      // A manual override is a strong, deliberate signal. High utility so
+      // the episodic boost weights it heavily when a similar situation
+      // (extraction of this same domain) recurs.
+      utilityScore: 0.9,
+    });
+
+    try {
+      const resolved = await getMemoryPortForUser(userId);
+      await resolved.port.recordEpisode({
+        id: episodeRow.id,
+        userId,
+        wing: wingId ?? domainName,
+        summary,
+        startedAt: new Date(),
+        endedAt: new Date(),
+        metadata: {
+          kind: 'lifebook_importance_override',
+          domainName,
+          action,
+          value,
+          ...(decayDays !== undefined ? { decayDays } : {}),
+        },
+      });
+    } catch (portErr) {
+      log.warn('memory port recordEpisode failed for importance override (legacy table updated regardless)', {
+        userId,
+        domainName,
+        error: portErr instanceof Error ? portErr.message : String(portErr),
+      });
+    }
+  } catch (err) {
+    log.warn('failed to record importance-override episode', {
+      userId,
+      domainName,
+      action,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
 
 /**
  * #319 generic fallback layout — the shape returned when the LLM is
@@ -249,9 +340,10 @@ export function createLifebooksRouter(): Router {
         typeof body.decayDays === 'number' && Number.isFinite(body.decayDays) && body.decayDays >= 0
           ? Math.floor(body.decayDays)
           : 90;
+      const decodedDomain = decodeURIComponent(domainName);
       const updated = await lifebookRepository.setImportanceOverride(
         userId,
-        decodeURIComponent(domainName),
+        decodedDomain,
         body.value,
         decayDays,
       );
@@ -259,6 +351,18 @@ export function createLifebooksRouter(): Router {
         res.status(404).json({ error: 'Lifebook not found' });
         return;
       }
+      // #321 AC: record the override as an episode so the twin can
+      // reference it. Best-effort — already-awaited so a slow memory
+      // layer doesn't leave the response hanging open, but a failure is
+      // swallowed inside the recorder and never gates the 200.
+      await recordImportanceOverrideEpisode({
+        userId,
+        domainName: updated.domain_name,
+        action: 'set',
+        value: body.value,
+        decayDays,
+        wingId: updated.wing_id,
+      });
       res.json({ lifebook: rowToJson(updated) });
     } catch (err) {
       next(err);
@@ -445,6 +549,15 @@ export function createLifebooksRouter(): Router {
         res.status(404).json({ error: 'Lifebook not found' });
         return;
       }
+      // #321 AC: record the clear as an episode too — the twin should
+      // know the user reverted to letting the extractor decide.
+      await recordImportanceOverrideEpisode({
+        userId,
+        domainName: updated.domain_name,
+        action: 'clear',
+        value: null,
+        wingId: updated.wing_id,
+      });
       res.json({ lifebook: rowToJson(updated) });
     } catch (err) {
       next(err);

--- a/apps/web/public/js/api-client.js
+++ b/apps/web/public/js/api-client.js
@@ -1016,6 +1016,37 @@ export function unhideLifebook(userId, domainName) {
 }
 
 /**
+ * #321: set a user importance override for a Lifebook (promote/demote).
+ * `value` is one of 'core' | 'secondary' | 'emerging'. Optional
+ * `decayDays` controls how long the override wins over the extractor's
+ * automatic pick (server default 90; pass 0 for "never auto-decay").
+ * Returns `{ lifebook }` with `importanceOverride` populated so the
+ * caller can re-render the "set by you" state. The server also records
+ * the override as an episode in memory (best-effort) so the twin
+ * remembers it.
+ */
+export function setLifebookImportance(userId, domainName, value, decayDays) {
+  const body = { value };
+  if (typeof decayDays === 'number') body.decayDays = decayDays;
+  return fetchJSON(
+    `${API}/lifebooks/${encodeURIComponent(userId)}/${encodeURIComponent(domainName)}/importance`,
+    { method: 'POST', body: JSON.stringify(body) },
+  );
+}
+
+/**
+ * #321: clear a user importance override so the weekly extractor
+ * resumes computing importance for this Lifebook. Idempotent. Returns
+ * `{ lifebook }` with `importanceOverride: null`.
+ */
+export function clearLifebookImportance(userId, domainName) {
+  return fetchJSON(
+    `${API}/lifebooks/${encodeURIComponent(userId)}/${encodeURIComponent(domainName)}/importance`,
+    { method: 'DELETE' },
+  );
+}
+
+/**
  * #193 follow-up: fetch the latest per-Lifebook briefing for one
  * domain. Returns `{ briefing: TwinBriefingRow | null }` — null when
  * no per-domain briefing exists yet (the worker hasn't emitted one,

--- a/apps/web/public/js/pages/lifebook.js
+++ b/apps/web/public/js/pages/lifebook.js
@@ -3,6 +3,8 @@ import {
   fetchLifebookBriefing,
   fetchLifebookLayout,
   hideLifebook,
+  setLifebookImportance,
+  clearLifebookImportance,
   escapeHtml,
 } from '../api-client.js';
 import { showSavedToast, showErrorToast } from '../toast.js';
@@ -20,6 +22,11 @@ import { KEY_USER_ID } from '../storage-keys.js';
  */
 
 let _lifebookListenerWired = false;
+// The most-recently-rendered container, captured so the singleton
+// delegated handler can re-render in place after a mutation (importance
+// change) without the handler closing over a stale container from an
+// earlier render.
+let _lifebookContainer = null;
 
 function getCurrentUserId() {
   return localStorage.getItem(KEY_USER_ID) || '';
@@ -40,23 +47,80 @@ export function parseLifebookRoute() {
   }
 }
 
+const IMPORTANCE_ORDER = ['emerging', 'secondary', 'core'];
+const IMPORTANCE_LABELS = { core: 'Core', secondary: 'Secondary', emerging: 'Emerging' };
+
 function importanceBadge(importance) {
   const colors = {
     core: 'var(--success)',
     secondary: 'var(--text)',
     emerging: 'var(--text-muted)',
   };
-  const label = {
-    core: 'Core',
-    secondary: 'Secondary',
-    emerging: 'Emerging',
-  }[importance] ?? importance;
+  const label = IMPORTANCE_LABELS[importance] ?? importance;
   const color = colors[importance] ?? 'var(--text-muted)';
   return `<span style="display:inline-block;padding:2px 8px;border-radius:10px;font-size:0.75rem;font-weight:600;color:${color};border:1px solid ${color};">${escapeHtml(label)}</span>`;
 }
 
+/**
+ * #321 promote/demote ceremony — the user-facing control for telling
+ * the twin "treat this Lifebook as more / less important than the
+ * weekly extractor decided." Renders three tier buttons (Emerging →
+ * Secondary → Core); the current tier is the disabled/active one, the
+ * others promote or demote. When a manual override is in effect we
+ * surface a "set by you" line + a Clear button that hands importance
+ * back to the extractor.
+ *
+ * No inline handlers — every control is a `data-action` button that the
+ * hash-gated singleton delegator (`ensureLifebookListener`) dispatches.
+ * The domain is carried on `data-domain` and the target tier on
+ * `data-importance` so the handler reads the current user id at click
+ * time (per CLAUDE.md "Frontend Event Handling").
+ */
+export function renderImportanceControl(lb) {
+  const current = lb.importance;
+  const override = lb.importanceOverride; // { value, setAt, decayDays } | null
+  const buttons = IMPORTANCE_ORDER.map((tier) => {
+    const isCurrent = tier === current;
+    const cls = isCurrent ? 'btn btn-primary btn-sm' : 'btn btn-outline btn-sm';
+    const disabledAttr = isCurrent ? ' aria-pressed="true" disabled' : '';
+    return `<button type="button" class="${cls}" data-action="set-importance" data-domain="${escapeHtml(lb.domainName)}" data-importance="${escapeHtml(tier)}"${disabledAttr}>${escapeHtml(IMPORTANCE_LABELS[tier])}</button>`;
+  }).join('');
+
+  const overrideLine = override
+    ? `<div class="card-subtitle" style="margin-top:0.5rem;display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap;">
+         <span style="color:var(--accent, #7C72E8);">Set by you${override.decayDays === 0 ? ' (stays until you clear it)' : ` · resets ${formatOverrideExpiry(override)}`}.</span>
+         <button type="button" class="btn btn-outline btn-sm" data-action="clear-importance" data-domain="${escapeHtml(lb.domainName)}">Let the twin decide</button>
+       </div>`
+    : `<div class="card-subtitle" style="margin-top:0.5rem;">Auto-detected by your weekly review. Promote or demote to tell the twin what matters right now.</div>`;
+
+  return `
+    <div class="card">
+      <div class="card-header"><span class="card-title">How important is this right now?</span></div>
+      <div style="display:flex;gap:0.4rem;flex-wrap:wrap;margin-top:0.5rem;">${buttons}</div>
+      ${overrideLine}
+    </div>
+  `;
+}
+
+/**
+ * Format the date an override decays back to the extractor's pick:
+ * `setAt + decayDays`. Defensive — bad input falls back to a vague
+ * "soon" rather than rendering `Invalid Date`.
+ */
+export function formatOverrideExpiry(override) {
+  try {
+    const setAt = new Date(override.setAt);
+    if (Number.isNaN(setAt.getTime())) return 'soon';
+    const expiry = new Date(setAt.getTime() + override.decayDays * 24 * 60 * 60 * 1000);
+    return expiry.toLocaleDateString();
+  } catch {
+    return 'soon';
+  }
+}
+
 export async function renderLifebook(container, _userIdFromArg) {
   ensureLifebookListener();
+  _lifebookContainer = container;
   const userId = getCurrentUserId();
   const domainName = parseLifebookRoute();
   if (!userId || !domainName) {
@@ -116,6 +180,8 @@ export async function renderLifebook(container, _userIdFromArg) {
         ${renderLayoutSourceHint(layoutSource, layout?.layoutId)}
       </div>
     </div>
+
+    ${renderImportanceControl(lb)}
 
     ${renderLifebookBriefingCard(briefing, lb.domainName)}
 
@@ -371,20 +437,82 @@ function ensureLifebookListener() {
   if (_lifebookListenerWired || typeof document === 'undefined') return;
   _lifebookListenerWired = true;
   document.addEventListener('click', async (e) => {
+    // Hash-gated singleton (per CLAUDE.md): the SPA reuses one
+    // #page-content container across routes, so gate on the hash, not
+    // on DOM containment, and wire exactly once on `document`.
     if ((window.location.hash || '').split('?')[0].indexOf('#/lifebook/') !== 0) return;
     const target = e.target instanceof Element ? e.target : null;
     if (!target) return;
-    const btn = target.closest('[data-action="hide-lifebook"]');
-    if (!btn) return;
-    const domain = btn.getAttribute('data-domain');
-    if (!domain) return;
-    if (!confirm(`Hide ${domain} from dashboards? Your memories stay; only the surface visibility changes.`)) return;
-    try {
-      await hideLifebook(getCurrentUserId(), domain);
-      showSavedToast(`${domain} hidden`);
-      window.location.hash = '#/';
-    } catch (err) {
-      showErrorToast(`Couldn't hide: ${err?.message ?? 'unknown error'}`);
+
+    const hideBtn = target.closest('[data-action="hide-lifebook"]');
+    if (hideBtn) {
+      const domain = hideBtn.getAttribute('data-domain');
+      if (!domain) return;
+      if (!confirm(`Hide ${domain} from dashboards? Your memories stay; only the surface visibility changes.`)) return;
+      try {
+        await hideLifebook(getCurrentUserId(), domain);
+        showSavedToast(`${domain} hidden`);
+        window.location.hash = '#/';
+      } catch (err) {
+        showErrorToast(`Couldn't hide: ${err?.message ?? 'unknown error'}`);
+      }
+      return;
+    }
+
+    // #321 promote/demote.
+    const setBtn = target.closest('[data-action="set-importance"]');
+    if (setBtn) {
+      if (setBtn.hasAttribute('disabled')) return; // current tier — no-op
+      const domain = setBtn.getAttribute('data-domain');
+      const value = setBtn.getAttribute('data-importance');
+      if (!domain || !value) return;
+      await applyImportanceChange(setBtn, () =>
+        setLifebookImportance(getCurrentUserId(), domain, value),
+        `${domain} set to ${IMPORTANCE_LABELS[value] ?? value}`,
+      );
+      return;
+    }
+
+    // #321 clear override — hand importance back to the extractor.
+    const clearBtn = target.closest('[data-action="clear-importance"]');
+    if (clearBtn) {
+      const domain = clearBtn.getAttribute('data-domain');
+      if (!domain) return;
+      await applyImportanceChange(clearBtn, () =>
+        clearLifebookImportance(getCurrentUserId(), domain),
+        `${domain} importance handed back to your twin`,
+      );
+      return;
     }
   });
+}
+
+/**
+ * Shared apply-and-rerender helper for the #321 promote/demote/clear
+ * buttons. Disables the clicked button while the request is in flight
+ * (so a double-click can't fire two overlapping writes), shows a toast,
+ * and re-renders the detail page in place so the badge + "set by you"
+ * line reflect the new state. Errors surface via the toast and the
+ * page is re-rendered to restore the pre-click control state.
+ */
+async function applyImportanceChange(btn, apiCall, successMessage) {
+  const wasDisabled = btn.hasAttribute('disabled');
+  btn.setAttribute('disabled', 'true');
+  try {
+    await apiCall();
+    showSavedToast(successMessage);
+  } catch (err) {
+    showErrorToast(`Couldn't update importance: ${err?.friendlyMessage ?? err?.message ?? 'unknown error'}`);
+  } finally {
+    if (!wasDisabled) btn.removeAttribute('disabled');
+    // Re-render in place so the active tier + override line update.
+    // _lifebookContainer is set on every renderLifebook call.
+    if (_lifebookContainer) {
+      try {
+        await renderLifebook(_lifebookContainer);
+      } catch {
+        /* re-render is best-effort; the toast already reported success/failure */
+      }
+    }
+  }
 }

--- a/apps/web/public/js/pages/lifebook.test.js
+++ b/apps/web/public/js/pages/lifebook.test.js
@@ -1,0 +1,124 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  parseLifebookRoute,
+  renderImportanceControl,
+  formatOverrideExpiry,
+} from './lifebook.js';
+
+/**
+ * #321: unit tests for the Lifebook detail page promote/demote ceremony
+ * controls. These cover the pure render/parse helpers — the parts that
+ * decide which tier button is active, how the "set by you" override line
+ * renders, and the override-expiry formatting (including its fallback on
+ * garbage input). The delegated click handler + network calls are
+ * covered by the API-side route tests in
+ * `apps/api/src/__tests__/lifebook-importance-routes.test.ts`.
+ */
+
+beforeEach(() => {
+  // Reset the hash gate used by parseLifebookRoute.
+  globalThis.window.location.hash = '';
+});
+
+describe('parseLifebookRoute', () => {
+  it('extracts a domain name from a #/lifebook/<domain> hash', () => {
+    globalThis.window.location.hash = '#/lifebook/Aging%20Parents';
+    expect(parseLifebookRoute()).toBe('Aging Parents');
+  });
+
+  it('returns null for a non-lifebook route', () => {
+    globalThis.window.location.hash = '#/dashboard';
+    expect(parseLifebookRoute()).toBeNull();
+  });
+
+  it('strips a query string before matching', () => {
+    globalThis.window.location.hash = '#/lifebook/Health?from=card';
+    expect(parseLifebookRoute()).toBe('Health');
+  });
+});
+
+describe('renderImportanceControl — #321 promote/demote', () => {
+  const baseLb = {
+    domainName: 'Health',
+    importance: 'secondary',
+    importanceOverride: null,
+  };
+
+  it('renders three tier buttons and marks the current tier disabled/pressed', () => {
+    const html = renderImportanceControl(baseLb);
+    // Three set-importance buttons, one per tier.
+    const matches = html.match(/data-action="set-importance"/g) ?? [];
+    expect(matches.length).toBe(3);
+    // Each tier carries its data-importance value.
+    expect(html).toContain('data-importance="core"');
+    expect(html).toContain('data-importance="secondary"');
+    expect(html).toContain('data-importance="emerging"');
+    // The current tier (secondary) is the disabled, pressed, primary one.
+    expect(html).toMatch(
+      /class="btn btn-primary btn-sm" data-action="set-importance" data-domain="Health" data-importance="secondary" aria-pressed="true" disabled/,
+    );
+    // Non-current tiers are outline buttons and NOT disabled.
+    expect(html).toMatch(
+      /class="btn btn-outline btn-sm" data-action="set-importance" data-domain="Health" data-importance="core"(?!.*disabled)/,
+    );
+  });
+
+  it('shows the auto-detected hint and no Clear button when there is no override', () => {
+    const html = renderImportanceControl(baseLb);
+    expect(html).toContain('Auto-detected by your weekly review');
+    expect(html).not.toContain('data-action="clear-importance"');
+  });
+
+  it('shows "Set by you" + a Clear button when an override is in effect', () => {
+    const html = renderImportanceControl({
+      ...baseLb,
+      importance: 'core',
+      importanceOverride: { value: 'core', setAt: '2026-06-01T00:00:00Z', decayDays: 90 },
+    });
+    expect(html).toContain('Set by you');
+    expect(html).toContain('data-action="clear-importance"');
+    expect(html).toContain('data-domain="Health"');
+    // 90-day window → it shows a reset date, not the never-clear copy.
+    expect(html).toContain('resets');
+    expect(html).not.toContain('stays until you clear it');
+  });
+
+  it('describes a decayDays=0 override as sticking until cleared', () => {
+    const html = renderImportanceControl({
+      ...baseLb,
+      importance: 'emerging',
+      importanceOverride: { value: 'emerging', setAt: '2026-06-01T00:00:00Z', decayDays: 0 },
+    });
+    expect(html).toContain('stays until you clear it');
+    expect(html).not.toContain('resets');
+  });
+
+  it('escapes the domain name in the rendered control (no raw injection)', () => {
+    const html = renderImportanceControl({
+      domainName: '<img src=x>',
+      importance: 'core',
+      importanceOverride: null,
+    });
+    expect(html).not.toContain('<img src=x>');
+    expect(html).toContain('&lt;img src=x&gt;');
+  });
+});
+
+describe('formatOverrideExpiry', () => {
+  it('returns setAt + decayDays as a locale date', () => {
+    const out = formatOverrideExpiry({ setAt: '2026-06-01T00:00:00Z', decayDays: 90 });
+    // 2026-06-01 + 90 days ≈ 2026-08-30. Don't pin the exact locale
+    // string; just assert it parsed to a real date in the right year.
+    expect(out).not.toBe('soon');
+    expect(out).toMatch(/2026/);
+  });
+
+  it('falls back to "soon" on an invalid setAt', () => {
+    expect(formatOverrideExpiry({ setAt: 'not-a-date', decayDays: 90 })).toBe('soon');
+  });
+
+  it('falls back to "soon" when the override is missing fields', () => {
+    expect(formatOverrideExpiry({})).toBe('soon');
+  });
+});

--- a/apps/web/test/setup.ts
+++ b/apps/web/test/setup.ts
@@ -1,0 +1,67 @@
+/**
+ * Minimal DOM/browser-global stubs for unit-testing the web dashboard's
+ * browser ESM modules in a Node vitest environment, without adding a
+ * jsdom/happy-dom dependency the rest of the repo doesn't carry.
+ *
+ * Only the surface the pure helpers actually touch is stubbed:
+ *   - `document.createElement(...).textContent`/`.innerHTML` — used by
+ *     `escapeHtml` in `api-client.js`.
+ *   - `window.location.hash` — read by route parsers / hash gates.
+ *   - `localStorage` — read for the current user id.
+ *
+ * The `escapeHtml` stub mirrors browser behavior closely enough for the
+ * assertions in these tests (escapes `&`, `<`, `>`, `"`, `'`).
+ */
+
+interface FakeElement {
+  _text: string;
+  textContent: string;
+  innerHTML: string;
+}
+
+function makeElement(): FakeElement {
+  const el = {
+    _text: '',
+    get textContent() {
+      return el._text;
+    },
+    set textContent(v: string) {
+      el._text = v == null ? '' : String(v);
+    },
+    get innerHTML() {
+      // Match the browser: setting textContent then reading innerHTML
+      // returns the HTML-escaped form of the text. api-client.escapeHtml
+      // additionally replaces " and ' afterwards.
+      return el._text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    },
+    set innerHTML(_v: string) {
+      /* not used by the helpers under test */
+    },
+  };
+  return el;
+}
+
+if (typeof (globalThis as Record<string, unknown>).document === 'undefined') {
+  (globalThis as Record<string, unknown>).document = {
+    createElement: () => makeElement(),
+  };
+}
+
+if (typeof (globalThis as Record<string, unknown>).window === 'undefined') {
+  (globalThis as Record<string, unknown>).window = {
+    location: { hash: '' },
+  };
+}
+
+if (typeof (globalThis as Record<string, unknown>).localStorage === 'undefined') {
+  const store = new Map<string, string>();
+  (globalThis as Record<string, unknown>).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => store.set(k, String(v)),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
+  };
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest config for the web dashboard's browser ESM modules
+ * (`public/js/**`). These modules are plain browser ES modules that
+ * touch a handful of DOM globals (`document`, `localStorage`, `window`)
+ * — `test/setup.ts` installs minimal stubs for the few APIs the pure
+ * render/parse helpers use, so we can unit-test them in a Node
+ * environment without pulling in a jsdom/happy-dom dependency the rest
+ * of this repo doesn't use.
+ */
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['public/js/**/*.test.{js,ts}'],
+    setupFiles: ['./test/setup.ts'],
+  },
+});


### PR DESCRIPTION
## What

Finishes **#321** (*Emergent Lifebooks: importance promotion/demotion ceremony*). The backend persistence + the worker-respects-override SQL `CASE` shipped in **#332**; this PR adds the two remaining ACs: the **promote/demote UI on the Lifebook detail page** and **recording the override as an episode in memory**.

### UI — promote/demote control on the Lifebook detail page
- New **"How important is this right now?"** card on the per-Lifebook page (`apps/web/public/js/pages/lifebook.js`) with three tier buttons (Emerging → Secondary → Core). The current tier is the active/disabled button; the others promote or demote via the existing `POST /api/lifebooks/:userId/:domainName/importance` route.
- Manual-override state: a **"Set by you"** line (shows the reset date for a decaying override, or *"stays until you clear it"* for the `decayDays: 0` never-decay case) plus a **"Let the twin decide"** button that clears the override (`DELETE …/importance`).
- All controls are `data-action` buttons dispatched by the page's **hash-gated singleton delegator** (no inline `onclick`, per CLAUDE.md "Frontend Event Handling"). The handler reads the current user id at click time, disables the button in-flight to prevent double-writes, and re-renders the page in place so the badge + override line update.
- New `setLifebookImportance` / `clearLifebookImportance` helpers in `api-client.js`.

### Backend wiring — override recorded as an episode in memory
- `POST`/`DELETE …/importance` now record a **best-effort episodic memory** (`apps/api/src/routes/lifebooks.ts`) so the twin remembers "user set Aging Parents to Core on 2026-06-15" and can reference it later. Mirrors the approval-episode recorder in `approvals.ts`: writes to **both** the legacy `episodic_memories` table (`situationType: 'lifebook_importance_override'`, `feedbackType: 'edit'`, utility 0.9) **and** the pluggable memory port, each swallowing its own error so a memory-layer hiccup **never gates** the user-facing importance write that already committed.

## ACs satisfied (vs. the issue body)
- [x] Promote/demote control on the detail page (dashboard-card control remains a separate follow-up; this PR is the detail-page slice per the audit scope)
- [x] Manual overrides persist on `lifebooks.metadata.importanceOverride` with a timestamp — *shipped in #332, surfaced by this UI*
- [x] Domain-extraction worker respects override — *shipped in #332*
- [x] **Override is recorded as an episode in memory so the twin can reference it** — this PR
- [x] Override decays after a configurable window / explicit clear — *shipped in #332; this UI exposes both the decay date and the clear action*

## Tests
- **apps/api** — 4 new cases in `lifebook-importance-routes.test.ts` (records on set; records a "cleared" episode on delete; returns 200 when the legacy write throws; returns 200 when the memory-port write throws). All **23** lifebook route tests pass; `tsc --noEmit` clean.
- **apps/web** — first vitest setup for the package (`vitest.config.ts` + `test/setup.ts` with minimal `document`/`window`/`localStorage` stubs, **no new jsdom dependency**) and **11** cases for route parsing, importance-control render states (current-tier marker, no-override hint, "set by you" + Clear, `decayDays:0` copy, domain escaping), and the override-expiry fallback.

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)