### PR TITLE
fix(db): backup-cli test mock satisfies UserRow (unbreak the build)

### DIFF
--- a/packages/db/src/__tests__/backup-cli.test.ts
+++ b/packages/db/src/__tests__/backup-cli.test.ts
@@ -35,6 +35,8 @@ function makeBackupData(): BackupData {
       trust_tier: 'observer',
       autonomy_settings: {},
       ironclaw_channel: null,
+      language: null,
+      timezone: null,
       created_at: new Date('2026-01-01T00:00:00Z'),
       updated_at: new Date('2026-01-01T00:00:00Z'),
     },


### PR DESCRIPTION
Build-break fix surfaced by the post-batch clean build: #517's UserRow mock predates #486's required `language`/`timezone`. Adds the two null fields to the test fixture. `pnpm build` now green (35/35). No behavior change.