### PR TITLE
feat(desktop): OS-keychain remember for credential-vault passphrase (#401)

### DIFF
--- a/apps/desktop/src/__mocks__/electron.ts
+++ b/apps/desktop/src/__mocks__/electron.ts
@@ -66,6 +66,14 @@ const shell = {
   openExternal: vi.fn(() => Promise.resolve()),
 };
 
+// safeStorage stub — round-trips with a reversible (NOT secure) transform so
+// tests that exercise the passphrase-vault wiring don't need a real keychain.
+const safeStorage = {
+  isEncryptionAvailable: vi.fn(() => true),
+  encryptString: vi.fn((plaintext: string) => Buffer.from(plaintext, 'utf8')),
+  decryptString: vi.fn((ciphertext: Buffer) => ciphertext.toString('utf8')),
+};
+
 export {
   nativeImage,
   Tray,
@@ -75,4 +83,5 @@ export {
   BrowserWindow,
   ipcMain,
   shell,
+  safeStorage,
 };

--- a/apps/desktop/src/__tests__/passphrase-vault.test.ts
+++ b/apps/desktop/src/__tests__/passphrase-vault.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  PassphraseVault,
+  type PassphraseKeyValueStore,
+  type SafeStoragePort,
+} from '../passphrase-vault.js';
+
+/** In-memory key-value store standing in for electron-store. */
+function makeStore(): PassphraseKeyValueStore & { _map: Map<string, string> } {
+  const map = new Map<string, string>();
+  return {
+    _map: map,
+    get: (key) => map.get(key),
+    set: (key, value) => { map.set(key, value); },
+    delete: (key) => { map.delete(key); },
+  };
+}
+
+/**
+ * Fake safeStorage. The "encryption" is a reversible XOR so we can assert the
+ * persisted value is NOT the plaintext, while still round-tripping cleanly.
+ */
+function makeSafeStorage(overrides: Partial<SafeStoragePort> = {}): SafeStoragePort {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => {
+      const buf = Buffer.from(plaintext, 'utf8');
+      return Buffer.from(buf.map((b) => b ^ 0x5a));
+    },
+    decryptString: (ciphertext: Buffer) =>
+      Buffer.from(ciphertext.map((b) => b ^ 0x5a)).toString('utf8'),
+    ...overrides,
+  };
+}
+
+const USER = 'user-123';
+const PASSPHRASE = 'correct horse battery';
+
+describe('PassphraseVault', () => {
+  let store: ReturnType<typeof makeStore>;
+
+  beforeEach(() => {
+    store = makeStore();
+  });
+
+  describe('happy path — remember + retrieve', () => {
+    it('persists encrypted ciphertext (never plaintext) and round-trips', () => {
+      const vault = new PassphraseVault(makeSafeStorage(), store);
+
+      const write = vault.remember(USER, PASSPHRASE);
+      expect(write).toEqual({ ok: true });
+
+      // The stored value must not contain the plaintext.
+      const stored = [...store._map.values()][0];
+      expect(stored).toBeDefined();
+      expect(stored).not.toContain(PASSPHRASE);
+
+      const read = vault.getRemembered(USER);
+      expect(read).toEqual({ ok: true, passphrase: PASSPHRASE });
+    });
+
+    it('reports has() correctly without decrypting', () => {
+      const vault = new PassphraseVault(makeSafeStorage(), store);
+      expect(vault.has(USER)).toBe(false);
+      vault.remember(USER, PASSPHRASE);
+      expect(vault.has(USER)).toBe(true);
+    });
+
+    it('keys per-user — one user does not clobber another', () => {
+      const vault = new PassphraseVault(makeSafeStorage(), store);
+      vault.remember('alice', 'alice-pass-phrase');
+      vault.remember('bob', 'bob-pass-phrase-12');
+      expect(vault.getRemembered('alice')).toEqual({ ok: true, passphrase: 'alice-pass-phrase' });
+      expect(vault.getRemembered('bob')).toEqual({ ok: true, passphrase: 'bob-pass-phrase-12' });
+    });
+
+    it('forget removes the entry and is idempotent', () => {
+      const vault = new PassphraseVault(makeSafeStorage(), store);
+      vault.remember(USER, PASSPHRASE);
+      expect(vault.has(USER)).toBe(true);
+      vault.forget(USER);
+      expect(vault.has(USER)).toBe(false);
+      expect(vault.getRemembered(USER)).toEqual({ ok: false, reason: 'not_found' });
+      // second forget does not throw
+      expect(() => vault.forget(USER)).not.toThrow();
+    });
+
+    it('remember overwrites a previous passphrase', () => {
+      const vault = new PassphraseVault(makeSafeStorage(), store);
+      vault.remember(USER, 'first-passphrase-x');
+      vault.remember(USER, 'second-passphrase-y');
+      expect(vault.getRemembered(USER)).toEqual({ ok: true, passphrase: 'second-passphrase-y' });
+    });
+  });
+
+  describe('graceful fallback — OS keychain unavailable', () => {
+    it('remember returns unsupported and stores nothing', () => {
+      const safeStorage = makeSafeStorage({ isEncryptionAvailable: () => false });
+      const vault = new PassphraseVault(safeStorage, store);
+
+      const result = vault.remember(USER, PASSPHRASE);
+      expect(result).toEqual({ ok: false, reason: 'unsupported' });
+      expect(store._map.size).toBe(0);
+    });
+
+    it('getRemembered returns unsupported', () => {
+      const safeStorage = makeSafeStorage({ isEncryptionAvailable: () => false });
+      const vault = new PassphraseVault(safeStorage, store);
+      expect(vault.getRemembered(USER)).toEqual({ ok: false, reason: 'unsupported' });
+    });
+
+    it('isSupported is false when isEncryptionAvailable throws (fail safe)', () => {
+      const safeStorage = makeSafeStorage({
+        isEncryptionAvailable: () => { throw new Error('no backend'); },
+      });
+      const vault = new PassphraseVault(safeStorage, store);
+      expect(vault.isSupported()).toBe(false);
+      expect(vault.remember(USER, PASSPHRASE)).toEqual({ ok: false, reason: 'unsupported' });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('refuses to remember an empty passphrase', () => {
+      const vault = new PassphraseVault(makeSafeStorage(), store);
+      expect(vault.remember(USER, '')).toEqual({ ok: false, reason: 'empty_passphrase' });
+      expect(store._map.size).toBe(0);
+    });
+
+    it('returns not_found when nothing is stored', () => {
+      const vault = new PassphraseVault(makeSafeStorage(), store);
+      expect(vault.getRemembered(USER)).toEqual({ ok: false, reason: 'not_found' });
+    });
+
+    it('treats an undecryptable entry as corrupt and evicts it', () => {
+      // Store a value, then swap in a safeStorage whose decrypt throws — as if
+      // the store was copied to a different machine / account.
+      const goodVault = new PassphraseVault(makeSafeStorage(), store);
+      goodVault.remember(USER, PASSPHRASE);
+      expect(store._map.size).toBe(1);
+
+      const brokenSafeStorage = makeSafeStorage({
+        decryptString: () => { throw new Error('decrypt failed: wrong machine'); },
+      });
+      const vault = new PassphraseVault(brokenSafeStorage, store);
+      const read = vault.getRemembered(USER);
+      expect(read).toEqual({ ok: false, reason: 'corrupt' });
+      // The bad entry was evicted so we stop retrying.
+      expect(store._map.size).toBe(0);
+    });
+
+    it('treats a decrypt-to-empty result as corrupt and evicts it', () => {
+      const goodVault = new PassphraseVault(makeSafeStorage(), store);
+      goodVault.remember(USER, PASSPHRASE);
+
+      const emptySafeStorage = makeSafeStorage({ decryptString: () => '' });
+      const vault = new PassphraseVault(emptySafeStorage, store);
+      expect(vault.getRemembered(USER)).toEqual({ ok: false, reason: 'corrupt' });
+      expect(store._map.size).toBe(0);
+    });
+  });
+});

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,7 +1,13 @@
-import { app, BrowserWindow, ipcMain, powerMonitor, shell, type Tray } from 'electron';
+import { app, BrowserWindow, ipcMain, powerMonitor, safeStorage, shell, type Tray } from 'electron';
+import Store from 'electron-store';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { ServiceManager } from './service-manager.js';
+import {
+  PassphraseVault,
+  type PassphraseKeyValueStore,
+  type SafeStoragePort,
+} from './passphrase-vault.js';
 import { createTray } from './tray.js';
 import { getSavedBounds, trackWindowState } from './window-state.js';
 import { checkDependencies, showDependencyDialog } from './first-launch.js';
@@ -22,6 +28,20 @@ import {
 import { reportCrash } from './crash-reporter.js';
 
 const serviceManager = new ServiceManager();
+
+// OS-keychain-backed "remember my vault passphrase on this device" store (#401).
+// Persists the safeStorage-encrypted passphrase ciphertext in the OS userData
+// dir; only decryptable on this machine + user account. See passphrase-vault.ts.
+// Cast through the structural ports for the same reason desktop-preferences.ts
+// does — electron-store's ESM Conf inheritance doesn't survive `module: commonjs`.
+const passphraseStore = new Store<Record<string, string>>({
+  name: 'skytwin-passphrase-vault',
+}) as unknown as PassphraseKeyValueStore;
+const passphraseVault = new PassphraseVault(
+  safeStorage as unknown as SafeStoragePort,
+  passphraseStore,
+);
+
 let mainWindow: BrowserWindow | null = null;
 let splashWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
@@ -289,6 +309,40 @@ ipcMain.handle('read-dxt-file', async (_event, filePath: string) => {
   }
   const data = await fs.readFile(filePath);
   return { name: filePath.split(/[\\/]/).pop() ?? 'artifact.dxt', base64: data.toString('base64') };
+});
+
+// ── Credential-vault passphrase remember-on-device (#401) ────────────────────
+// Lets the renderer optionally cache the vault passphrase in the OS keychain so
+// a relaunch can auto-unlock. Plaintext never crosses the bridge to disk — the
+// main process encrypts via safeStorage before persisting. Unsupported
+// environments degrade gracefully (the renderer hides the prompt and keeps the
+// per-session passphrase behavior).
+ipcMain.handle('vault-passphrase-supported', () => passphraseVault.isSupported());
+
+ipcMain.handle('vault-passphrase-remember', (_event, userId: string, passphrase: string) => {
+  if (typeof userId !== 'string' || userId === '') {
+    return { ok: false, reason: 'empty_passphrase' as const };
+  }
+  if (typeof passphrase !== 'string') {
+    return { ok: false, reason: 'empty_passphrase' as const };
+  }
+  return passphraseVault.remember(userId, passphrase);
+});
+
+ipcMain.handle('vault-passphrase-get', (_event, userId: string) => {
+  if (typeof userId !== 'string' || userId === '') {
+    return { ok: false, reason: 'not_found' as const };
+  }
+  return passphraseVault.getRemembered(userId);
+});
+
+ipcMain.handle('vault-passphrase-has', (_event, userId: string) => {
+  if (typeof userId !== 'string' || userId === '') return false;
+  return passphraseVault.has(userId);
+});
+
+ipcMain.handle('vault-passphrase-forget', (_event, userId: string) => {
+  if (typeof userId === 'string' && userId !== '') passphraseVault.forget(userId);
 });
 
 app.on('open-file', (event, filePath) => {

--- a/apps/desktop/src/passphrase-vault.ts
+++ b/apps/desktop/src/passphrase-vault.ts
@@ -1,0 +1,164 @@
+/**
+ * passphrase-vault.ts — OS-keychain-backed "remember my passphrase" store (#401).
+ *
+ * The credential vault (`@skytwin/credential-vault`) encrypts OAuth tokens at
+ * rest with a scrypt-derived key. The derived key lives only in the API
+ * process's in-memory KeyCache, so the user must re-type their vault passphrase
+ * on every restart. This module lets the desktop app optionally remember that
+ * passphrase on the *local device* — and only the local device — so a relaunch
+ * can unlock the vault without a re-prompt.
+ *
+ * SECURITY MODEL
+ * ──────────────
+ * The passphrase is encrypted with Electron `safeStorage`, which is backed by
+ * the OS-native secret store:
+ *   - macOS   → Keychain
+ *   - Windows → DPAPI (Credential Manager)
+ *   - Linux   → Secret Service (libsecret) / kwallet
+ * The resulting ciphertext (NOT the plaintext) is persisted via the injected
+ * key-value store (electron-store in production, in the OS userData dir). Even
+ * with filesystem access to that store, the ciphertext is only decryptable on
+ * the same machine + user account that wrote it.
+ *
+ * GRACEFUL FALLBACK (AC: "if no, current behavior unchanged")
+ * ───────────────────────────────────────────────────────────
+ * On a headless Linux box, a freshly-installed distro with no Secret Service,
+ * or any environment where `safeStorage.isEncryptionAvailable()` is false, we
+ * MUST NOT persist the passphrase in plaintext. Instead every operation returns
+ * a typed `{ ok: false, reason: 'unsupported' }` and the renderer keeps the
+ * current behavior (prompt for the passphrase every session). We never weaken
+ * the boundary to a plaintext fallback.
+ *
+ * The class is dependency-injected (ports for safeStorage + the key-value
+ * store) so the core logic is unit-testable without spawning Electron.
+ */
+
+/** The subset of Electron's `safeStorage` this module depends on. */
+export interface SafeStoragePort {
+  isEncryptionAvailable(): boolean;
+  encryptString(plaintext: string): Buffer;
+  decryptString(ciphertext: Buffer): string;
+}
+
+/**
+ * The subset of a key-value store (electron-store) this module depends on.
+ * Values are base64-encoded safeStorage ciphertext strings.
+ */
+export interface PassphraseKeyValueStore {
+  get(key: string): string | undefined;
+  set(key: string, value: string): void;
+  delete(key: string): void;
+}
+
+/** Result of an attempt to read a remembered passphrase. */
+export type RememberedPassphraseResult =
+  | { ok: true; passphrase: string }
+  | { ok: false; reason: 'unsupported' | 'not_found' | 'corrupt' };
+
+/** Result of an attempt to remember / forget a passphrase. */
+export type RememberWriteResult =
+  | { ok: true }
+  | { ok: false; reason: 'unsupported' | 'empty_passphrase' };
+
+/**
+ * Storage-key prefix. Per-user so multiple device accounts each keep their own
+ * remembered passphrase without clobbering each other.
+ */
+const STORE_KEY_PREFIX = 'vault-passphrase:';
+
+function storeKeyFor(userId: string): string {
+  return `${STORE_KEY_PREFIX}${userId}`;
+}
+
+export class PassphraseVault {
+  private readonly safeStorage: SafeStoragePort;
+  private readonly store: PassphraseKeyValueStore;
+
+  constructor(safeStorage: SafeStoragePort, store: PassphraseKeyValueStore) {
+    this.safeStorage = safeStorage;
+    this.store = store;
+  }
+
+  /**
+   * Whether remembering the passphrase is supported on this device. False on
+   * platforms / environments where the OS secret store is unavailable (the
+   * renderer hides the "Remember on this device?" prompt in that case).
+   */
+  isSupported(): boolean {
+    try {
+      return this.safeStorage.isEncryptionAvailable();
+    } catch {
+      // Some Electron builds throw rather than return false when the platform
+      // backend is missing. Treat any failure as "not supported" — fail safe.
+      return false;
+    }
+  }
+
+  /**
+   * Encrypt + persist `passphrase` for `userId`. No-op-safe to call repeatedly
+   * (overwrites the previous ciphertext). Returns a typed failure when the OS
+   * secret store is unavailable or the passphrase is empty — never stores
+   * plaintext as a fallback.
+   */
+  remember(userId: string, passphrase: string): RememberWriteResult {
+    if (!this.isSupported()) {
+      return { ok: false, reason: 'unsupported' };
+    }
+    if (passphrase.length === 0) {
+      // Refuse to persist an empty passphrase — that's never a real unlock
+      // secret and would silently "unlock" with nothing.
+      return { ok: false, reason: 'empty_passphrase' };
+    }
+    const ciphertext = this.safeStorage.encryptString(passphrase);
+    this.store.set(storeKeyFor(userId), ciphertext.toString('base64'));
+    return { ok: true };
+  }
+
+  /**
+   * Decrypt the remembered passphrase for `userId`, if any. Returns a typed
+   * failure when unsupported, absent, or undecryptable (e.g. the keychain
+   * entry was rotated out from under us, or the store was copied to a
+   * different machine). On a `corrupt` result the caller should fall back to
+   * the passphrase prompt; we proactively evict the bad entry.
+   */
+  getRemembered(userId: string): RememberedPassphraseResult {
+    if (!this.isSupported()) {
+      return { ok: false, reason: 'unsupported' };
+    }
+    const stored = this.store.get(storeKeyFor(userId));
+    if (stored === undefined || stored === '') {
+      return { ok: false, reason: 'not_found' };
+    }
+    try {
+      const ciphertext = Buffer.from(stored, 'base64');
+      const passphrase = this.safeStorage.decryptString(ciphertext);
+      if (passphrase.length === 0) {
+        // Decrypted to nothing — treat as corrupt rather than handing back an
+        // empty unlock secret.
+        this.forget(userId);
+        return { ok: false, reason: 'corrupt' };
+      }
+      return { ok: true, passphrase };
+    } catch {
+      // Undecryptable on this machine/account — drop it so we stop retrying a
+      // permanently-broken entry, and fall back to the prompt.
+      this.forget(userId);
+      return { ok: false, reason: 'corrupt' };
+    }
+  }
+
+  /** Whether a remembered passphrase exists for `userId` (does not decrypt). */
+  has(userId: string): boolean {
+    const stored = this.store.get(storeKeyFor(userId));
+    return stored !== undefined && stored !== '';
+  }
+
+  /**
+   * Forget the remembered passphrase for `userId`. Idempotent — safe to call
+   * when nothing is stored. Works regardless of `isSupported()` so a user can
+   * always clear a stale entry.
+   */
+  forget(userId: string): void {
+    this.store.delete(storeKeyFor(userId));
+  }
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -50,6 +50,33 @@ contextBridge.exposeInMainWorld('skytwinDesktop', {
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
 
   /**
+   * Credential-vault passphrase "remember on this device" (#401).
+   *
+   * The passphrase is encrypted by the OS keychain (Electron safeStorage) in
+   * the main process before it ever touches disk — plaintext crosses this
+   * bridge only on the way in (remember) and out (get), never to storage.
+   *
+   * `vaultPassphraseSupported()` is false on environments without an OS secret
+   * store (e.g. headless Linux with no Secret Service); the renderer hides the
+   * "Remember on this device?" prompt and keeps the per-session behavior.
+   */
+  vaultPassphraseSupported: () =>
+    ipcRenderer.invoke('vault-passphrase-supported') as Promise<boolean>,
+  vaultPassphraseRemember: (userId: string, passphrase: string) =>
+    ipcRenderer.invoke('vault-passphrase-remember', userId, passphrase) as Promise<
+      { ok: true } | { ok: false; reason: 'unsupported' | 'empty_passphrase' }
+    >,
+  vaultPassphraseGet: (userId: string) =>
+    ipcRenderer.invoke('vault-passphrase-get', userId) as Promise<
+      | { ok: true; passphrase: string }
+      | { ok: false; reason: 'unsupported' | 'not_found' | 'corrupt' }
+    >,
+  vaultPassphraseHas: (userId: string) =>
+    ipcRenderer.invoke('vault-passphrase-has', userId) as Promise<boolean>,
+  vaultPassphraseForget: (userId: string) =>
+    ipcRenderer.invoke('vault-passphrase-forget', userId) as Promise<void>,
+
+  /**
    * Subscribe to idle state changes from the OS-level powerMonitor.
    * Returns an unsubscribe function. The renderer can use this to fire
    * proactive scans when the user goes idle, or to pause expensive work

--- a/apps/web/public/js/pages/credential-vault.js
+++ b/apps/web/public/js/pages/credential-vault.js
@@ -18,6 +18,96 @@ import { fetchJSON, escapeHtml } from '../api-client.js';
 import { showToast } from '../toast.js';
 import { KEY_USER_ID } from '../storage-keys.js';
 
+// ─── Desktop OS-keychain passphrase bridge (#401) ────────────────────────────
+// On the desktop app, `window.skytwinDesktop` exposes a passphrase store backed
+// by the OS keychain (Electron safeStorage). In pure-web mode these are all
+// no-ops, so the page falls back to the per-session passphrase prompt with no
+// behavioral change.
+
+function desktopBridge() {
+  return (typeof window !== 'undefined' && window.skytwinDesktop?.isDesktop)
+    ? window.skytwinDesktop
+    : null;
+}
+
+/** Whether "remember on this device" is available (desktop + OS keychain). */
+async function rememberSupported() {
+  const bridge = desktopBridge();
+  if (!bridge?.vaultPassphraseSupported) return false;
+  try {
+    return await bridge.vaultPassphraseSupported();
+  } catch {
+    return false;
+  }
+}
+
+/** Persist the passphrase in the OS keychain. Returns true on success. */
+async function rememberPassphrase(userId, passphrase) {
+  const bridge = desktopBridge();
+  if (!bridge?.vaultPassphraseRemember) return false;
+  try {
+    const result = await bridge.vaultPassphraseRemember(userId, passphrase);
+    return result?.ok === true;
+  } catch {
+    return false;
+  }
+}
+
+/** Read the remembered passphrase for this user, or null if none/unsupported. */
+async function getRememberedPassphrase(userId) {
+  const bridge = desktopBridge();
+  if (!bridge?.vaultPassphraseGet) return null;
+  try {
+    const result = await bridge.vaultPassphraseGet(userId);
+    return result?.ok === true ? result.passphrase : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether a remembered passphrase exists for this user. */
+async function hasRememberedPassphrase(userId) {
+  const bridge = desktopBridge();
+  if (!bridge?.vaultPassphraseHas) return false;
+  try {
+    return await bridge.vaultPassphraseHas(userId);
+  } catch {
+    return false;
+  }
+}
+
+/** Forget the remembered passphrase. */
+async function forgetPassphrase(userId) {
+  const bridge = desktopBridge();
+  if (!bridge?.vaultPassphraseForget) return;
+  try {
+    await bridge.vaultPassphraseForget(userId);
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * After a successful init/unlock, offer to remember the passphrase on this
+ * device. Only prompts on desktop where the OS keychain is available and a
+ * passphrase isn't already remembered (AC: "First unlock → Remember on this
+ * device?"; "If no, current behavior unchanged").
+ */
+async function maybeOfferRemember(userId, passphrase) {
+  if (!userId || !passphrase) return;
+  if (!(await rememberSupported())) return;
+  if (await hasRememberedPassphrase(userId)) return;
+  const yes = window.confirm(
+    'Remember this passphrase on this device?\n\n'
+    + 'It will be stored in your operating system keychain (encrypted) so the '
+    + 'vault unlocks automatically next time you open SkyTwin on this computer. '
+    + 'It is never uploaded and only works on this device.',
+  );
+  if (!yes) return;
+  const ok = await rememberPassphrase(userId, passphrase);
+  showToast(ok ? 'Passphrase remembered on this device' : 'Could not save to the OS keychain', ok ? 'success' : 'error');
+}
+
 // ─── Singleton delegator ───────────────────────────────────────────────────
 
 let _credentialVaultListenerWired = false;
@@ -55,6 +145,7 @@ function ensureCredentialVaultListener() {
           body: JSON.stringify({ passphrase, userId }),
         });
         showToast('Vault initialized and unlocked');
+        await maybeOfferRemember(userId, passphrase);
         const container = document.getElementById('page-content');
         if (container) await renderCredentialVault(container, userId);
       } catch (err) {
@@ -128,11 +219,25 @@ function ensureCredentialVaultListener() {
           body: JSON.stringify({ passphrase, userId }),
         });
         showToast('Vault unlocked');
+        await maybeOfferRemember(userId, passphrase);
         const container = document.getElementById('page-content');
         if (container) await renderCredentialVault(container, userId);
       } catch (err) {
         showToast(err.friendlyMessage ?? 'Failed to unlock vault', 'error');
       }
+      return;
+    }
+
+    if (action === 'vault-forget-passphrase') {
+      const ok = window.confirm(
+        'Forget the passphrase saved on this device?\n\n'
+        + 'You will need to type it again next time you unlock the vault.',
+      );
+      if (!ok) return;
+      await forgetPassphrase(userId);
+      showToast('Removed the remembered passphrase from this device');
+      const container = document.getElementById('page-content');
+      if (container) await renderCredentialVault(container, userId);
       return;
     }
   });
@@ -160,9 +265,32 @@ export async function renderCredentialVault(container, userId) {
   }
 
   const initialized = status?.initialized ?? false;
-  const unlocked = status?.unlocked ?? false;
+  let unlocked = status?.unlocked ?? false;
   const keyVersion = status?.keyVersion ?? null;
   const lastRotated = status?.lastRotated ?? null;
+
+  // Desktop auto-unlock (#401): if the vault is initialized + locked and the
+  // user opted to remember the passphrase on this device, decrypt it from the
+  // OS keychain and unlock silently. A corrupt/wrong remembered passphrase
+  // falls through to the manual unlock form below — no behavior change.
+  const remembered = await hasRememberedPassphrase(userId);
+  if (initialized && !unlocked && remembered) {
+    const passphrase = await getRememberedPassphrase(userId);
+    if (passphrase) {
+      try {
+        await fetchJSON(`/api/credential-vault/unlock`, {
+          method: 'POST',
+          body: JSON.stringify({ passphrase, userId }),
+        });
+        unlocked = true;
+        showToast('Vault unlocked from this device');
+      } catch {
+        // Remembered passphrase no longer valid (e.g. rotated elsewhere).
+        // Drop it so we stop auto-retrying, and fall back to the prompt.
+        await forgetPassphrase(userId);
+      }
+    }
+  }
 
   const statusBadge = initialized
     ? `<span style="color:var(--success);font-weight:600;">Initialized</span>`
@@ -257,6 +385,15 @@ export async function renderCredentialVault(container, userId) {
     </div>
   ` : '';
 
+  // Re-check after the auto-unlock attempt above (which forgets a stale entry).
+  const rememberedNow = initialized ? await hasRememberedPassphrase(userId) : false;
+  const rememberSection = rememberedNow ? `
+    <div style="margin-top:0.5rem;display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap;">
+      <span style="color:var(--muted)">Passphrase remembered on this device (stored in the OS keychain).</span>
+      <button class="btn btn-outline btn-sm" data-action="vault-forget-passphrase">Forget on this device</button>
+    </div>
+  ` : '';
+
   container.innerHTML = `
     <div class="card">
       <div class="card-header">
@@ -272,6 +409,7 @@ export async function renderCredentialVault(container, userId) {
         ${lastRotatedDisplay}
       </div>
       ${lockSection}
+      ${rememberSection}
     </div>
     ${initSection}
     ${unlockSection}


### PR DESCRIPTION
## What changed

Adds an optional **"remember my vault passphrase on this device"** path so a desktop relaunch can auto-unlock the credential vault without re-typing the scrypt passphrase. The passphrase is encrypted with **Electron `safeStorage`** (macOS Keychain / Windows DPAPI / Linux Secret Service) and only the ciphertext is persisted in the OS userData dir — never plaintext.

- **`apps/desktop/src/passphrase-vault.ts`** — new `PassphraseVault`. Dependency-injected (`SafeStoragePort` + a key-value store port) so the core is unit-testable without spawning Electron. Typed result objects for expected failures; per-user keying so multiple device accounts don't clobber each other.
- **`apps/desktop/src/main.ts`** — instantiates it against the real `safeStorage` + a dedicated `electron-store` (`skytwin-passphrase-vault`) and exposes five IPC handlers (`vault-passphrase-supported/remember/get/has/forget`), each validating the `userId`/`passphrase` inputs.
- **`apps/desktop/src/preload.ts`** — bridges them to the renderer (`vaultPassphraseSupported/Remember/Get/Has/Forget`).
- **`apps/web/public/js/pages/credential-vault.js`** — prompts **"Remember this passphrase on this device?"** after a successful init/unlock (desktop + keychain only; pure-web is a no-op), **auto-unlocks** on page load when a passphrase is remembered, shows a **"Passphrase remembered on this device"** indicator with a **Forget on this device** button, and proactively drops a remembered passphrase that no longer unlocks (e.g. rotated elsewhere) so it falls back cleanly to the prompt.
- **`apps/desktop/src/__mocks__/electron.ts`** — adds a `safeStorage` stub.

## Acceptance criteria

- [x] First unlock → "Remember on this device?" prompt — fires after a successful init/unlock when on desktop and the OS keychain is available.
- [x] If yes, passphrase stored in OS keychain — `safeStorage.encryptString` → ciphertext persisted; plaintext never written.
- [x] If no, current behavior unchanged — declining stores nothing; and when `safeStorage.isEncryptionAvailable()` is false the prompt is hidden entirely and the per-session passphrase behavior is unchanged. **We never persist plaintext as a fallback.**

## Tests added

`apps/desktop/src/__tests__/passphrase-vault.test.ts` — 12 vitest cases:
- happy path round-trip (asserts the stored bytes are **not** the plaintext), per-user keying, overwrite, `has()`, `forget()` idempotency
- graceful fallback: unsupported `remember`/`getRemembered`, and `isSupported()` fail-safe when `isEncryptionAvailable()` throws
- edge cases: empty-passphrase refusal, `not_found`, undecryptable entry → `corrupt` + evicted, decrypt-to-empty → `corrupt` + evicted

## Verification

- `vitest run` on the desktop package: passphrase-vault suite green (12/12); full desktop unit suite green except 3 pre-existing `integration-live.test.ts` cases that require a running API server (unrelated to this change).
- `tsc --noEmit -p apps/desktop/tsconfig.json` clean (run against the installed dep tree).

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)