### PR TITLE
feat(#324): wire IronClawAdapter.rollback through executionRouter in regret path

### DIFF
--- a/apps/api/src/__tests__/capabilities-routes.test.ts
+++ b/apps/api/src/__tests__/capabilities-routes.test.ts
@@ -10,6 +10,9 @@ import type { Express } from 'express';
 const {
   mockMcpServerRepository,
   mockAppSuggestionRepository,
+  mockExecutionRepository,
+  mockGetExecutionRouter,
+  mockRouterRollback,
   mockQuery,
 } = vi.hoisted(() => ({
   mockMcpServerRepository: {
@@ -30,13 +33,26 @@ const {
     markDismissed: vi.fn(),
     markSnoozed: vi.fn(),
   },
+  mockExecutionRepository: {
+    getRollbackTargetsByServer: vi.fn(),
+  },
+  mockGetExecutionRouter: vi.fn(),
+  mockRouterRollback: vi.fn(),
   mockQuery: vi.fn(),
 }));
 
 vi.mock('@skytwin/db', () => ({
   mcpServerRepository: mockMcpServerRepository,
   appSuggestionRepository: mockAppSuggestionRepository,
+  executionRepository: mockExecutionRepository,
   query: mockQuery,
+}));
+
+// #324: the regret endpoint resolves the execution router to dispatch
+// IronClawAdapter.rollback(planId). Mock it so tests assert the wiring without
+// constructing real adapters.
+vi.mock('../execution-setup.js', () => ({
+  getExecutionRouter: mockGetExecutionRouter,
 }));
 
 // Mock RegistryClient so tests don't hit the filesystem during vitest
@@ -186,6 +202,15 @@ describe('Capabilities API routes', () => {
     mockAppSuggestionRepository.markSnoozed.mockResolvedValue(null);
     // Default: listForUser returns empty array
     mockMcpServerRepository.listForUser.mockResolvedValue([]);
+    // #324: default router resolves with a rollback() that succeeds.
+    mockRouterRollback.mockResolvedValue({
+      result: { success: true, message: 'Rolled back by ironclaw' },
+      adapterUsed: 'ironclaw',
+      noAdapter: false,
+    });
+    mockGetExecutionRouter.mockResolvedValue({ rollback: mockRouterRollback });
+    // #324: default rollback targets are empty unless a test sets them.
+    mockExecutionRepository.getRollbackTargetsByServer.mockResolvedValue([]);
   });
 
   // =========================================================================
@@ -297,32 +322,26 @@ describe('Capabilities API routes', () => {
       const server = makeMcpServer();
       mockMcpServerRepository.getById.mockResolvedValue(server);
 
-      // Mock: two provenance nodes — one reversible, one not.
-      // #324: the route now also reads `execution_plan_id` via a
-      // subquery against decision_outcomes. The mock returns NULL
-      // here (no decision_outcomes row matches), so the reversible
-      // action reports `result: 'no_plan_linkage'` rather than the
-      // old stub `'rolled_back'`. Honest reporting: we can't roll
-      // back without a plan ID to target.
-      mockQuery.mockResolvedValue({
-        rows: [
-          {
-            id: 'node-1',
-            ref_id: 'action-aaa',
-            payload: { reversible: true },
-            occurred_at: new Date(),
-            execution_plan_id: null,
-          },
-          {
-            id: 'node-2',
-            ref_id: 'action-bbb',
-            payload: { reversible: false, irreversibleReason: 'Sent email' },
-            occurred_at: new Date(),
-            execution_plan_id: null,
-          },
-        ],
-        rowCount: 2,
-      });
+      // Two rollback targets — one reversible (no plan linkage), one not.
+      // #324: the route resolves targets via the join repo method now. A
+      // reversible action with NULL executionPlanId reports
+      // `result: 'no_plan_linkage'` — honest reporting, no plan to target.
+      mockExecutionRepository.getRollbackTargetsByServer.mockResolvedValue([
+        {
+          actionId: 'action-aaa',
+          payload: { reversible: true },
+          occurredAt: new Date(),
+          executionPlanId: null,
+          adapterUsed: null,
+        },
+        {
+          actionId: 'action-bbb',
+          payload: { reversible: false, irreversibleReason: 'Sent email' },
+          occurredAt: new Date(),
+          executionPlanId: null,
+          adapterUsed: null,
+        },
+      ]);
 
       const app = buildApp(USER_ID);
       const res = await request(
@@ -344,24 +363,67 @@ describe('Capabilities API routes', () => {
       expect(body.irreversible).toHaveLength(1);
       expect(body.irreversible[0]!.actionId).toBe('action-bbb');
       expect(body.irreversible[0]!.reason).toBe('Sent email');
+      // No plan to target → the router's rollback is never dispatched.
+      expect(mockRouterRollback).not.toHaveBeenCalled();
     });
 
-    it('returns pending_adapter_wiring when the FK resolves a real plan id (#324)', async () => {
+    it('dispatches IronClawAdapter.rollback via the router and reports rolled_back (#324)', async () => {
       mockMcpServerRepository.getById.mockResolvedValue(makeMcpServer({ user_id: USER_ID }));
 
-      // Reversible action with a successfully resolved execution_plan_id —
-      // the new branch. Confirms the enum's happy-path value lands.
-      mockQuery.mockResolvedValue({
-        rows: [
-          {
-            id: 'node-3',
-            ref_id: 'action-ccc',
-            payload: { reversible: true },
-            occurred_at: new Date(),
-            execution_plan_id: 'plan-xyz',
-          },
-        ],
-        rowCount: 1,
+      // Reversible action with a resolved plan id + recorded adapter — the
+      // router rollback is dispatched against the SAME adapter that executed it.
+      mockExecutionRepository.getRollbackTargetsByServer.mockResolvedValue([
+        {
+          actionId: 'action-ccc',
+          payload: { reversible: true },
+          occurredAt: new Date(),
+          executionPlanId: 'plan-xyz',
+          adapterUsed: 'ironclaw',
+        },
+      ]);
+
+      const app = buildApp(USER_ID);
+      const res = await request(
+        app,
+        'POST',
+        `/api/capabilities/${SERVER_ID}/regret`,
+        { withinHours: 48 },
+      );
+
+      expect(res.status).toBe(200);
+      const body = res.body as {
+        undone: Array<{ actionId: string; planId: string | null; adapterUsed: string | null; result: string }>;
+      };
+      expect(body.undone).toHaveLength(1);
+      expect(body.undone[0]!.planId).toBe('plan-xyz');
+      expect(body.undone[0]!.adapterUsed).toBe('ironclaw');
+      expect(body.undone[0]!.result).toBe('rolled_back');
+      // The router was asked to roll back the resolved plan, targeting the
+      // adapter recorded at execution time.
+      expect(mockRouterRollback).toHaveBeenCalledWith('plan-xyz', 'ironclaw');
+      // Audit trail: a rollback provenance node was written (Safety Invariant #2).
+      const auditCall = mockQuery.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0].includes('capability_provenance_nodes'),
+      );
+      expect(auditCall).toBeDefined();
+    });
+
+    it('reports rollback_failed when the adapter cannot roll back (#324)', async () => {
+      mockMcpServerRepository.getById.mockResolvedValue(makeMcpServer({ user_id: USER_ID }));
+      mockExecutionRepository.getRollbackTargetsByServer.mockResolvedValue([
+        {
+          actionId: 'action-ddd',
+          payload: { reversible: true },
+          occurredAt: new Date(),
+          executionPlanId: 'plan-fail',
+          adapterUsed: 'openclaw',
+        },
+      ]);
+      // Adapter reports failure (e.g. no rollback steps / adapter gone).
+      mockRouterRollback.mockResolvedValue({
+        result: { success: false, message: 'This action is not reversible.' },
+        adapterUsed: 'openclaw',
+        noAdapter: true,
       });
 
       const app = buildApp(USER_ID);
@@ -374,11 +436,12 @@ describe('Capabilities API routes', () => {
 
       expect(res.status).toBe(200);
       const body = res.body as {
-        undone: Array<{ actionId: string; planId: string | null; result: string }>;
+        undone: Array<{ planId: string | null; result: string; message?: string }>;
       };
       expect(body.undone).toHaveLength(1);
-      expect(body.undone[0]!.planId).toBe('plan-xyz');
-      expect(body.undone[0]!.result).toBe('pending_adapter_wiring');
+      expect(body.undone[0]!.planId).toBe('plan-fail');
+      expect(body.undone[0]!.result).toBe('rollback_failed');
+      expect(body.undone[0]!.message).toContain('not reversible');
     });
 
     it('returns 403 when requester is not the owner', async () => {

--- a/apps/api/src/routes/capabilities.ts
+++ b/apps/api/src/routes/capabilities.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { mcpServerRepository, appSuggestionRepository, provenanceRepository, mcpServerMetricsRepository, mcpServerChangelogRepository, query } from '@skytwin/db';
+import { mcpServerRepository, appSuggestionRepository, provenanceRepository, mcpServerMetricsRepository, mcpServerChangelogRepository, executionRepository, query } from '@skytwin/db';
 import type { McpServerRow } from '@skytwin/db';
 import type { Request } from 'express';
 import { createLogger } from '@skytwin/core';
@@ -9,6 +9,7 @@ import type { TrustTier } from '@skytwin/shared-types';
 import { PROMOTION_THRESHOLDS } from '@skytwin/shared-types';
 import { runPrompt } from '@skytwin/policy-prompts';
 import { getLlmClientFromConfig } from '../lib/llm-client-factory.js';
+import { getExecutionRouter } from '../execution-setup.js';
 // SSE event constants — imported for re-export and for use in callers that
 // wire the promotion ceremony (e.g. promotion-eligibility-check.ts).
 // sseManager and SSE_CAPABILITY_PROMOTION_OFFERED are imported here so they
@@ -404,66 +405,61 @@ export function createCapabilitiesRouter(): Router {
 
       const sinceDate = new Date(Date.now() - withinHours * 60 * 60 * 1000);
 
-      // Query actions executed via this server in the recent window.
-      // Provenance still owns the server↔action attribution; the #324
-      // FK gives us the execution_plan_id for each action via
-      // decision_outcomes (selected_action_id = provenance.ref_id).
-      // Returns real plan IDs in the response so callers / the eventual
-      // IronClawAdapter.rollback(planId) wiring have something concrete
-      // to act on — replaces the prior "stub recorded intent" behavior.
-      //
-      // SUBQUERY rather than LEFT JOIN — even though `selected_action_id`
-      // should be unique per decision in practice, there is no DB
-      // constraint enforcing it, and a malformed row (or future
-      // schema change) where the same candidate_actions.id ends up
-      // on two outcomes would have a LEFT JOIN duplicating the
-      // provenance row in the result set. Subquery + LIMIT 1 keeps
-      // one row per provenance node regardless. (Copilot caught the
-      // JOIN duplication risk.)
-      const provenanceResult = await query<{
-        id: string;
-        ref_id: string;
-        payload: unknown;
-        occurred_at: Date;
-        execution_plan_id: string | null;
-      }>(
-        `SELECT pn.id, pn.ref_id, pn.payload, pn.occurred_at,
-                (SELECT doc.execution_plan_id
-                   FROM decision_outcomes doc
-                  WHERE doc.selected_action_id = pn.ref_id
-                  LIMIT 1) AS execution_plan_id
-         FROM capability_provenance_nodes pn
-         WHERE pn.server_id = $1
-           AND pn.node_type = 'action'
-           AND pn.occurred_at >= $2
-           AND pn.user_id = $3
-         ORDER BY pn.occurred_at DESC`,
-        [id, sinceDate, userId],
-      );
+      // Resolve rollback targets via the #324 join repo method:
+      // capability_provenance_nodes (server↔action attribution) →
+      // decision_outcomes.execution_plan_id (the #324 FK) → the real plan ID,
+      // plus the adapter that executed it (execution_results.adapter_used) so
+      // rollback routes back to the SAME adapter. The duplication-safe LIMIT-1
+      // subquery + lateral join live in the repo method now (was an inline
+      // query here before #324's adapter wiring landed).
+      const targets = await executionRepository.getRollbackTargetsByServer({
+        serverId: id,
+        userId,
+        since: sinceDate,
+      });
 
       // Result enum:
-      //   - 'pending_adapter_wiring' — FK resolved a real plan ID;
-      //     IronClawAdapter.rollback(planId) call is the next step
-      //     (separate follow-up, needs routing through executionRouter)
-      //   - 'no_plan_linkage' — FK lookup returned NULL; can't roll
-      //     back because we don't know which plan to target. Honest
-      //     reporting beats lying about rollback success. (Copilot
-      //     caught the prior inverted enum that returned
-      //     'rolled_back' in this no-linkage branch — never true.)
+      //   - 'rolled_back'      — adapter.rollback(planId) succeeded.
+      //   - 'rollback_failed'  — the adapter ran but reported failure (e.g.
+      //                          the plan had no rollback steps, or the
+      //                          executing adapter is no longer registered).
+      //   - 'no_plan_linkage'  — the #324 FK lookup returned NULL; no plan to
+      //                          target, so nothing to dispatch. Honest
+      //                          reporting beats claiming a rollback happened.
       const undone: Array<{
         actionId: string;
         planId: string | null;
-        result: 'pending_adapter_wiring' | 'no_plan_linkage';
+        adapterUsed: string | null;
+        result: 'rolled_back' | 'rollback_failed' | 'no_plan_linkage';
+        message?: string;
       }> = [];
       const irreversible: Array<{ actionId: string; reason: string }> = [];
 
-      for (const node of provenanceResult.rows) {
-        const payload = node.payload as Record<string, unknown> | null;
+      // Resolve the execution router once for the whole batch. If it can't be
+      // constructed (no adapters configured), treat every reversible action as
+      // a rollback failure rather than throwing the whole request — the user
+      // still gets an honest per-action report.
+      let router: Awaited<ReturnType<typeof getExecutionRouter>> | null = null;
+      let routerError: string | null = null;
+      const hasReversibleTarget = targets.some(
+        (t) => (t.payload?.['reversible'] === true) && t.executionPlanId,
+      );
+      if (hasReversibleTarget) {
+        try {
+          router = await getExecutionRouter();
+        } catch (err) {
+          routerError = err instanceof Error ? err.message : String(err);
+          log.warn('Execution router unavailable for regret rollback', { serverId: id, error: routerError });
+        }
+      }
+
+      for (const target of targets) {
+        const payload = target.payload;
         const reversible = payload?.['reversible'] === true;
 
         if (!reversible) {
           irreversible.push({
-            actionId: node.ref_id,
+            actionId: target.actionId,
             reason: typeof payload?.['irreversibleReason'] === 'string'
               ? payload['irreversibleReason']
               : 'Action was marked irreversible at execution time',
@@ -471,11 +467,70 @@ export function createCapabilitiesRouter(): Router {
           continue;
         }
 
+        if (!target.executionPlanId) {
+          undone.push({
+            actionId: target.actionId,
+            planId: null,
+            adapterUsed: null,
+            result: 'no_plan_linkage',
+          });
+          continue;
+        }
+
+        // Dispatch the rollback through the execution router, targeting the
+        // adapter that executed the plan (#324).
+        if (!router) {
+          undone.push({
+            actionId: target.actionId,
+            planId: target.executionPlanId,
+            adapterUsed: target.adapterUsed,
+            result: 'rollback_failed',
+            message: routerError
+              ? `Execution router unavailable: ${routerError}`
+              : 'Execution router unavailable',
+          });
+          continue;
+        }
+
+        const rollback = await router.rollback(target.executionPlanId, target.adapterUsed);
+
         undone.push({
-          actionId: node.ref_id,
-          planId: node.execution_plan_id,
-          result: node.execution_plan_id ? 'pending_adapter_wiring' : 'no_plan_linkage',
+          actionId: target.actionId,
+          planId: target.executionPlanId,
+          adapterUsed: rollback.adapterUsed,
+          result: rollback.result.success ? 'rolled_back' : 'rollback_failed',
+          message: rollback.result.message,
         });
+
+        // Audit trail (Safety Invariant #2): record every rollback attempt as
+        // a provenance node so the reversal is explainable. A rollback is the
+        // user reversing an action — recorded under the existing 'feedback'
+        // node type (no schema change) with a descriptive payload.
+        try {
+          await writeProvenanceNode({
+            userId,
+            nodeType: 'feedback',
+            refTable: 'execution_plans',
+            refId: target.executionPlanId,
+            serverId: id,
+            payload: {
+              kind: 'rollback',
+              actionId: target.actionId,
+              adapterUsed: rollback.adapterUsed,
+              success: rollback.result.success,
+              message: rollback.result.message,
+              withinHours,
+            },
+          });
+        } catch (auditErr) {
+          // Audit write failure must not mask a successful rollback — log and
+          // continue. The rollback result is still reported to the caller.
+          log.warn('Failed to write rollback provenance node', {
+            serverId: id,
+            planId: target.executionPlanId,
+            error: auditErr instanceof Error ? auditErr.message : String(auditErr),
+          });
+        }
       }
 
       res.json({ undone, irreversible });

--- a/packages/db/src/__tests__/execution-repository.test.ts
+++ b/packages/db/src/__tests__/execution-repository.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockClientQuery = vi.fn();
+const mockQuery = vi.fn();
 const mockWithTransaction = vi.fn(
   async (cb: (client: { query: typeof mockClientQuery }) => Promise<unknown>) =>
     cb({ query: mockClientQuery }),
 );
 
 vi.mock('../connection.js', () => ({
-  query: vi.fn(),
+  query: (...args: unknown[]) => mockQuery(...args),
   withTransaction: (cb: (client: { query: typeof mockClientQuery }) => Promise<unknown>) =>
     mockWithTransaction(cb),
 }));
@@ -102,5 +103,77 @@ describe('executionRepository.createPlan — #324 outcome linkage', () => {
     // Single withTransaction call wraps both statements
     expect(mockWithTransaction).toHaveBeenCalledTimes(1);
     expect(mockClientQuery).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('executionRepository.getRollbackTargetsByServer — #324 rollback join', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves plan id + adapter from the provenance→outcome→result join', async () => {
+    const occurredAt = new Date('2026-06-14T00:00:00Z');
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          ref_id: 'action-1',
+          payload: { reversible: true },
+          occurred_at: occurredAt,
+          execution_plan_id: 'plan-1',
+          adapter_used: 'ironclaw',
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const since = new Date('2026-06-13T00:00:00Z');
+    const targets = await executionRepository.getRollbackTargetsByServer({
+      serverId: 'server-1',
+      userId: 'user-1',
+      since,
+    });
+
+    // The join query is parameterized with [serverId, since, userId] in order.
+    const [sql, params] = mockQuery.mock.calls[0]!;
+    expect(sql).toContain('capability_provenance_nodes');
+    expect(sql).toContain('decision_outcomes');
+    expect(sql).toContain("outputs->>'adapter_used'");
+    expect(params).toEqual(['server-1', since, 'user-1']);
+
+    expect(targets).toEqual([
+      {
+        actionId: 'action-1',
+        payload: { reversible: true },
+        occurredAt,
+        executionPlanId: 'plan-1',
+        adapterUsed: 'ironclaw',
+      },
+    ]);
+  });
+
+  it('passes through NULL plan id + adapter (no decision_outcomes / result linkage)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          ref_id: 'action-2',
+          payload: { reversible: false, irreversibleReason: 'sent' },
+          occurred_at: new Date(),
+          execution_plan_id: null,
+          adapter_used: null,
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const targets = await executionRepository.getRollbackTargetsByServer({
+      serverId: 'server-1',
+      userId: 'user-1',
+      since: new Date(),
+    });
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.executionPlanId).toBeNull();
+    expect(targets[0]!.adapterUsed).toBeNull();
+    expect(targets[0]!.payload).toEqual({ reversible: false, irreversibleReason: 'sent' });
   });
 });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -136,6 +136,7 @@ export type {
   CreateExecutionResultInput,
   CreateExecutionEventInput,
   ExecutionPlanWithResult,
+  RollbackTarget,
 } from './repositories/index.js';
 
 export { signalRepository, proposalRepository, skillGapRepository, proactiveScanRepository } from './repositories/index.js';

--- a/packages/db/src/repositories/execution-repository.ts
+++ b/packages/db/src/repositories/execution-repository.ts
@@ -38,6 +38,29 @@ export interface ExecutionPlanWithResult {
 }
 
 /**
+ * One rollback candidate resolved for a capability server's recent actions.
+ *
+ * #324: this is the materialized output of the
+ * `capability_provenance_nodes → decision_outcomes → execution_plans →
+ * execution_results` join the `regret` endpoint needs. `executionPlanId` is the
+ * real plan ID `IronClawAdapter.rollback(planId)` acts on (NULL when no outcome
+ * links to a plan yet); `adapterUsed` is the adapter that executed the plan
+ * (read from `execution_results.outputs.adapter_used`) so rollback can route
+ * back to the SAME adapter that performed the action.
+ */
+export interface RollbackTarget {
+  /** The provenance node's `ref_id` — the candidate action id. */
+  actionId: string;
+  /** Raw provenance payload (carries `reversible` + `irreversibleReason`). */
+  payload: Record<string, unknown> | null;
+  occurredAt: Date;
+  /** Real execution plan id resolved via the #324 FK, or NULL if unlinked. */
+  executionPlanId: string | null;
+  /** Adapter that executed the plan, or NULL if not recorded / no result. */
+  adapterUsed: string | null;
+}
+
+/**
  * Repository for execution plan and result operations.
  */
 export const executionRepository = {
@@ -161,6 +184,67 @@ export const executionRepository = {
       plan,
       result: resultResult.rows[0] ?? null,
     };
+  },
+
+  /**
+   * Resolve rollback targets for a capability server's recent actions (#324).
+   *
+   * Walks `capability_provenance_nodes` (the server↔action attribution) and,
+   * for each `action` node, resolves the real execution plan via the #324
+   * `decision_outcomes.execution_plan_id` FK plus the adapter that executed it
+   * via `execution_results.outputs->>'adapter_used'`. The `regret` endpoint
+   * uses this to dispatch `IronClawAdapter.rollback(planId)` through the
+   * execution router, targeting the SAME adapter that ran the action.
+   *
+   * SUBQUERY (not LEFT JOIN) for `execution_plan_id`: `selected_action_id`
+   * should be unique per outcome but there is no DB constraint enforcing it, so
+   * a LEFT JOIN could duplicate the provenance row. `LIMIT 1` keeps one row per
+   * provenance node regardless. The adapter lookup is similarly a scalar
+   * subquery against the latest result for the resolved plan.
+   */
+  async getRollbackTargetsByServer(input: {
+    serverId: string;
+    userId: string;
+    since: Date;
+  }): Promise<RollbackTarget[]> {
+    const result = await query<{
+      ref_id: string;
+      payload: Record<string, unknown> | null;
+      occurred_at: Date;
+      execution_plan_id: string | null;
+      adapter_used: string | null;
+    }>(
+      `SELECT pn.ref_id,
+              pn.payload,
+              pn.occurred_at,
+              link.execution_plan_id,
+              (SELECT er.outputs->>'adapter_used'
+                 FROM execution_results er
+                WHERE er.plan_id = link.execution_plan_id
+                ORDER BY er.completed_at DESC
+                LIMIT 1) AS adapter_used
+         FROM capability_provenance_nodes pn
+         LEFT JOIN LATERAL (
+                SELECT doc.execution_plan_id
+                  FROM decision_outcomes doc
+                 WHERE doc.selected_action_id = pn.ref_id
+                 LIMIT 1
+              ) link ON true
+        WHERE pn.server_id = $1
+          AND pn.node_type = 'action'
+          AND pn.occurred_at >= $2
+          AND pn.user_id = $3
+        ORDER BY pn.occurred_at DESC`,
+      [input.serverId, input.since, input.userId],
+    );
+
+    return result.rows.map((row) => ({
+      actionId: row.ref_id,
+      payload: row.payload,
+      occurredAt: row.occurred_at,
+      executionPlanId: row.execution_plan_id,
+      adapterUsed: row.adapter_used,
+    }));
   },
 
   /**

--- a/packages/db/src/repositories/index.ts
+++ b/packages/db/src/repositories/index.ts
@@ -44,6 +44,7 @@ export type {
   CreateExecutionResultInput,
   CreateExecutionEventInput,
   ExecutionPlanWithResult,
+  RollbackTarget,
 } from './execution-repository.js';
 
 export { signalRepository } from './signal-repository.js';

--- a/packages/execution-router/src/__tests__/execution-router.test.ts
+++ b/packages/execution-router/src/__tests__/execution-router.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { RiskTier, ConfidenceLevel, RiskDimension } from '@skytwin/shared-types';
 import type {
   CandidateAction,
@@ -432,6 +432,80 @@ describe('ExecutionRouter', () => {
           // noop
         }
       })()).rejects.toThrow(/does not match/);
+    });
+  });
+
+  // ── #324: rollback routing ──────────────────────────────────────────
+  describe('rollback', () => {
+    it('dispatches to the adapter that executed the plan (happy path)', async () => {
+      const ironclaw = createMockAdapter('ironclaw');
+      const openclaw = createMockAdapter('openclaw', OPENCLAW_SKILLS);
+      const ironclawSpy = vi.spyOn(ironclaw, 'rollback');
+      const openclawSpy = vi.spyOn(openclaw, 'rollback');
+      registry.register('ironclaw', ironclaw, IRONCLAW_TRUST_PROFILE);
+      registry.register('openclaw', openclaw, OPENCLAW_TRUST_PROFILE, OPENCLAW_SKILLS);
+
+      const out = await router.rollback('plan-1', 'ironclaw');
+
+      expect(out.result.success).toBe(true);
+      expect(out.adapterUsed).toBe('ironclaw');
+      expect(out.noAdapter).toBe(false);
+      // Routed to the recorded adapter only — never the other registered one.
+      expect(ironclawSpy).toHaveBeenCalledWith('plan-1');
+      expect(openclawSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns noAdapter when the recorded adapter is no longer registered', async () => {
+      // ironclaw executed the plan but was since uninstalled — must NOT fall
+      // back to a different adapter and ask it to roll back a plan it never ran.
+      const direct = createMockAdapter('direct');
+      const directSpy = vi.spyOn(direct, 'rollback');
+      registry.register('direct', direct, DIRECT_TRUST_PROFILE);
+
+      const out = await router.rollback('plan-1', 'ironclaw');
+
+      expect(out.noAdapter).toBe(true);
+      expect(out.result.success).toBe(false);
+      expect(out.adapterUsed).toBe('ironclaw');
+      expect(directSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns noAdapter (fail-safe) when no adapter name was recorded', async () => {
+      registry.register('ironclaw', createMockAdapter('ironclaw'), IRONCLAW_TRUST_PROFILE);
+
+      const out = await router.rollback('plan-1', null);
+
+      expect(out.noAdapter).toBe(true);
+      expect(out.result.success).toBe(false);
+      expect(out.adapterUsed).toBeNull();
+    });
+
+    it('surfaces an adapter-thrown error as a failed (not noAdapter) result', async () => {
+      const ironclaw = createMockAdapter('ironclaw');
+      vi.spyOn(ironclaw, 'rollback').mockRejectedValue(new Error('boom'));
+      registry.register('ironclaw', ironclaw, IRONCLAW_TRUST_PROFILE);
+
+      const out = await router.rollback('plan-1', 'ironclaw');
+
+      expect(out.noAdapter).toBe(false);
+      expect(out.result.success).toBe(false);
+      expect(out.result.message).toContain('boom');
+      expect(out.adapterUsed).toBe('ironclaw');
+    });
+
+    it('reports the adapter\'s own failure (e.g. no rollback steps) verbatim', async () => {
+      const ironclaw = createMockAdapter('ironclaw');
+      vi.spyOn(ironclaw, 'rollback').mockResolvedValue({
+        success: false,
+        message: 'This action is not reversible. No rollback steps were defined.',
+      });
+      registry.register('ironclaw', ironclaw, IRONCLAW_TRUST_PROFILE);
+
+      const out = await router.rollback('plan-1', 'ironclaw');
+
+      expect(out.noAdapter).toBe(false);
+      expect(out.result.success).toBe(false);
+      expect(out.result.message).toContain('not reversible');
     });
   });
 });

--- a/packages/execution-router/src/execution-router.ts
+++ b/packages/execution-router/src/execution-router.ts
@@ -4,6 +4,7 @@ import type {
   ExecutionPlan,
   RiskAssessment,
   ExecutionResult,
+  RollbackResult,
   RoutingDecision,
   SkillGap,
 } from '@skytwin/shared-types';
@@ -23,6 +24,23 @@ import { logSkillGap } from './skill-gap-logger.js';
  */
 export interface ExecutionContext {
   approved?: boolean;
+}
+
+/**
+ * Outcome of routing a rollback request through the registry.
+ *
+ * `result` is the adapter's own `RollbackResult`. `adapterUsed` records which
+ * registered adapter actually serviced the rollback so callers can persist it
+ * alongside the rollback audit record. `noAdapter` is the typed failure mode
+ * (Code Style: typed result objects for expected failures) — set when no
+ * registered adapter could service the rollback, rather than throwing for the
+ * recoverable "this server is no longer installed" case.
+ */
+export interface RollbackRoutingResult {
+  result: RollbackResult;
+  adapterUsed: string | null;
+  /** True when no registered adapter could handle the rollback. */
+  noAdapter: boolean;
 }
 
 /**
@@ -289,6 +307,81 @@ export class ExecutionRouter {
       action.decisionId,
     );
     throw new NoAdapterError(gap);
+  }
+
+  /**
+   * Roll back a previously executed plan by routing to the adapter that ran it.
+   *
+   * Rollback is fundamentally different from execution routing: it must target
+   * the SAME adapter that executed the plan, because each adapter keeps its own
+   * in-memory plan store keyed by `planId` (see the mock/real IronClaw adapters
+   * and OpenClawAdapter). Re-running the trust-ranked selection from
+   * `executeWithRouting` would pick whichever adapter ranks highest today, not
+   * the one that actually performed the action — so we resolve the adapter by
+   * the `adapterUsed` name persisted at execution time (`execution_results`
+   * `outputs.adapter_used`).
+   *
+   * Resolution order:
+   *   1. If `adapterUsed` names a registered adapter, dispatch to it.
+   *   2. If `adapterUsed` is unknown/unregistered (e.g. the capability was
+   *      uninstalled, or older rows that predate adapter_used persistence),
+   *      return `noAdapter: true` — we will NOT guess a different adapter and
+   *      ask it to roll back a plan it never executed. Lying about which
+   *      adapter can undo the work is worse than honest "no adapter".
+   *
+   * This never throws for the expected "adapter gone" case; it returns a typed
+   * result object (Code Style). It only surfaces adapter-thrown errors as a
+   * failed `RollbackResult`.
+   */
+  async rollback(
+    planId: string,
+    adapterUsed: string | null | undefined,
+  ): Promise<RollbackRoutingResult> {
+    // Only an adapter that actually executed the plan can roll it back, and the
+    // only reliable record of that is the persisted adapter name. An absent or
+    // unrecognized name fails safe — never fall back to a different adapter.
+    if (!adapterUsed) {
+      return {
+        result: {
+          success: false,
+          message:
+            'Cannot roll back: no adapter was recorded for this plan. The ' +
+            'executing adapter is unknown, so no rollback target can be resolved.',
+        },
+        adapterUsed: null,
+        noAdapter: true,
+      };
+    }
+
+    const entry = this.registry.get(adapterUsed);
+    if (!entry) {
+      return {
+        result: {
+          success: false,
+          message:
+            `Cannot roll back: adapter "${adapterUsed}" that executed this plan ` +
+            `is no longer registered (the capability may have been uninstalled).`,
+        },
+        adapterUsed,
+        noAdapter: true,
+      };
+    }
+
+    try {
+      const result = await entry.adapter.rollback(planId);
+      return { result, adapterUsed, noAdapter: false };
+    } catch (err) {
+      // Adapter threw mid-rollback — surface as a failed (not "no adapter")
+      // result so the caller reports the failure honestly rather than a stub.
+      return {
+        result: {
+          success: false,
+          message: `Rollback via adapter "${adapterUsed}" threw: ${err instanceof Error ? err.message : String(err)}`,
+        },
+        adapterUsed,
+        noAdapter: false,
+      };
+    }
   }
 
   /**

--- a/packages/execution-router/src/index.ts
+++ b/packages/execution-router/src/index.ts
@@ -1,5 +1,5 @@
 export { ExecutionRouter, NoAdapterError, InvariantViolationError } from './execution-router.js';
-export type { ExecutionContext } from './execution-router.js';
+export type { ExecutionContext, RollbackRoutingResult } from './execution-router.js';
 
 export {
   AdapterRegistry,


### PR DESCRIPTION
## What changed

Finalizes the decision-action-execution linkage's rollback follow-up — item 1 of the "Remaining work, scoped" list in [#324's status comment](https://github.com/jayzalowitz/skytwin/issues/324#issuecomment-4473902621). The `regret` endpoint already resolved real `execution_plan_id`s via the migration-055 `decision_outcomes.execution_plan_id` FK, but reported `result: 'pending_adapter_wiring'` and never dispatched. It now actually rolls back.

### `ExecutionRouter.rollback(planId, adapterUsed)` — `packages/execution-router`
New method that routes a rollback to the **same adapter that executed the plan** (resolved by the persisted adapter name), not whichever adapter ranks highest today. Rollback is fundamentally different from execution routing: each adapter keeps its own in-memory plan store keyed by `planId`, so re-running trust-ranked selection would target the wrong adapter. Fail-safe semantics:
- Absent or unregistered `adapterUsed` → typed `{ noAdapter: true, result: { success: false, … } }`. Never falls back to a stranger adapter to undo work it never did.
- Adapter-thrown error → failed (not `noAdapter`) result, message included.

New exported `RollbackRoutingResult` interface.

### `executionRepository.getRollbackTargetsByServer({ serverId, userId, since })` — `packages/db`
New `decision_outcomes → execution_plans` join repo method (the join was inline in `capabilities.ts` before). Walks `capability_provenance_nodes` for the server's recent `action` nodes, resolves the real plan id via the #324 FK (`LIMIT 1` subquery — no LEFT-JOIN row duplication), and reads the executing adapter from `execution_results.outputs->>'adapter_used'`. Returns typed `RollbackTarget[]`, re-exported from `@skytwin/db`.

### `POST /api/capabilities/:id/regret` — `apps/api`
Dispatches the rollback through the router for each reversible action with a resolved plan id and reports the honest per-action outcome: `'rolled_back'` / `'rollback_failed'` / `'no_plan_linkage'`. Each attempt writes a `feedback`-typed `capability_provenance_nodes` audit row (Safety Invariant #2 — every deliberate action is explainable; no schema change, reuses the existing node-type CHECK enum). Router-unavailable and audit-write failures degrade gracefully without masking the rollback result. Removes the `'pending_adapter_wiring'` stub markers.

## Acceptance criteria

This PR resolves item 1 of #324's three remaining follow-ups:
- [x] **IronClawAdapter.rollback wiring** — endpoint now dispatches through `executionRouter.rollback`, picking the same adapter that executed the plan.
- [x] **decision_outcomes → execution_plans join query/repo method** — `getRollbackTargetsByServer`.
- [x] **End-to-end test: action executed → rollback via real plan ID** — unit-level: repo resolves the FK + adapter, router dispatches to that adapter, endpoint reports `rolled_back` and writes the audit node.

Explicitly **out of scope** (per the issue's own follow-up plan, tracked under #324's items 2 & 3):
- `server_id` on `execution_plans` for the promotion-stats unstubs (separate migration).
- Time-machine counterfactual rerun (needs a decision-pipeline rerun harness that doesn't exist yet).

## Tests added
- `ExecutionRouter.rollback`: happy path (routes to recorded adapter, never the other) · adapter-gone fail-safe · no-adapter-name fail-safe · adapter-throws → failed result · adapter-refuses (no rollback steps) → verbatim message.
- `getRollbackTargetsByServer`: resolves plan id + adapter from the join (asserts params + SQL shape) · passes through NULL plan/adapter.
- `regret` endpoint: `rolled_back` dispatch (asserts `rollback(planId, adapter)` call + audit write) · `rollback_failed` · `no_plan_linkage` (router never dispatched).

Verified green on the touched packages only (not the whole monorepo): `@skytwin/execution-router` (88), `@skytwin/db` (339), and `apps/api` capabilities-routes (25). Per-package `tsc --noEmit` clean.

Addresses #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)