### PR TITLE
docs(pages): rebuild the landing page — brand, demo link, screenshots, current story

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SkyTwin — a digital twin that learns what you'd want and does it</title>
-  <meta name="description" content="SkyTwin is an open-source, local-first personal assistant. It builds a structured model of your preferences from your inbox and calendar, then acts on your behalf — with explanations, trust tiers, spend limits, and a pause-everything switch. Runs entirely on your machine.">
+  <meta name="description" content="SkyTwin is an open-source, local-first personal assistant. It builds a structured model of your preferences from your inbox and calendar, then acts on your behalf — with explanations, trust tiers, spend limits, and a pause-everything switch. Local by default; cloud AI is opt-in.">
   <link rel="canonical" href="https://jayzalowitz.github.io/skytwin/">
   <meta property="og:title" content="SkyTwin — it acts, it doesn't chat">
   <meta property="og:description" content="Open-source, local-first digital twin: reads your inbox + calendar, splits what needs you from what's just awareness, and acts within limits you set. Five minutes from cold start to trust.">
@@ -128,7 +128,7 @@
     <section class="hero wrap">
       <p class="eyebrow">Open source · local-first · Apache 2.0</p>
       <h1>A digital twin that learns what you'd want — and does it.</h1>
-      <p class="lede">SkyTwin reads your inbox and calendar, builds a structured model of your preferences, and acts on your behalf. It splits what needs you from what's just awareness, explains every decision, and never does anything risky without asking. Everything runs on your machine.</p>
+      <p class="lede">SkyTwin reads your inbox and calendar, builds a structured model of your preferences, and acts on your behalf. It splits what needs you from what's just awareness, explains every decision, and never does anything risky without asking. Local-first by default — cloud AI is opt-in.</p>
       <div class="actions">
         <a class="button primary" href="https://github.com/jayzalowitz/skytwin/releases/latest">Download desktop beta</a>
         <a class="button" href="demo.html">See the 5-minute demo</a>
@@ -159,8 +159,8 @@
         </div>
         <div class="card">
           <span class="tag">Local-first</span>
-          <h3>Your data never leaves</h3>
-          <p>CockroachDB and an optional local LLM are embedded in the desktop app. OAuth tokens are encrypted on disk. Nothing is sent to a server we control — and email addresses are redacted before any prompt reaches a cloud model.</p>
+          <h3>Local by default</h3>
+          <p>CockroachDB and an optional local LLM are embedded in the desktop app, and OAuth tokens are encrypted on disk. We don't run a server your data flows through. Cloud AI is opt-in — and when you choose it, the decision pipeline redacts email addresses from its prompts first.</p>
         </div>
       </div>
     </section>
@@ -169,10 +169,10 @@
       <h2>See it before you connect anything</h2>
       <p class="section-lede">The demo path uses a seeded sample profile, so a stranger sees real decisions, real explanations, and real controls without touching a private inbox. <a href="demo.html">Walk the five-minute storyboard →</a></p>
       <div class="shot-grid">
-        <figure><img class="shot" src="screenshots/onboarding.png" alt="Cold-start onboarding with a 'try a sample profile' path."><figcaption>Cold start — explore with a sample profile in seconds.</figcaption></figure>
-        <figure><img class="shot" src="screenshots/approvals.png" alt="Approvals queue: approve, reject, or edit a proposed action."><figcaption>Approvals — yes, no, or edit; every answer teaches the model.</figcaption></figure>
-        <figure><img class="shot" src="screenshots/settings.png" alt="Settings: autonomy level, spend limits, connected accounts, pause and delete controls."><figcaption>Settings — autonomy, spend limits, pause everything, delete my data.</figcaption></figure>
-        <figure><img class="shot" src="screenshots/briefing.png" alt="The briefing digest with to-dos and topics."><figcaption>Briefing — what needs you, and what's just FYI.</figcaption></figure>
+        <figure><img class="shot" loading="lazy" src="screenshots/onboarding.png" alt="Cold-start onboarding with a 'try a sample profile' path."><figcaption>Cold start — explore with a sample profile in seconds.</figcaption></figure>
+        <figure><img class="shot" loading="lazy" src="screenshots/approvals.png" alt="Approvals queue: approve, reject, or edit a proposed action."><figcaption>Approvals — yes, no, or edit; every answer teaches the model.</figcaption></figure>
+        <figure><img class="shot" loading="lazy" src="screenshots/settings.png" alt="Settings: autonomy level, spend limits, connected accounts, pause and delete controls."><figcaption>Settings — autonomy, spend limits, pause everything, delete my data.</figcaption></figure>
+        <figure><img class="shot" loading="lazy" src="screenshots/briefing.png" alt="The briefing digest with to-dos and topics."><figcaption>Briefing — what needs you, and what's just FYI.</figcaption></figure>
       </div>
     </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,160 +3,223 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>SkyTwin — A digital twin that learns what you'd want and does it</title>
-  <meta name="description" content="SkyTwin is an open-source personal assistant that builds a structured model of your preferences and acts on your behalf — with safety constraints, explanations, and progressive trust. Runs entirely on your machine.">
+  <title>SkyTwin — a digital twin that learns what you'd want and does it</title>
+  <meta name="description" content="SkyTwin is an open-source, local-first personal assistant. It builds a structured model of your preferences from your inbox and calendar, then acts on your behalf — with explanations, trust tiers, spend limits, and a pause-everything switch. Runs entirely on your machine.">
   <link rel="canonical" href="https://jayzalowitz.github.io/skytwin/">
+  <meta property="og:title" content="SkyTwin — it acts, it doesn't chat">
+  <meta property="og:description" content="Open-source, local-first digital twin: reads your inbox + calendar, splits what needs you from what's just awareness, and acts within limits you set. Five minutes from cold start to trust.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://jayzalowitz.github.io/skytwin/">
+  <!-- No external font fetch: the --font-* vars fall back to the system stack,
+       keeping this privacy-focused doc set free of third-party requests. Shares
+       the design system with demo.html so the Pages site reads as one product. -->
   <style>
     :root {
-      --bg: #0b0b10;
-      --fg: #e8e8ee;
-      --muted: #9b9bab;
-      --card: #16161e;
-      --border: #2a2a36;
-      --accent: #7c5cff;
-      --accent-hover: #9d83ff;
+      --bg: #0E0F13;
+      --surface: #16181F;
+      --elevated: #1D2029;
+      --border: #272B38;
+      --border-strong: #363B4C;
+      --text: #ECEDF1;
+      --text-muted: #9CA0AE;
+      --text-dim: #5E6374;
+      --accent: #7C72E8;
+      --accent-hover: #9A92F2;
+      --accent-soft: rgba(124,114,232,.16);
+      --safe: #46C08A;
+      --danger: #F26D5B;
+      --shadow: 0 24px 80px rgba(0, 0, 0, .32);
+      --font-ui: "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      --font-voice: "Fraunces", Georgia, serif;
+      --font-data: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
       background: var(--bg);
-      color: var(--fg);
-      line-height: 1.6;
+      color: var(--text);
+      font-family: var(--font-ui);
+      line-height: 1.55;
+      -webkit-font-smoothing: antialiased;
     }
-    .wrap { max-width: 880px; margin: 0 auto; padding: 3rem 1.5rem 4rem; }
-    header { padding-bottom: 2.5rem; border-bottom: 1px solid var(--border); margin-bottom: 2.5rem; }
-    h1 { font-size: 2.4rem; margin: 0 0 0.75rem; letter-spacing: -0.02em; }
-    h2 { font-size: 1.4rem; margin: 2.5rem 0 1rem; letter-spacing: -0.01em; }
-    h3 { font-size: 1.1rem; margin: 1.5rem 0 0.5rem; }
-    p, li { font-size: 1.05rem; color: var(--fg); }
-    .tagline { color: var(--muted); font-size: 1.15rem; margin: 0 0 1.5rem; }
     a { color: var(--accent); text-decoration: none; }
-    a:hover { color: var(--accent-hover); text-decoration: underline; }
-    .btn {
-      display: inline-block;
-      padding: 0.7rem 1.4rem;
-      background: var(--accent);
-      color: #fff !important;
-      border-radius: 0.5rem;
-      font-weight: 600;
-      margin: 0.25rem 0.5rem 0.25rem 0;
+    a:hover { color: var(--accent-hover); }
+    code, pre { font-family: var(--font-data); }
+    .wrap { max-width: 960px; margin: 0 auto; padding: 0 1.5rem; }
+
+    /* Nav */
+    .nav { border-bottom: 1px solid var(--border); position: sticky; top: 0; background: rgba(14,15,19,.82); backdrop-filter: blur(10px); z-index: 10; }
+    .nav-inner { display: flex; align-items: center; justify-content: space-between; height: 60px; }
+    .brand { display: flex; align-items: center; gap: .55rem; color: var(--text); font-weight: 600; }
+    .brand-mark { display: grid; place-items: center; width: 28px; height: 28px; border-radius: 8px; background: var(--accent); color: #fff; font-weight: 700; }
+    .nav-links { display: flex; align-items: center; gap: 1.4rem; font-size: .95rem; }
+    .nav-links a { color: var(--text-muted); }
+    .nav-links a:hover { color: var(--text); }
+    .button { display: inline-block; padding: .55rem 1rem; border-radius: 9px; border: 1px solid var(--border-strong); color: var(--text); font-weight: 550; }
+    .button:hover { color: var(--text); border-color: var(--text-muted); }
+    .button.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+    .button.primary:hover { background: var(--accent-hover); color: #fff; }
+
+    /* Hero */
+    .hero { padding: 4.5rem 0 1rem; }
+    .eyebrow { color: var(--accent); font-weight: 600; font-size: .82rem; letter-spacing: .08em; text-transform: uppercase; margin: 0 0 1rem; }
+    h1 { font-family: var(--font-voice); font-weight: 400; font-size: clamp(2.4rem, 5vw, 3.6rem); line-height: 1.06; letter-spacing: -.01em; margin: 0 0 1.1rem; }
+    .lede { font-size: 1.2rem; color: var(--text-muted); max-width: 40rem; margin: 0 0 1.8rem; }
+    .actions { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; }
+    .actions .note { color: var(--text-dim); font-size: .85rem; margin-left: .3rem; }
+
+    /* Sections */
+    section { padding: 3.2rem 0; border-top: 1px solid var(--border); }
+    section.hero { border-top: 0; }
+    h2 { font-size: 1.6rem; letter-spacing: -.01em; margin: 0 0 .4rem; }
+    .section-lede { color: var(--text-muted); max-width: 42rem; margin: 0 0 1.6rem; }
+
+    /* Shots */
+    .shot { border: 1px solid var(--border); border-radius: 14px; box-shadow: var(--shadow); width: 100%; display: block; }
+    .shot-hero { margin-top: 2rem; }
+    .shot-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 1.4rem; }
+    .shot-grid figure { margin: 0; }
+    .shot-grid figcaption { color: var(--text-dim); font-size: .82rem; margin-top: .5rem; }
+
+    /* Feature grid */
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 1.4rem; }
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 1.3rem; }
+    .card h3 { margin: 0 0 .4rem; font-size: 1.06rem; }
+    .card p { margin: 0; color: var(--text-muted); font-size: .96rem; }
+    .card .tag { display: inline-block; font-size: .72rem; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; color: var(--accent); margin-bottom: .5rem; }
+    .card.safe .tag { color: var(--safe); }
+
+    /* Scopes table (Google OAuth review) */
+    .scopes { width: 100%; border-collapse: collapse; margin-top: 1.2rem; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+    .scopes th, .scopes td { padding: .8rem 1rem; text-align: left; border-bottom: 1px solid var(--border); font-size: .94rem; vertical-align: top; }
+    .scopes th { background: var(--accent-soft); font-weight: 600; }
+    .scopes tr:last-child td { border-bottom: 0; }
+    .scopes code { font-size: .84rem; color: var(--text); }
+
+    pre.code { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 1rem 1.1rem; overflow-x: auto; font-size: .9rem; }
+    ul.links { margin: 1rem 0 0; padding-left: 1.1rem; }
+    ul.links li { margin: .35rem 0; color: var(--text-muted); }
+
+    footer { border-top: 1px solid var(--border); color: var(--text-dim); font-size: .9rem; padding: 2.4rem 0 3.5rem; }
+    footer a { color: var(--text-muted); }
+
+    @media (max-width: 680px) {
+      .grid, .shot-grid { grid-template-columns: 1fr; }
+      .nav-links a:not(.button) { display: none; }
     }
-    .btn:hover { background: var(--accent-hover); text-decoration: none; }
-    .btn.outline { background: transparent; border: 1px solid var(--border); color: var(--fg) !important; }
-    .btn.outline:hover { background: var(--card); }
-    .feature-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1.5rem 0; }
-    .feature {
-      background: var(--card); padding: 1.2rem; border-radius: 0.6rem;
-      border: 1px solid var(--border);
-    }
-    .feature h3 { margin-top: 0; }
-    .feature p { color: var(--muted); margin: 0.5rem 0 0; font-size: 0.95rem; }
-    .scopes-table {
-      width: 100%; border-collapse: collapse; margin: 1rem 0;
-      background: var(--card); border-radius: 0.6rem; overflow: hidden;
-    }
-    .scopes-table th, .scopes-table td {
-      padding: 0.75rem 1rem; text-align: left; border-bottom: 1px solid var(--border);
-      font-size: 0.95rem;
-    }
-    .scopes-table th { background: rgba(124,92,255,0.1); font-weight: 600; }
-    .scopes-table tr:last-child td { border-bottom: none; }
-    .scopes-table code { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace; font-size: 0.85rem; }
-    footer { margin-top: 4rem; padding-top: 2rem; border-top: 1px solid var(--border); color: var(--muted); font-size: 0.9rem; }
-    footer a { color: var(--muted); }
-    @media (max-width: 640px) { .feature-grid { grid-template-columns: 1fr; } }
   </style>
 </head>
 <body>
-  <div class="wrap">
-    <header>
-      <h1>SkyTwin</h1>
-      <p class="tagline">A digital twin that learns what you'd want — and does it. Open source, runs locally, never sends your data anywhere.</p>
-      <p>
-        <a href="https://github.com/jayzalowitz/skytwin" class="btn">View on GitHub</a>
-        <a href="privacy.html" class="btn outline">Privacy policy</a>
-        <a href="terms.html" class="btn outline">Terms of service</a>
-      </p>
-    </header>
-
-    <h2>What SkyTwin does</h2>
-    <p>SkyTwin is a personal-automation desktop app that builds a structured model of your preferences and decision patterns — a digital twin — then uses that model to act on your behalf. When it's confident, it just handles things. When it's not, it asks the right question instead of the wrong one.</p>
-
-    <div class="feature-grid">
-      <div class="feature">
-        <h3>Watches your inbox</h3>
-        <p>Reads incoming Gmail to classify and prioritize, learns which newsletters you archive, drafts replies in your style.</p>
-      </div>
-      <div class="feature">
-        <h3>Manages your calendar</h3>
-        <p>Spots conflicts, schedules meetings, declines auto-invites you'd ignore, surfaces ones you'd want.</p>
-      </div>
-      <div class="feature">
-        <h3>Explains every action</h3>
-        <p>Every automated decision produces an explanation record: what evidence was used, what preferences applied, how to correct it.</p>
-      </div>
-      <div class="feature">
-        <h3>Stays local</h3>
-        <p>CockroachDB embedded in the desktop app. Your decisions, your data, your machine. Nothing sent to our servers.</p>
+  <nav class="nav">
+    <div class="wrap nav-inner">
+      <a class="brand" href="index.html" aria-label="SkyTwin home">
+        <span class="brand-mark">S</span><span>SkyTwin</span>
+      </a>
+      <div class="nav-links">
+        <a href="demo.html">Demo</a>
+        <a href="connect-gmail.html">Connect Gmail</a>
+        <a href="https://github.com/jayzalowitz/skytwin">GitHub</a>
+        <a class="button primary" href="https://github.com/jayzalowitz/skytwin/releases/latest">Download</a>
       </div>
     </div>
+  </nav>
 
-    <h2>Google account access — what we use and why</h2>
-    <p>SkyTwin asks for the minimum Google API scopes needed to actually be useful as a personal assistant. Each scope below ties to a specific user-facing feature in the app. The OAuth flow lands on <code>http://127.0.0.1</code> — your access token is delivered directly to the SkyTwin desktop process and stored encrypted on disk. It never traverses skytwin.dev or any other server we control.</p>
+  <main>
+    <section class="hero wrap">
+      <p class="eyebrow">Open source · local-first · Apache 2.0</p>
+      <h1>A digital twin that learns what you'd want — and does it.</h1>
+      <p class="lede">SkyTwin reads your inbox and calendar, builds a structured model of your preferences, and acts on your behalf. It splits what needs you from what's just awareness, explains every decision, and never does anything risky without asking. Everything runs on your machine.</p>
+      <div class="actions">
+        <a class="button primary" href="https://github.com/jayzalowitz/skytwin/releases/latest">Download desktop beta</a>
+        <a class="button" href="demo.html">See the 5-minute demo</a>
+        <a class="button" href="https://github.com/jayzalowitz/skytwin">View source</a>
+        <span class="note">No account or inbox needed — explore with a sample profile.</span>
+      </div>
+      <img class="shot shot-hero" src="screenshots/briefing.png" alt="SkyTwin briefing — a daily digest that separates to-dos that need you from topics to catch up on, each with citations.">
+    </section>
 
-    <table class="scopes-table">
-      <thead>
-        <tr><th>Scope</th><th>What it enables</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>gmail.readonly</code></td>
-          <td>Read inbox to classify incoming mail, learn which threads you act on vs. ignore, and surface the few that need your attention. Without this, SkyTwin can't observe email at all.</td>
-        </tr>
-        <tr>
-          <td><code>gmail.modify</code></td>
-          <td>Apply labels and archive newsletters you've taught SkyTwin to archive. Required for the auto-archive feature; never sends or deletes mail.</td>
-        </tr>
-        <tr>
-          <td><code>calendar.readonly</code></td>
-          <td>Read your calendar to spot conflicts, find time, and learn your scheduling preferences.</td>
-        </tr>
-        <tr>
-          <td><code>calendar.events</code></td>
-          <td>Create, modify, and decline calendar invites with your approval (or auto-handle for events that match patterns you've taught SkyTwin).</td>
-        </tr>
-        <tr>
-          <td><code>openid</code>, <code>email</code>, <code>profile</code></td>
-          <td>Confirm your Google identity so we can associate the right account with the right twin profile in your local database.</td>
-        </tr>
-      </tbody>
-    </table>
+    <section class="wrap">
+      <h2>It acts. It doesn't chat.</h2>
+      <p class="section-lede">SkyTwin isn't a chatbot waiting for a prompt. It watches your connected accounts and acts when there's something worth doing — within limits you set, with a record you can audit.</p>
+      <div class="grid">
+        <div class="card">
+          <span class="tag">Briefing</span>
+          <h3>Act vs. catch-up, cited</h3>
+          <p>The Inbox-Intelligence digest splits the few things that need a decision from the topics you just want awareness of — grouped by matter, de-duplicated across signals, each line citing the email/event it came from.</p>
+        </div>
+        <div class="card">
+          <span class="tag">Decisions</span>
+          <h3>Every action is explained</h3>
+          <p>Each automated decision produces a record: what happened, what evidence was used, which of your preferences applied, why this over the alternatives, and how to correct it.</p>
+        </div>
+        <div class="card safe">
+          <span class="tag">Safety</span>
+          <h3>Trust you grant, not assume</h3>
+          <p>New twins start in observe-only mode and earn autonomy through your feedback. Spend limits are hard caps. Untrusted-origin content can never auto-run destructive work. One switch pauses everything.</p>
+        </div>
+        <div class="card">
+          <span class="tag">Local-first</span>
+          <h3>Your data never leaves</h3>
+          <p>CockroachDB and an optional local LLM are embedded in the desktop app. OAuth tokens are encrypted on disk. Nothing is sent to a server we control — and email addresses are redacted before any prompt reaches a cloud model.</p>
+        </div>
+      </div>
+    </section>
 
-    <h2>Open source &amp; transparent</h2>
-    <p>SkyTwin is Apache 2.0 licensed. Every line of the agent that reads your mail, every line of the OAuth flow, every line of the policy engine that decides what auto-runs vs. asks first — all on <a href="https://github.com/jayzalowitz/skytwin">GitHub</a>. The CHANGELOG documents every behavior change. The architecture docs explain how decisions get made.</p>
-    <ul>
-      <li><a href="https://github.com/jayzalowitz/skytwin/blob/main/docs/safety-model.md">Safety model</a> — threat model, trust tiers, defense layers</li>
-      <li><a href="https://github.com/jayzalowitz/skytwin/blob/main/docs/technical-spec.md">Technical spec</a> — architecture, data flow, schema</li>
-      <li><a href="https://github.com/jayzalowitz/skytwin/blob/main/docs/product-spec.md">Product spec</a> — what we will and won't ship, and why</li>
-      <li><a href="privacy.html">Privacy policy</a> — how we handle Google user data</li>
-      <li><a href="connect-gmail.html">Connect Gmail (5-min setup)</a> — wire up Gmail features with your own OAuth credentials</li>
-    </ul>
+    <section class="wrap">
+      <h2>See it before you connect anything</h2>
+      <p class="section-lede">The demo path uses a seeded sample profile, so a stranger sees real decisions, real explanations, and real controls without touching a private inbox. <a href="demo.html">Walk the five-minute storyboard →</a></p>
+      <div class="shot-grid">
+        <figure><img class="shot" src="screenshots/onboarding.png" alt="Cold-start onboarding with a 'try a sample profile' path."><figcaption>Cold start — explore with a sample profile in seconds.</figcaption></figure>
+        <figure><img class="shot" src="screenshots/approvals.png" alt="Approvals queue: approve, reject, or edit a proposed action."><figcaption>Approvals — yes, no, or edit; every answer teaches the model.</figcaption></figure>
+        <figure><img class="shot" src="screenshots/settings.png" alt="Settings: autonomy level, spend limits, connected accounts, pause and delete controls."><figcaption>Settings — autonomy, spend limits, pause everything, delete my data.</figcaption></figure>
+        <figure><img class="shot" src="screenshots/briefing.png" alt="The briefing digest with to-dos and topics."><figcaption>Briefing — what needs you, and what's just FYI.</figcaption></figure>
+      </div>
+    </section>
 
-    <h2>Install</h2>
-    <p>One-command on macOS / Linux / WSL:</p>
-    <pre style="background: var(--card); padding: 1rem; border-radius: 0.5rem; overflow-x: auto; border: 1px solid var(--border);"><code>curl -fsSL https://raw.githubusercontent.com/jayzalowitz/skytwin/main/install.sh | bash</code></pre>
-    <p>Or grab the desktop installer (<code>.dmg</code> / <code>.exe</code> / <code>.AppImage</code>) from <a href="https://github.com/jayzalowitz/skytwin/releases">GitHub Releases</a>.</p>
+    <section class="wrap">
+      <h2>Google account access — what we use and why</h2>
+      <p class="section-lede">SkyTwin requests the minimum Google API scopes needed to be useful as a personal assistant. Each scope ties to a specific feature. The OAuth flow lands on <code>http://127.0.0.1</code> — your token is delivered straight to the desktop process and stored encrypted on disk. It never traverses any server we control.</p>
+      <table class="scopes">
+        <thead><tr><th>Scope</th><th>What it enables</th></tr></thead>
+        <tbody>
+          <tr><td><code>gmail.readonly</code></td><td>Read inbox to classify incoming mail, learn which threads you act on vs. ignore, and surface the few that need your attention. Without this, SkyTwin can't observe email at all.</td></tr>
+          <tr><td><code>gmail.modify</code></td><td>Apply labels and archive newsletters you've taught SkyTwin to archive. Required for auto-archive; never sends or deletes mail.</td></tr>
+          <tr><td><code>calendar.readonly</code></td><td>Read your calendar to spot conflicts, find time, and learn your scheduling preferences.</td></tr>
+          <tr><td><code>calendar.events</code></td><td>Create, modify, and decline calendar invites with your approval (or auto-handle events matching patterns you've taught SkyTwin).</td></tr>
+          <tr><td><code>openid</code>, <code>email</code>, <code>profile</code></td><td>Confirm your Google identity so the right account maps to the right twin profile in your local database.</td></tr>
+        </tbody>
+      </table>
+      <p style="margin-top:1rem;color:var(--text-muted);font-size:.95rem;">Full detail in the <a href="privacy.html">privacy policy</a>. Bringing your own OAuth credentials takes about five minutes — see <a href="connect-gmail.html">Connect Gmail</a>.</p>
+    </section>
 
-    <h2>How this stays alive</h2>
-    <p><strong>Free and open source forever for personal use.</strong> Future Team and Hosted tiers are planned for organizations that need shared policies, audit logs, or managed infrastructure. Personal features will never be paywalled.</p>
-    <p>No prices today. We're not ready to commit numbers, and overpromising on a backlog we haven't shipped is the easiest trust to lose. Want one of the upcoming tiers? <a href="https://github.com/jayzalowitz/skytwin/issues">Open an issue</a> describing what shared-team policy or audit features your org needs and you'll help us shape what ships.</p>
+    <section class="wrap">
+      <h2>Open source &amp; transparent</h2>
+      <p class="section-lede">Apache 2.0. Every line of the agent that reads your mail, the OAuth flow, and the policy engine that decides what auto-runs vs. asks first is on GitHub. The CHANGELOG records every behavior change; the architecture docs explain how decisions get made.</p>
+      <ul class="links">
+        <li><a href="https://github.com/jayzalowitz/skytwin/blob/main/docs/safety-model.md">Safety model</a> — threat model, trust tiers, defense layers</li>
+        <li><a href="https://github.com/jayzalowitz/skytwin/blob/main/docs/technical-spec.md">Technical spec</a> — architecture, data flow, schema</li>
+        <li><a href="https://github.com/jayzalowitz/skytwin/blob/main/docs/product-spec.md">Product spec</a> — what we will and won't ship, and why</li>
+        <li><a href="demo.html">Demo storyboard</a> — and the <a href="https://github.com/jayzalowitz/skytwin/blob/main/docs/demo.md">operator script</a> behind it</li>
+        <li><a href="privacy.html">Privacy policy</a> · <a href="terms.html">Terms of service</a></li>
+      </ul>
+    </section>
 
-    <footer>
-      <p>SkyTwin is an open-source personal automation project by <a href="https://github.com/jayzalowitz">Jay Zalowitz</a>. Source code is licensed under Apache 2.0.</p>
-      <p>Questions, security disclosures, or feedback: open an issue on <a href="https://github.com/jayzalowitz/skytwin/issues">GitHub</a>.</p>
-      <p>Last updated: 2026-05-22.</p>
-    </footer>
-  </div>
+    <section class="wrap">
+      <h2>Install</h2>
+      <p class="section-lede">Grab the desktop installer (<code>.dmg</code> / <code>.exe</code> / <code>.AppImage</code> / <code>.deb</code> / <code>.rpm</code>) from <a href="https://github.com/jayzalowitz/skytwin/releases/latest">the latest release</a>. The app keeps itself current — it checks for updates in the background and offers a one-click restart when one's ready. Or build from source in one command on macOS / Linux / WSL:</p>
+      <pre class="code"><code>curl -fsSL https://raw.githubusercontent.com/jayzalowitz/skytwin/main/install.sh | bash</code></pre>
+      <p style="color:var(--text-dim);font-size:.88rem;margin-top:.8rem;">Beta builds aren't code-signed yet, so macOS Gatekeeper / Windows SmartScreen will warn on first launch — right-click → Open (macOS) or More info → Run anyway (Windows). Signing is in progress.</p>
+    </section>
+
+    <section class="wrap">
+      <h2>How this stays alive</h2>
+      <p class="section-lede"><strong>Free and open source forever for personal use.</strong> Future Team and Hosted tiers are planned for organizations that need shared policies, audit logs, or managed infrastructure — personal features will never be paywalled. No prices today: overpromising on a backlog we haven't shipped is the easiest trust to lose. Want one of the upcoming tiers? <a href="https://github.com/jayzalowitz/skytwin/issues">Open an issue</a> describing what your org needs and help shape what ships.</p>
+    </section>
+  </main>
+
+  <footer class="wrap">
+    <p>SkyTwin is an open-source personal-automation project by <a href="https://github.com/jayzalowitz">Jay Zalowitz</a>, licensed Apache 2.0.</p>
+    <p>Questions, security disclosures, or feedback: <a href="https://github.com/jayzalowitz/skytwin/issues">open an issue on GitHub</a>.</p>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
Rebuilds the GitHub Pages home (https://jayzalowitz.github.io/skytwin/) into a cohesive, current landing page. It was a modest OAuth-review page (off-brand purple, system fonts, no demo link, no screenshots, stale copy); now it shares the DESIGN.md design system with `demo.html` so the Pages site reads as one product.

**What's new:**
- Hero + the "it acts, it doesn't chat" thesis; primary CTAs: **Download** (releases/latest), **See the 5-minute demo** (→ `demo.html`, finally linked), View source.
- Accurate current product story — Inbox-Intelligence briefing (act vs FYI, cited), explained decisions, trust tiers + spend limits + pause/delete, local-first (embedded CRDB + local LLM, on-disk token encryption, #375 prompt redaction), background auto-update (#370). All claims map to shipped code.
- Four product screenshots (the regenerated iris-UI shots) + a demo callout.

**Preserved** the Google OAuth scopes table + privacy/terms links (load-bearing for #351 verification), restyled into the new system.

**Validated** (Pages serves on merge): self-contained — no external font fetch, no JS, no inline handlers; all 9 local refs resolve. 🤖 Generated with [Claude Code](https://claude.com/claude-code)