### PR TITLE
feat(demo): canned sample-decision recipe library with "Try this on your real data" (#405)

### DIFF
--- a/apps/api/src/__tests__/demo-routes.test.ts
+++ b/apps/api/src/__tests__/demo-routes.test.ts
@@ -150,6 +150,42 @@ describe('demo routes', () => {
     });
   });
 
+  // ── /recipes ───────────────────────────────────────────────────────
+
+  describe('GET /recipes', () => {
+    it('returns the canned recipe library (>=6 recipes, #405)', async () => {
+      const res = await request(buildApp(), 'GET', '/api/v1/demo/recipes');
+      expect(res.status).toBe(200);
+      const body = res.body as { recipes: Array<{ slug: string; situation: string }> };
+      expect(Array.isArray(body.recipes)).toBe(true);
+      expect(body.recipes.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it('covers the six named launch workflows', async () => {
+      const res = await request(buildApp(), 'GET', '/api/v1/demo/recipes');
+      const body = res.body as { recipes: Array<{ slug: string }> };
+      const slugs = body.recipes.map((r) => r.slug);
+      for (const required of [
+        'newsletter-triage',
+        'calendar-conflict-resolution',
+        'subscription-renewal-review',
+        'meeting-prep',
+        'expense-report-categorization',
+        'recurring-task-auto-handling',
+      ]) {
+        expect(slugs).toContain(required);
+      }
+    });
+
+    it('is reachable without a seeded demo user (static, no DB read)', async () => {
+      // findById must never be consulted for the recipe library.
+      mockUserRepository.findById.mockResolvedValue(null);
+      const res = await request(buildApp(), 'GET', '/api/v1/demo/recipes');
+      expect(res.status).toBe(200);
+      expect(mockUserRepository.findById).not.toHaveBeenCalled();
+    });
+  });
+
   // ── /preview ───────────────────────────────────────────────────────
 
   describe('POST /preview', () => {

--- a/apps/api/src/routes/demo.ts
+++ b/apps/api/src/routes/demo.ts
@@ -11,7 +11,7 @@ import type {
   DemoInfoResponse,
   DemoPreviewResponse,
 } from '@skytwin/shared-types';
-import { TrustTier } from '@skytwin/shared-types';
+import { TrustTier, DEMO_RECIPES } from '@skytwin/shared-types';
 import { DecisionMaker } from '@skytwin/decision-engine';
 import type { DecisionRepositoryPort } from '@skytwin/decision-engine';
 import { TwinService } from '@skytwin/twin-model';
@@ -133,6 +133,24 @@ export function createDemoRouter(): Router {
     } catch (error) {
       next(error);
     }
+  });
+
+  /**
+   * GET /api/demo/recipes
+   *
+   * Public, unauthenticated, no rate limit — returns the canned demo recipe
+   * library (#405). These are static, fictional sample situations the tour
+   * UI offers so a visitor can see the twin reason across SkyTwin's headline
+   * workflows (newsletter triage, calendar-conflict resolution, subscription
+   * renewal, meeting prep, expense categorization, recurring-task handling).
+   *
+   * No LLM cost, no DB read, no user data — just the frozen catalog from
+   * shared-types — so it doesn't need the preview route's rate-limit guards.
+   * Each recipe's `situation` is what the dashboard's "Try this on your real
+   * data" button submits to the (guarded) prediction path.
+   */
+  router.get('/recipes', (_req, res) => {
+    res.json({ recipes: DEMO_RECIPES });
   });
 
   // Read-only prediction infra. Same shape as the protected /v1/twin/ask

--- a/apps/web/public/js/api-client.js
+++ b/apps/web/public/js/api-client.js
@@ -417,6 +417,12 @@ export function previewDemoDecision(situation) {
   });
 }
 
+// Canned demo recipe library (#405). Public, read-only, no rate limit —
+// the source of truth is DEMO_RECIPES in @skytwin/shared-types.
+export function fetchDemoRecipes() {
+  return fetchJSON(`${API}/v1/demo/recipes`);
+}
+
 export function askTwin(userId, situation, opts = {}) {
   return fetchJSON(`${API}/v1/twin/ask/${encodeURIComponent(userId)}`, {
     method: 'POST',

--- a/apps/web/public/js/pages/dashboard-view.js
+++ b/apps/web/public/js/pages/dashboard-view.js
@@ -16,7 +16,7 @@
  * post-render side effects); this file owns presentation.
  */
 
-import { askTwin, escapeHtml } from '../api-client.js';
+import { askTwin, escapeHtml, fetchDemoRecipes } from '../api-client.js';
 import { dismissTierLadderIntro } from '../components/tier-ladder-intro.js';
 import {
   KEY_USER_ID,
@@ -371,6 +371,119 @@ export function renderAskResult(r) {
   `;
 }
 
+// ── Demo recipe library (#405) ─────────────────────────────────────────
+//
+// A library of canned sample-decision recipes — newsletter triage, calendar
+// conflict resolution, subscription renewal, meeting prep, expense
+// categorization, recurring-task handling — surfaced as cards on the
+// dashboard so a visitor can feel the twin reason across SkyTwin's headline
+// workflows. Each card carries a "Try this on your real data" button that
+// drops the recipe's situation prompt into the Ask Your Twin box above and
+// runs it against the user's own twin (read-only prediction — nothing
+// executes). The recipes themselves are the frozen DEMO_RECIPES catalog in
+// @skytwin/shared-types, fetched via /api/v1/demo/recipes so there's a
+// single source of truth.
+
+// Domain → icon glyph for the recipe card, reusing the dashboard's vocabulary.
+function recipeDomainIcon(domain) {
+  const icons = {
+    email: 'E',
+    calendar: 'C',
+    subscriptions: 'R',
+    finance: '$',
+    task_management: 'T',
+  };
+  return icons[domain] || '?';
+}
+
+/**
+ * Render the recipe library card from an array of recipes. Pure — returns an
+ * HTML string. When `recipes` is empty (fetch failed or returned nothing) it
+ * returns the empty string so the dashboard simply omits the section rather
+ * than showing a broken skeleton.
+ */
+export function renderRecipeLibrary(recipes) {
+  if (!Array.isArray(recipes) || recipes.length === 0) return '';
+
+  const cards = recipes.map((r) => {
+    const slug = escapeHtml(r.slug || '');
+    const title = escapeHtml(r.title || 'Sample decision');
+    const desc = escapeHtml(r.description || '');
+    // The situation is what the button submits — escape it for the
+    // data-attribute (HTML-attribute context). The handler reads it back
+    // via getAttribute, which decodes entities, so the twin gets the
+    // original plain text.
+    const situation = escapeHtml(r.situation || '');
+    const icon = recipeDomainIcon(r.domain);
+    return `
+      <div class="insight-card" style="align-items: stretch;">
+        <div class="insight-icon" style="background: var(--accent-soft); color: var(--accent);">${icon}</div>
+        <div class="insight-content" style="min-width: 0;">
+          <div class="insight-title">${title}</div>
+          <div class="insight-desc">${desc}</div>
+          <button
+            class="btn btn-outline btn-sm"
+            style="margin-top: 0.5rem;"
+            data-action="try-recipe"
+            data-recipe="${slug}"
+            data-situation="${situation}"
+          >Try this on your real data</button>
+        </div>
+      </div>
+    `;
+  }).join('');
+
+  return `
+    <div class="card" id="recipe-library" style="border-left: 3px solid var(--primary);">
+      <div class="card-header">
+        <span class="card-title">Sample decisions to try</span>
+        <span class="badge badge-info" style="font-size: 0.7rem;">no setup required</span>
+      </div>
+      <div class="card-subtitle" style="margin-bottom: 0.75rem;">
+        Here are a few situations SkyTwin handles all the time. Tap "Try this on your real data"
+        and I'll reason through it the way I would for you — what I'd do, why, and how confident I am.
+        Nothing actually happens; it's a preview.
+      </div>
+      ${cards}
+    </div>
+  `;
+}
+
+/**
+ * Fetch the recipe library and drop it into a placeholder element by id.
+ * Best-effort: a failed fetch leaves the placeholder empty (the card simply
+ * doesn't appear). Called post-render from dashboard.js so the synchronous
+ * render path doesn't block on the network.
+ */
+export async function hydrateRecipeLibrary(placeholderId) {
+  const el = document.getElementById(placeholderId);
+  if (!el) return;
+  try {
+    const resp = await fetchDemoRecipes();
+    const recipes = (resp && Array.isArray(resp.recipes)) ? resp.recipes : [];
+    el.innerHTML = renderRecipeLibrary(recipes);
+  } catch {
+    // Leave the placeholder empty — the library is a nice-to-have, not a
+    // blocker, and we never want a transient API hiccup to break the page.
+    el.innerHTML = '';
+  }
+}
+
+/**
+ * Run a recipe: drop its situation into the Ask Your Twin box and submit.
+ * Shared by the click delegator. Falls back to scrolling the box into view
+ * if it isn't on the page (defensive — the widget always ships together).
+ */
+export function handleTryRecipe(userId, situation) {
+  if (!situation) return;
+  const input = document.getElementById('ask-twin-input');
+  if (input) {
+    input.value = situation;
+    input.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }
+  handleAskTwin(userId);
+}
+
 export function renderTourBanner() {
   return `
     <div class="card" style="border-left: 3px solid var(--warning, #e6a700); background: linear-gradient(135deg, var(--bg-card) 0%, var(--bg) 100%);">
@@ -625,6 +738,14 @@ export function initDashboardGlobals() {
     } else if (action === 'ask-twin') {
       const uid = el.getAttribute('data-user-id');
       if (uid) handleAskTwin(uid);
+    } else if (action === 'try-recipe') {
+      // The recipe button doesn't carry the userId; read it from the
+      // Ask Your Twin box, which is the surface the prediction runs through
+      // and is always present on the dashboard alongside the library.
+      const situation = el.getAttribute('data-situation');
+      const askInput = document.getElementById('ask-twin-input');
+      const uid = askInput?.getAttribute('data-user-id');
+      if (uid && situation) handleTryRecipe(uid, situation);
     } else if (action === 'exit-tour') {
       skyTwinExitTour();
     } else if (action === 'connect-google') {

--- a/apps/web/public/js/pages/dashboard.js
+++ b/apps/web/public/js/pages/dashboard.js
@@ -21,6 +21,7 @@ import {
   renderSinceLastVisit,
   renderEmptyDashboardPreview,
   renderAskTwinWidget,
+  hydrateRecipeLibrary,
   renderTourBanner,
   renderJustConnectedCelebration,
   renderConnectGoogleHero,
@@ -551,6 +552,7 @@ export async function renderDashboard(container, userId) {
     ${tourMode ? '' : renderConnectGoogleHero({ googleConnected, googleSystemConfigured, userId })}
     ${tourMode ? '' : renderConnectGmailHero({ googleConnected, googleScopes: googleOAuth.status === 'fulfilled' ? (googleOAuth.value?.scopes ?? []) : [] })}
     ${renderAskTwinWidget({ userId, tourMode })}
+    <div id="recipe-library-slot"></div>
     ${showBriefing ? renderBriefingCard({ items: briefingItems, createdAt: briefing.createdAt }) : ''}
     ${renderLifebooksCard(lifebooks)}
     ${pending > 0 ? `<div class="card" style="border-left: 3px solid var(--warning); cursor: pointer;" data-action="goto" data-hash="#/approvals">
@@ -690,6 +692,11 @@ export async function renderDashboard(container, userId) {
     </div>
     `}
   `;
+
+  // Demo recipe library (#405): fetch the canned sample-decision recipes
+  // and fill the placeholder. Best-effort — a failed fetch leaves the slot
+  // empty rather than blocking the synchronous render above.
+  hydrateRecipeLibrary('recipe-library-slot').catch(() => { /* nice-to-have */ });
 
   // First-decision celebration: a one-time "look — your twin just acted!"
   // moment, fired the first time decisions transition from 0 to >0 for this

--- a/packages/shared-types/src/__tests__/demo-recipes.test.ts
+++ b/packages/shared-types/src/__tests__/demo-recipes.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { DEMO_RECIPES, findDemoRecipe } from '../demo-recipes.js';
+
+describe('DEMO_RECIPES', () => {
+  it('ships at least 6 recipes (#405 acceptance criterion)', () => {
+    expect(DEMO_RECIPES.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('covers each of the six named launch workflows', () => {
+    const slugs = DEMO_RECIPES.map((r) => r.slug);
+    for (const required of [
+      'newsletter-triage',
+      'calendar-conflict-resolution',
+      'subscription-renewal-review',
+      'meeting-prep',
+      'expense-report-categorization',
+      'recurring-task-auto-handling',
+    ]) {
+      expect(slugs).toContain(required);
+    }
+  });
+
+  it('has unique slugs', () => {
+    const slugs = DEMO_RECIPES.map((r) => r.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('every recipe has the fields the demo surface needs', () => {
+    for (const r of DEMO_RECIPES) {
+      // slug is URL-safe (lowercase, digits, hyphens) so it can ride in a
+      // data-attribute / query param without escaping.
+      expect(r.slug).toMatch(/^[a-z0-9-]+$/);
+      expect(r.title.trim().length).toBeGreaterThan(0);
+      expect(r.description.trim().length).toBeGreaterThan(0);
+      // situation is what "Try this on your real data" submits to the
+      // prediction path; the demo/preview route caps input at 600 chars.
+      expect(r.situation.trim().length).toBeGreaterThan(0);
+      expect(r.situation.length).toBeLessThanOrEqual(600);
+      expect(['email', 'calendar', 'subscriptions', 'finance', 'task_management']).toContain(r.domain);
+    }
+  });
+
+  it('is immutable — push throws on the frozen array', () => {
+    expect(() => {
+      // @ts-expect-error — intentionally violating readonly to prove the freeze.
+      DEMO_RECIPES.push({
+        slug: 'x',
+        title: 'x',
+        domain: 'email',
+        description: 'x',
+        situation: 'x',
+      });
+    }).toThrow();
+  });
+});
+
+describe('findDemoRecipe', () => {
+  it('returns { found: true, recipe } for a known slug', () => {
+    const result = findDemoRecipe('newsletter-triage');
+    expect(result.found).toBe(true);
+    if (result.found) {
+      expect(result.recipe.slug).toBe('newsletter-triage');
+      expect(result.recipe.domain).toBe('email');
+    }
+  });
+
+  it('returns { found: false } for an unknown slug (no undefined deref)', () => {
+    const result = findDemoRecipe('does-not-exist');
+    expect(result).toEqual({ found: false });
+  });
+
+  it('does not match on a partial / empty slug', () => {
+    expect(findDemoRecipe('').found).toBe(false);
+    expect(findDemoRecipe('newsletter').found).toBe(false);
+  });
+});

--- a/packages/shared-types/src/demo-recipes.ts
+++ b/packages/shared-types/src/demo-recipes.ts
@@ -1,0 +1,120 @@
+/**
+ * Demo recipe library (#405) — canned sample-decision recipes for the in-app
+ * tour / demo.
+ *
+ * Each recipe is a self-contained, fictional sample situation that the demo
+ * surface can drop into the "Ask your twin" box so a first-time visitor sees
+ * the twin reason out loud across SkyTwin's headline workflows before they
+ * connect any real account. Every recipe also carries the `situation` string
+ * the dashboard wires behind a "Try this on your real data" button — clicking
+ * it runs the same prompt against the user's *own* connected twin via the
+ * existing `whatWouldIDo` path (read-only prediction, nothing executes).
+ *
+ * These are data, not behavior: no policy decision, execution, or provenance
+ * lives here. The prediction path that consumes a recipe's `situation` is the
+ * one that applies trust-tier / policy / injection-guard checks (the
+ * `/api/v1/demo/preview` and `/v1/twin/ask` routes). A recipe is just a
+ * pre-written situation prompt plus presentation copy.
+ *
+ * Content is fictional — no real names, companies, amounts, or addresses.
+ */
+
+/** A demo recipe `domain` maps onto the dashboard's existing domain labels/icons. */
+export type DemoRecipeDomain =
+  | 'email'
+  | 'calendar'
+  | 'subscriptions'
+  | 'finance'
+  | 'task_management';
+
+/**
+ * A single canned sample-decision recipe.
+ *
+ * `situation` is the plain-language prompt fed to the prediction path. It is
+ * intentionally first-person and concrete so the twin's reasoning reads well
+ * in the demo. The same string is what "Try this on your real data" submits.
+ */
+export interface DemoRecipe {
+  /** Stable, URL-safe identifier — used as a `data-recipe` attribute key. */
+  readonly slug: string;
+  /** Short human title for the recipe card. */
+  readonly title: string;
+  /** Which dashboard domain this recipe demonstrates. */
+  readonly domain: DemoRecipeDomain;
+  /** One-sentence framing of what the twin is being asked to weigh in on. */
+  readonly description: string;
+  /** First-person situation prompt fed to the prediction path. */
+  readonly situation: string;
+}
+
+/**
+ * The canned recipe library. At least the six named launch workflows
+ * (#405): newsletter triage, calendar conflict resolution, subscription
+ * renewal review, meeting prep, expense report categorization, and recurring
+ * task auto-handling.
+ *
+ * Frozen so a consumer can't mutate the shared array in place.
+ */
+export const DEMO_RECIPES: readonly DemoRecipe[] = Object.freeze([
+  {
+    slug: 'newsletter-triage',
+    title: 'Newsletter triage',
+    domain: 'email',
+    description: 'A recurring newsletter you usually skim and archive lands again.',
+    situation:
+      "The weekly product newsletter from a tool I use just arrived. I've archived the last 11 of these without opening them. What would you do?",
+  },
+  {
+    slug: 'calendar-conflict-resolution',
+    title: 'Calendar conflict resolution',
+    domain: 'calendar',
+    description: 'A new invite double-books a slot you already hold.',
+    situation:
+      'A new meeting invite for Tuesday at 2pm just landed, but I already have a one-on-one with my manager at that time. What would you do?',
+  },
+  {
+    slug: 'subscription-renewal-review',
+    title: 'Subscription renewal review',
+    domain: 'subscriptions',
+    description: 'A recurring charge is about to renew — keep it or cancel?',
+    situation:
+      "My streaming subscription is about to renew at $15.99/month. I've opened it 3 times this month. What would you do?",
+  },
+  {
+    slug: 'meeting-prep',
+    title: 'Meeting prep',
+    domain: 'calendar',
+    description: 'A meeting is coming up — what should be ready beforehand?',
+    situation:
+      "I have a kickoff call with a new partner tomorrow morning and I haven't put together an agenda or notes yet. What would you do?",
+  },
+  {
+    slug: 'expense-report-categorization',
+    title: 'Expense report categorization',
+    domain: 'finance',
+    description: 'A receipt needs to be filed under the right expense category.',
+    situation:
+      'I just got a $42 receipt emailed to me from a ride-share trip to the airport for a work conference. How would you categorize it for my expense report?',
+  },
+  {
+    slug: 'recurring-task-auto-handling',
+    title: 'Recurring task auto-handling',
+    domain: 'task_management',
+    description: 'A routine task you do every week comes around again.',
+    situation:
+      "Every Friday I send the team a short status update summarizing the week. It's Friday afternoon again. What would you do?",
+  },
+]);
+
+/**
+ * Look a recipe up by slug. Returns a typed result so callers handle the
+ * "no such recipe" case explicitly rather than dereferencing `undefined`.
+ */
+export function findDemoRecipe(
+  slug: string,
+):
+  | { found: true; recipe: DemoRecipe }
+  | { found: false } {
+  const recipe = DEMO_RECIPES.find((r) => r.slug === slug);
+  return recipe ? { found: true, recipe } : { found: false };
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -146,6 +146,12 @@ export type {
 } from './demo.js';
 
 export type {
+  DemoRecipe,
+  DemoRecipeDomain,
+} from './demo-recipes.js';
+export { DEMO_RECIPES, findDemoRecipe } from './demo-recipes.js';
+
+export type {
   FsScanRoot,
   RawSignal,
 } from './capability-acquisition.js';


### PR DESCRIPTION
## What changed

Adds a **demo recipe library** (#405): 6 fictional, ready-to-run sample-decision recipes covering the named launch workflows, surfaced on the dashboard so a first-time visitor can feel the twin reason across SkyTwin's headline workflows before connecting any account.

Recipes (all in the new frozen `DEMO_RECIPES` catalog):
1. Newsletter triage
2. Calendar conflict resolution
3. Subscription renewal review
4. Meeting prep
5. Expense report categorization
6. Recurring task auto-handling

### Files
- **`packages/shared-types/src/demo-recipes.ts`** — `DEMO_RECIPES` (frozen) + `DemoRecipe`/`DemoRecipeDomain` types + `findDemoRecipe()` typed-result lookup. Single source of truth. Each `situation` is capped at <=600 chars to match the existing `/demo/preview` input cap. Exported from `index.ts`.
- **`apps/api/src/routes/demo.ts`** — `GET /api/v1/demo/recipes` serves the catalog. Read-only, no DB read, no LLM cost, no rate limit (it's static data, unlike `/preview`).
- **`apps/web`** — a "Sample decisions to try" card renders the library (fetched via the API so there's one source of truth). Each recipe has a **"Try this on your real data"** button that drops the recipe's `situation` into the Ask Your Twin box and runs it through the existing read-only `whatWouldIDo` prediction path.

### Acceptance criteria (#405)
- [x] **At least 6 recipes shipped** — exactly the six named workflows; asserted by tests.
- [x] **Each recipe has a "Try this on your real data" button** — rendered per card, wired through the read-only prediction path.

### Safety
- The "Try this on your real data" button runs through the existing prediction path (`/v1/twin/ask` via the dashboard's `handleAskTwin`), which is **read-only** — nothing executes. Trust-tier, policy, and injection-guard checks still apply on that path; this change does not weaken them and sets no provenance.
- Frontend follows the repo's "no inline onclick" rule: `data-action="try-recipe"` + the existing **hash-gated singleton click delegator** in `dashboard-view.js`. `data-situation` is `escapeHtml`-escaped for the attribute context (`"` → `&quot;`), decoded back to plain text by `getAttribute`.
- The `/recipes` route reads no user/DB state (test asserts `findById` is never called).

### Tests added
- `packages/shared-types/src/__tests__/demo-recipes.test.ts` — catalog ships >=6 recipes, covers the six named workflows, unique slugs, field shape (incl. <=600-char situation), frozen array, and `findDemoRecipe` happy + edge (unknown/empty/partial slug) cases.
- `apps/api/src/__tests__/demo-routes.test.ts` — 3 new cases: route returns >=6 recipes, covers the six workflows, and reads no user/DB state.

Tests verified green: `@skytwin/shared-types` (33 passing) and `apps/api` `demo-routes.test.ts` (15 passing). Both packages typecheck clean against the worktree's `shared-types` dist. Web JS syntax-checked.

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)