### PR TITLE
feat(desktop): native macOS menu bar (#406)

### DIFF
--- a/apps/desktop/src/__mocks__/electron.ts
+++ b/apps/desktop/src/__mocks__/electron.ts
@@ -30,6 +30,7 @@ const Tray = vi.fn().mockImplementation(() => ({
 // Menu stub
 const Menu = {
   buildFromTemplate: vi.fn((template: unknown[]) => ({ template })),
+  setApplicationMenu: vi.fn(),
 };
 
 // dialog stub

--- a/apps/desktop/src/__tests__/app-menu.test.ts
+++ b/apps/desktop/src/__tests__/app-menu.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildAppMenuTemplate,
+  toElectronTemplate,
+  DOCUMENTATION_URL,
+  REPORT_ISSUE_URL,
+  type AppMenuItem,
+  type AppMenuHandlers,
+  type AppMenuOptions,
+} from '../app-menu.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function topLevelLabels(template: AppMenuItem[]): string[] {
+  return template.filter((i) => i.label !== undefined).map((i) => i.label!);
+}
+
+function menuByLabel(template: AppMenuItem[], label: string): AppMenuItem | undefined {
+  return template.find((i) => i.label === label);
+}
+
+function findAction(items: AppMenuItem[], action: string): AppMenuItem | undefined {
+  for (const item of items) {
+    if (item.action === action) return item;
+    if (item.submenu) {
+      const nested = findAction(item.submenu, action);
+      if (nested) return nested;
+    }
+  }
+  return undefined;
+}
+
+function hasRole(items: AppMenuItem[], role: string): boolean {
+  for (const item of items) {
+    if (item.role === role) return true;
+    if (item.submenu && hasRole(item.submenu, role)) return true;
+  }
+  return false;
+}
+
+const macDev: AppMenuOptions = { platform: 'darwin', isPackaged: false, isPaused: false };
+const macProd: AppMenuOptions = { platform: 'darwin', isPackaged: true, isPaused: false };
+const winDev: AppMenuOptions = { platform: 'win32', isPackaged: false, isPaused: false };
+const winProd: AppMenuOptions = { platform: 'win32', isPackaged: true, isPaused: false };
+
+// ---------------------------------------------------------------------------
+// buildAppMenuTemplate — structure
+// ---------------------------------------------------------------------------
+
+describe('buildAppMenuTemplate — macOS structure', () => {
+  const template = buildAppMenuTemplate(macDev);
+
+  it('leads with the SkyTwin app menu on macOS', () => {
+    expect(template[0].label).toBe('SkyTwin');
+  });
+
+  it('includes File, Edit, View, Window, Help menus', () => {
+    const labels = topLevelLabels(template);
+    for (const m of ['SkyTwin', 'File', 'Edit', 'View', 'Window', 'Help']) {
+      expect(labels).toContain(m);
+    }
+  });
+
+  it('app menu holds about, preferences, hide, and quit', () => {
+    const appMenu = menuByLabel(template, 'SkyTwin')!;
+    expect(hasRole(appMenu.submenu!, 'about')).toBe(true);
+    expect(hasRole(appMenu.submenu!, 'hide')).toBe(true);
+    expect(hasRole(appMenu.submenu!, 'quit')).toBe(true);
+    expect(findAction(appMenu.submenu!, 'show-preferences')).toBeDefined();
+  });
+
+  it('File menu does NOT duplicate Quit on macOS (lives in app menu)', () => {
+    const fileMenu = menuByLabel(template, 'File')!;
+    expect(hasRole(fileMenu.submenu!, 'quit')).toBe(false);
+  });
+});
+
+describe('buildAppMenuTemplate — non-macOS structure', () => {
+  const template = buildAppMenuTemplate(winDev);
+
+  it('does NOT have a leading app menu on Windows/Linux', () => {
+    expect(template[0].label).toBe('File');
+  });
+
+  it('File menu owns Preferences and Quit on non-mac', () => {
+    const fileMenu = menuByLabel(template, 'File')!;
+    expect(findAction(fileMenu.submenu!, 'show-preferences')).toBeDefined();
+    expect(hasRole(fileMenu.submenu!, 'quit')).toBe(true);
+  });
+
+  it('includes File, Edit, View, Window, Help', () => {
+    const labels = topLevelLabels(template);
+    for (const m of ['File', 'Edit', 'View', 'Window', 'Help']) {
+      expect(labels).toContain(m);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance criteria — required items present
+// ---------------------------------------------------------------------------
+
+describe('buildAppMenuTemplate — Edit menu (standard roles)', () => {
+  it('has cut/copy/paste/selectAll/undo/redo', () => {
+    const template = buildAppMenuTemplate(macDev);
+    const edit = menuByLabel(template, 'Edit')!;
+    for (const role of ['undo', 'redo', 'cut', 'copy', 'paste', 'selectAll']) {
+      expect(hasRole(edit.submenu!, role)).toBe(true);
+    }
+  });
+});
+
+describe('buildAppMenuTemplate — View menu (Reload + dev-only DevTools)', () => {
+  it('always exposes Reload', () => {
+    const view = menuByLabel(buildAppMenuTemplate(macDev), 'View')!;
+    expect(findAction(view.submenu!, 'reload')).toBeDefined();
+  });
+
+  it('shows Toggle Developer Tools in development builds', () => {
+    const view = menuByLabel(buildAppMenuTemplate(macDev), 'View')!;
+    expect(findAction(view.submenu!, 'toggle-devtools')).toBeDefined();
+  });
+
+  it('HIDES Toggle Developer Tools in packaged (production) builds', () => {
+    const viewMac = menuByLabel(buildAppMenuTemplate(macProd), 'View')!;
+    const viewWin = menuByLabel(buildAppMenuTemplate(winProd), 'View')!;
+    expect(findAction(viewMac.submenu!, 'toggle-devtools')).toBeUndefined();
+    expect(findAction(viewWin.submenu!, 'toggle-devtools')).toBeUndefined();
+    // Reload still present in production.
+    expect(findAction(viewMac.submenu!, 'reload')).toBeDefined();
+  });
+});
+
+describe('buildAppMenuTemplate — Window menu', () => {
+  it('has Minimize and Zoom', () => {
+    const win = menuByLabel(buildAppMenuTemplate(macDev), 'Window')!;
+    expect(hasRole(win.submenu!, 'minimize')).toBe(true);
+    expect(hasRole(win.submenu!, 'zoom')).toBe(true);
+  });
+});
+
+describe('buildAppMenuTemplate — Help menu', () => {
+  it('has Documentation and Report Issue on every platform', () => {
+    for (const opts of [macDev, winDev]) {
+      const help = menuByLabel(buildAppMenuTemplate(opts), 'Help')!;
+      const doc = findAction(help.submenu!, 'open-documentation');
+      const issue = findAction(help.submenu!, 'report-issue');
+      expect(doc?.label).toBe('Documentation');
+      expect(issue?.label).toBe('Report Issue');
+    }
+  });
+});
+
+describe('buildAppMenuTemplate — SkyTwin actions', () => {
+  it('exposes Open Dashboard, Latest Briefing, Pause Twin', () => {
+    const template = buildAppMenuTemplate(macDev);
+    expect(findAction(template, 'open-dashboard')).toBeDefined();
+    expect(findAction(template, 'latest-briefing')).toBeDefined();
+    expect(findAction(template, 'pause-resume')).toBeDefined();
+  });
+
+  it('Pause label reads "Pause Twin" when running', () => {
+    const item = findAction(buildAppMenuTemplate({ ...macDev, isPaused: false }), 'pause-resume')!;
+    expect(item.label).toBe('Pause Twin');
+  });
+
+  it('Pause label reads "Resume Twin" when paused', () => {
+    const item = findAction(buildAppMenuTemplate({ ...macDev, isPaused: true }), 'pause-resume')!;
+    expect(item.label).toBe('Resume Twin');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toElectronTemplate — data → Electron mapping
+// ---------------------------------------------------------------------------
+
+function makeHandlers(): { handlers: AppMenuHandlers; spies: Record<string, ReturnType<typeof vi.fn>> } {
+  const spies: Record<string, ReturnType<typeof vi.fn>> = {
+    'show-preferences': vi.fn(),
+    'open-dashboard': vi.fn(),
+    'latest-briefing': vi.fn(),
+    'pause-resume': vi.fn(),
+    'open-documentation': vi.fn(),
+    'report-issue': vi.fn(),
+    'reload': vi.fn(),
+    'toggle-devtools': vi.fn(),
+  };
+  return { handlers: spies as unknown as AppMenuHandlers, spies };
+}
+
+describe('toElectronTemplate', () => {
+  it('maps separators to { type: "separator" }', () => {
+    const { handlers } = makeHandlers();
+    const out = toElectronTemplate([{ separator: true }], handlers);
+    expect(out[0]).toEqual({ type: 'separator' });
+  });
+
+  it('passes built-in roles straight through', () => {
+    const { handlers } = makeHandlers();
+    const out = toElectronTemplate([{ role: 'copy' }], handlers);
+    expect(out[0].role).toBe('copy');
+    expect(out[0].click).toBeUndefined();
+  });
+
+  it('binds named actions to the matching handler click', () => {
+    const { handlers, spies } = makeHandlers();
+    const out = toElectronTemplate(
+      [{ label: 'Documentation', action: 'open-documentation' }],
+      handlers,
+    );
+    expect(typeof out[0].click).toBe('function');
+    (out[0].click as () => void)();
+    expect(spies['open-documentation']).toHaveBeenCalledTimes(1);
+  });
+
+  it('recurses into submenus', () => {
+    const { handlers, spies } = makeHandlers();
+    const out = toElectronTemplate(
+      [{ label: 'Help', submenu: [{ label: 'Report Issue', action: 'report-issue' }] }],
+      handlers,
+    );
+    const sub = out[0].submenu as Array<{ click?: () => void }>;
+    expect(typeof sub[0].click).toBe('function');
+    sub[0].click!();
+    expect(spies['report-issue']).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves accelerators', () => {
+    const { handlers } = makeHandlers();
+    const out = toElectronTemplate(
+      [{ label: 'Preferences…', action: 'show-preferences', accelerator: 'Cmd+,' }],
+      handlers,
+    );
+    expect(out[0].accelerator).toBe('Cmd+,');
+  });
+
+  it('converts a full mac template end-to-end without throwing', () => {
+    const { handlers } = makeHandlers();
+    const out = toElectronTemplate(buildAppMenuTemplate(macDev), handlers);
+    expect(out.length).toBeGreaterThan(0);
+    const labels = out.map((i) => i.label);
+    expect(labels).toContain('SkyTwin');
+    expect(labels).toContain('Help');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URL constants
+// ---------------------------------------------------------------------------
+
+describe('Help URLs', () => {
+  it('point at the GitHub repo and are https', () => {
+    expect(DOCUMENTATION_URL).toMatch(/^https:\/\/github\.com\/jayzalowitz\/skytwin/);
+    expect(REPORT_ISSUE_URL).toMatch(/^https:\/\/github\.com\/jayzalowitz\/skytwin\/issues/);
+  });
+});

--- a/apps/desktop/src/app-menu.ts
+++ b/apps/desktop/src/app-menu.ts
@@ -1,0 +1,282 @@
+import { Menu, shell, app, type BrowserWindow, type MenuItemConstructorOptions } from 'electron';
+
+// ---------------------------------------------------------------------------
+// Native application menu (menu bar) for the SkyTwin desktop app.
+//
+// Follows the same split as tray.ts: a pure-data template builder
+// (`buildAppMenuTemplate`) that takes no Electron API calls and is fully
+// unit-testable, plus a thin Electron wrapper (`applyAppMenu`) that converts
+// the data template into real Electron menu items and installs it as the
+// application menu. The wrapper is NOT unit-tested (it needs a running
+// Electron process); tests exercise `buildAppMenuTemplate` directly.
+// ---------------------------------------------------------------------------
+
+/** Documentation + issue-tracker URLs surfaced in the Help menu. */
+export const DOCUMENTATION_URL = 'https://github.com/jayzalowitz/skytwin#readme';
+export const REPORT_ISSUE_URL = 'https://github.com/jayzalowitz/skytwin/issues/new';
+
+/**
+ * Named actions a menu item can trigger. Keeping these as a string union
+ * (rather than inline click handlers) means the template is plain data —
+ * the Electron wrapper maps each action to a concrete handler, exactly the
+ * way the tray menu does. Items that use a built-in Electron `role`
+ * (copy/paste/minimize/zoom/quit/etc.) carry no action.
+ */
+export type AppMenuAction =
+  | 'show-preferences'
+  | 'open-dashboard'
+  | 'latest-briefing'
+  | 'pause-resume'
+  | 'open-documentation'
+  | 'report-issue'
+  | 'reload'
+  | 'toggle-devtools';
+
+/**
+ * A single menu item in the platform-agnostic template. Either:
+ *   - a `separator`, or
+ *   - a `submenu` group (top-level menu bar entries), or
+ *   - a leaf item carrying an optional built-in `role` and/or a named `action`.
+ *
+ * Data only — no Electron API calls and no click closures.
+ */
+export interface AppMenuItem {
+  /** Display label. Omitted for separators and for the macOS app menu (uses app name). */
+  label?: string;
+  /** A separator line. When true, all other fields are ignored. */
+  separator?: boolean;
+  /** Built-in Electron role (e.g. 'copy', 'minimize', 'quit'). */
+  role?: MenuItemConstructorOptions['role'];
+  /** Named SkyTwin action; mapped to a handler by `applyAppMenu`. */
+  action?: AppMenuAction;
+  /** Keyboard accelerator (e.g. 'CmdOrCtrl+,'). */
+  accelerator?: string;
+  /** Nested items — present on top-level menu bar entries. */
+  submenu?: AppMenuItem[];
+}
+
+/** Inputs that change the menu shape. */
+export interface AppMenuOptions {
+  /** Platform string (process.platform). Drives the macOS app-menu placement. */
+  platform: NodeJS.Platform;
+  /** Whether the build is packaged (production). Dev-only items (DevTools) are hidden in production. */
+  isPackaged: boolean;
+  /** Whether the twin is currently paused — flips the "Pause / Resume" label. */
+  isPaused: boolean;
+}
+
+const sep: AppMenuItem = { separator: true };
+
+/**
+ * Build the platform-agnostic application-menu template.
+ *
+ * macOS gets a leading app menu (bearing the app name) holding
+ * About / Preferences / Hide / Quit per Apple HIG; other platforms fold
+ * Quit + Preferences into the File menu. Help carries Documentation and
+ * Report Issue on every platform. DevTools appears only in non-packaged
+ * (development) builds.
+ */
+export function buildAppMenuTemplate(options: AppMenuOptions): AppMenuItem[] {
+  const { platform, isPackaged, isPaused } = options;
+  const isMac = platform === 'darwin';
+
+  const template: AppMenuItem[] = [];
+
+  // SkyTwin actions shared between the macOS app menu and the non-mac File menu.
+  const skytwinActions: AppMenuItem[] = [
+    { label: 'Open Dashboard', action: 'open-dashboard', accelerator: 'CmdOrCtrl+D' },
+    { label: 'Latest Briefing', action: 'latest-briefing', accelerator: 'CmdOrCtrl+B' },
+    {
+      label: isPaused ? 'Resume Twin' : 'Pause Twin',
+      action: 'pause-resume',
+      accelerator: 'CmdOrCtrl+Shift+P',
+    },
+  ];
+
+  if (isMac) {
+    // macOS app menu — first menu, labelled with the app name automatically.
+    template.push({
+      label: 'SkyTwin',
+      submenu: [
+        { role: 'about' },
+        sep,
+        { label: 'Preferences…', action: 'show-preferences', accelerator: 'Cmd+,' },
+        sep,
+        ...skytwinActions,
+        sep,
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        sep,
+        { role: 'quit' },
+      ],
+    });
+  }
+
+  // File menu. On macOS Quit/Preferences live in the app menu, so File holds
+  // the SkyTwin actions; on other platforms File also owns Preferences + Quit.
+  const fileSubmenu: AppMenuItem[] = isMac
+    ? [...skytwinActions]
+    : [
+        { label: 'Preferences…', action: 'show-preferences', accelerator: 'Ctrl+,' },
+        sep,
+        ...skytwinActions,
+        sep,
+        { role: 'quit' },
+      ];
+  template.push({ label: 'File', submenu: fileSubmenu });
+
+  // Edit menu — standard built-in roles.
+  template.push({
+    label: 'Edit',
+    submenu: [
+      { role: 'undo' },
+      { role: 'redo' },
+      sep,
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { role: 'selectAll' },
+    ],
+  });
+
+  // View menu — Reload always; DevTools only in development builds.
+  const viewSubmenu: AppMenuItem[] = [
+    { label: 'Reload', action: 'reload', accelerator: 'CmdOrCtrl+R' },
+  ];
+  if (!isPackaged) {
+    viewSubmenu.push({
+      label: 'Toggle Developer Tools',
+      action: 'toggle-devtools',
+      accelerator: isMac ? 'Alt+Cmd+I' : 'Ctrl+Shift+I',
+    });
+  }
+  template.push({ label: 'View', submenu: viewSubmenu });
+
+  // Window menu — standard window roles.
+  template.push({
+    label: 'Window',
+    submenu: [
+      { role: 'minimize' },
+      { role: 'zoom' },
+      ...(isMac ? [sep, { role: 'front' as const }] : [{ role: 'close' as const }]),
+    ],
+  });
+
+  // Help menu — Documentation + Report Issue on every platform.
+  template.push({
+    label: 'Help',
+    submenu: [
+      { label: 'Documentation', action: 'open-documentation' },
+      { label: 'Report Issue', action: 'report-issue' },
+    ],
+  });
+
+  return template;
+}
+
+/** Handlers the Electron wrapper invokes for each named action. */
+export interface AppMenuHandlers {
+  'show-preferences': () => void;
+  'open-dashboard': () => void;
+  'latest-briefing': () => void;
+  'pause-resume': () => void;
+  'open-documentation': () => void;
+  'report-issue': () => void;
+  'reload': () => void;
+  'toggle-devtools': () => void;
+}
+
+/**
+ * Convert an AppMenuItem[] template into Electron MenuItemConstructorOptions[],
+ * binding each named action to its handler. Recurses into submenus.
+ *
+ * Exported for testing the data→Electron mapping shape without installing a
+ * real menu. Items with a built-in `role` pass it straight through; named
+ * actions become a `click` bound to the matching handler.
+ */
+export function toElectronTemplate(
+  items: AppMenuItem[],
+  handlers: AppMenuHandlers,
+): MenuItemConstructorOptions[] {
+  return items.map((item): MenuItemConstructorOptions => {
+    if (item.separator) {
+      return { type: 'separator' };
+    }
+    const out: MenuItemConstructorOptions = {};
+    if (item.label !== undefined) out.label = item.label;
+    if (item.role !== undefined) out.role = item.role;
+    if (item.accelerator !== undefined) out.accelerator = item.accelerator;
+    if (item.action !== undefined) {
+      out.click = handlers[item.action];
+    }
+    if (item.submenu !== undefined) {
+      out.submenu = toElectronTemplate(item.submenu, handlers);
+    }
+    return out;
+  });
+}
+
+/**
+ * Build the application menu from the current options and install it as the
+ * global application menu via `Menu.setApplicationMenu`.
+ *
+ * This wrapper is NOT unit-tested in this PR — it requires a running Electron
+ * process. Tests call `buildAppMenuTemplate` / `toElectronTemplate` directly.
+ *
+ * Navigation actions drive the loaded web dashboard via `executeJavaScript`
+ * (the same mechanism the tray uses) so the menu and tray stay consistent.
+ */
+export function applyAppMenu(
+  mainWindow: BrowserWindow,
+  options: Pick<AppMenuOptions, 'isPaused'>,
+  callbacks: {
+    onShowPreferences?: () => void;
+    onPauseResume: () => void;
+  },
+): void {
+  function navigate(hash: string): void {
+    if (mainWindow.isDestroyed()) return;
+    mainWindow.show();
+    mainWindow.focus();
+    // JSON.stringify keeps the hash a valid, injection-safe JS string literal.
+    mainWindow.webContents
+      .executeJavaScript(`location.hash = ${JSON.stringify(hash)}`)
+      .catch(() => {
+        /* renderer may have navigated/closed mid-call — ignore */
+      });
+  }
+
+  const handlers: AppMenuHandlers = {
+    'show-preferences': () => {
+      if (callbacks.onShowPreferences) {
+        callbacks.onShowPreferences();
+      } else {
+        navigate('#/settings');
+      }
+    },
+    'open-dashboard': () => navigate('#/'),
+    'latest-briefing': () => navigate('#/briefing'),
+    'pause-resume': () => callbacks.onPauseResume(),
+    'open-documentation': () => {
+      void shell.openExternal(DOCUMENTATION_URL);
+    },
+    'report-issue': () => {
+      void shell.openExternal(REPORT_ISSUE_URL);
+    },
+    'reload': () => {
+      if (!mainWindow.isDestroyed()) mainWindow.webContents.reload();
+    },
+    'toggle-devtools': () => {
+      if (!mainWindow.isDestroyed()) mainWindow.webContents.toggleDevTools();
+    },
+  };
+
+  const template = buildAppMenuTemplate({
+    platform: process.platform,
+    isPackaged: app.isPackaged,
+    isPaused: options.isPaused,
+  });
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(toElectronTemplate(template, handlers)));
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -9,6 +9,7 @@ import {
   type SafeStoragePort,
 } from './passphrase-vault.js';
 import { createTray } from './tray.js';
+import { applyAppMenu } from './app-menu.js';
 import { getSavedBounds, trackWindowState } from './window-state.js';
 import { checkDependencies, showDependencyDialog } from './first-launch.js';
 import { AutoUpdateController, defaultAutoUpdateConfig } from './auto-update.js';
@@ -133,6 +134,32 @@ function createMainWindow(): BrowserWindow {
   return win;
 }
 
+/**
+ * (Re)install the native application menu. Called once after the main window
+ * is created and again after pause/resume so the "Pause / Resume Twin" label
+ * stays in sync with the worker's actual state.
+ */
+function refreshAppMenu(): void {
+  if (mainWindow === null || mainWindow.isDestroyed()) return;
+  applyAppMenu(
+    mainWindow,
+    { isPaused: serviceManager.isPaused() },
+    {
+      onPauseResume: async () => {
+        // Mirror the tray + IPC behavior: a menu-driven pause/resume is a
+        // manual user choice, so clear the idle-pause auto-flag.
+        idlePauseController.onManualPauseChange();
+        if (serviceManager.isPaused()) {
+          await serviceManager.resume();
+        } else {
+          await serviceManager.pause();
+        }
+        refreshAppMenu();
+      },
+    },
+  );
+}
+
 async function runFirstLaunchChecks(): Promise<boolean> {
   const missing = checkDependencies();
   if (missing.length > 0) {
@@ -158,6 +185,10 @@ async function startApp(): Promise<void> {
 
   // Set up tray
   tray = createTray(mainWindow, serviceManager);
+
+  // Install the native application menu bar (File / Edit / View / Window /
+  // Help + SkyTwin actions). Re-installed on pause/resume to flip the label.
+  refreshAppMenu();
 
   // Wire first-launch extraction progress (#383) so the splash shows
   // a real progress bar instead of a spinner. The splash's
@@ -269,6 +300,9 @@ ipcMain.handle('pause-twin', async () => {
   // a subsequent "active" event doesn't auto-resume the user's choice.
   idlePauseController.onManualPauseChange();
   await serviceManager.pause();
+  // Keep the menu-bar "Pause / Resume Twin" label in sync with a pause
+  // initiated from the dashboard UI.
+  refreshAppMenu();
   return serviceManager.getStatus();
 });
 ipcMain.handle('resume-twin', async () => {
@@ -277,6 +311,7 @@ ipcMain.handle('resume-twin', async () => {
   // (or the next poll tick from idle-bridge) will re-evaluate cleanly.
   idlePauseController.onManualPauseChange();
   await serviceManager.resume();
+  refreshAppMenu();
   return serviceManager.getStatus();
 });
 


### PR DESCRIPTION
## What changed

Implements a native application menu bar for the Electron desktop app, replacing the Electron default menu.

New `apps/desktop/src/app-menu.ts` follows the established `tray.ts` split:
- **`buildAppMenuTemplate(options)`** — a pure-data template builder (inputs: `platform`, `isPackaged`, `isPaused`). No Electron API calls, fully unit-testable.
- **`toElectronTemplate(items, handlers)`** — maps the data template to `MenuItemConstructorOptions[]`, binding named actions to handlers (separators/roles pass through; recurses submenus).
- **`applyAppMenu(...)`** — thin Electron wrapper that builds the template for the current platform and installs it via `Menu.setApplicationMenu(Menu.buildFromTemplate(...))`.

Menu structure:
- **macOS app menu** — About / Preferences… / SkyTwin actions / Hide / Quit (per Apple HIG).
- **File** — Preferences + Quit on Windows/Linux; SkyTwin actions on macOS (Quit lives in the app menu there).
- **Edit** — standard built-in roles (undo/redo/cut/copy/paste/selectAll).
- **View** — Reload always; **Toggle Developer Tools only in non-packaged (dev) builds**.
- **Window** — Minimize / Zoom (+ Front on mac, Close elsewhere).
- **Help** — Documentation, Report Issue → GitHub via `shell.openExternal` (hardcoded https URLs).
- **SkyTwin actions** — Open Dashboard (`Cmd+D`), Latest Briefing (`Cmd+B`), Pause/Resume Twin (`Cmd+Shift+P`).

Wired into `main.ts` via `refreshAppMenu()` after window creation and re-applied on pause/resume (both menu-driven and dashboard-IPC-driven) so the "Pause / Resume Twin" label stays in sync. Navigation reuses the renderer `location.hash` mechanism with `JSON.stringify` escaping (same as the tray); menu pause/resume clears the idle-pause auto-flag to match the existing IPC + tray behavior.

## Acceptance criteria

- [x] Native menu bar with **File** (Quit, Preferences)
- [x] **Edit** (standard roles)
- [x] **View** (Reload, DevTools in dev only)
- [x] **Window** (Minimize, Zoom)
- [x] **Help** (Documentation, Report Issue)
- [x] Plus SkyTwin actions (Open Dashboard, Latest Briefing, Pause/Resume)

## Tests

23 new tests in `apps/desktop/src/__tests__/app-menu.test.ts`:
- mac vs non-mac structure (app menu placement, no duplicate Quit on mac)
- Edit standard roles present
- View Reload always; **DevTools hidden in packaged builds** (edge case)
- Window Minimize/Zoom; Help Documentation/Report Issue on every platform
- Pause-label flip (running → "Pause Twin", paused → "Resume Twin")
- `toElectronTemplate` data→Electron mapping (separators, roles, action→click, submenu recursion, accelerators)

`pnpm --filter skytwin-desktop test`: my 23 tests pass; `tsc --noEmit -p apps/desktop/tsconfig.json` is clean. The only failing tests in the suite are the 3 pre-existing `integration-live.test.ts` cases that require a running API server + DB on localhost (unrelated to this change; this worktree shares a machine with other agents' API servers).

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)