### PR TITLE
v0.6.99.0 fix: complete demo QA followups

### DIFF
--- a/apps/api/src/__tests__/about-me-adaptive.test.ts
+++ b/apps/api/src/__tests__/about-me-adaptive.test.ts
@@ -99,8 +99,9 @@ describe('GET /about-me — J: self-portrait', () => {
     expect((res.body as { modelVersion: string }).modelVersion).toBe('stub-v0');
   });
 
-  // 3. LLM throws → placeholder fallback
-  it('returns placeholder when LLM throws', async () => {
+  // 3. LLM throws WITH facts present → deterministic portrait fallback
+  //    (facts exist, so it's a real deterministic-v1 portrait, not the empty stub-v0).
+  it('returns deterministic portrait when LLM throws and facts are present', async () => {
     const mockLlm = {
       hasProviders: true,
       generate: vi.fn().mockRejectedValue(new Error('timeout')),
@@ -118,7 +119,7 @@ describe('GET /about-me — J: self-portrait', () => {
     const app = buildApp();
     const res = await request(app, 'GET', '/api/about-me');
     expect(res.status).toBe(200);
-    expect((res.body as { modelVersion: string }).modelVersion).toBe('stub-v0');
+    expect((res.body as { modelVersion: string }).modelVersion).toBe('deterministic-v1');
   });
 
   // 4. POST /correct hard rail: always writes provenance node

--- a/apps/api/src/__tests__/capabilities-routes.test.ts
+++ b/apps/api/src/__tests__/capabilities-routes.test.ts
@@ -230,6 +230,32 @@ describe('Capabilities API routes', () => {
       expect(body.server.display_name).toBe('Filesystem');
     });
 
+    it('redacts command/args/env/url/token from the detail response', async () => {
+      const server = makeMcpServer();
+      Object.assign(server, {
+        command: '/usr/bin/npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem'],
+        env: { API_KEY: 'super-secret-value' },
+        url: 'https://user:pass@example.com/mcp?token=abc',
+        oauth_token_id: 'tok-123',
+      });
+      mockMcpServerRepository.getById.mockResolvedValue(server);
+
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'GET', `/api/capabilities/${SERVER_ID}`);
+
+      expect(res.status).toBe(200);
+      const srv = (res.body as { server: Record<string, unknown> }).server;
+      for (const field of ['command', 'args', 'env', 'url', 'oauth_token_id']) {
+        expect(srv).not.toHaveProperty(field);
+      }
+      // The secret value must not leak anywhere in the payload.
+      expect(JSON.stringify(res.body)).not.toContain('super-secret-value');
+      // Safe display metadata is still returned.
+      expect(srv.display_name).toBe('Filesystem');
+      expect(srv.trust_tier).toBeDefined();
+    });
+
     it('does not expose a capability owned by another user', async () => {
       const OTHER_USER = 'cccccccc-dddd-eeee-ffff-000000000099';
       mockMcpServerRepository.getById.mockResolvedValue(makeMcpServer({ user_id: OTHER_USER }));

--- a/apps/api/src/__tests__/capabilities-routes.test.ts
+++ b/apps/api/src/__tests__/capabilities-routes.test.ts
@@ -214,6 +214,105 @@ describe('Capabilities API routes', () => {
   });
 
   // =========================================================================
+  // GET /:id, /:id/skills, /:id/policy
+  // =========================================================================
+  describe('capability detail routes', () => {
+    it('returns a single owned capability server for the detail page', async () => {
+      const server = makeMcpServer();
+      mockMcpServerRepository.getById.mockResolvedValue(server);
+
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'GET', `/api/capabilities/${SERVER_ID}`);
+
+      expect(res.status).toBe(200);
+      const body = res.body as { server: { id: string; display_name: string } };
+      expect(body.server.id).toBe(SERVER_ID);
+      expect(body.server.display_name).toBe('Filesystem');
+    });
+
+    it('does not expose a capability owned by another user', async () => {
+      const OTHER_USER = 'cccccccc-dddd-eeee-ffff-000000000099';
+      mockMcpServerRepository.getById.mockResolvedValue(makeMcpServer({ user_id: OTHER_USER }));
+
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'GET', `/api/capabilities/${SERVER_ID}`);
+
+      expect(res.status).toBe(403);
+    });
+
+    it('returns cached skills for the capability detail page', async () => {
+      mockMcpServerRepository.getById.mockResolvedValue(makeMcpServer());
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            skill_name: 'read_file',
+            skill_description: 'Read a file',
+            is_destructive: false,
+            is_irreversible: false,
+            estimated_cost_cents: 0,
+          },
+        ],
+        rowCount: 1,
+      });
+
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'GET', `/api/capabilities/${SERVER_ID}/skills`);
+
+      expect(res.status).toBe(200);
+      const body = res.body as { skills: Array<{ skill_name: string }> };
+      expect(body.skills[0]!.skill_name).toBe('read_file');
+    });
+
+    it('returns per-capability policy values from the server row', async () => {
+      mockMcpServerRepository.getById.mockResolvedValue({
+        ...makeMcpServer(),
+        per_app_spend_per_action_cents: 500,
+        per_app_daily_spend_cents: 2500,
+        per_app_monthly_spend_cents: 10000,
+      });
+
+      const app = buildApp(USER_ID);
+      const res = await request(app, 'GET', `/api/capabilities/${SERVER_ID}/policy`);
+
+      expect(res.status).toBe(200);
+      const body = res.body as { policy: { perAppSpendPerActionCents: number; perAppDailySpendCents: number } };
+      expect(body.policy.perAppSpendPerActionCents).toBe(500);
+      expect(body.policy.perAppDailySpendCents).toBe(2500);
+    });
+
+    it('updates only the spend caps supplied by the detail page', async () => {
+      mockMcpServerRepository.getById.mockResolvedValue(makeMcpServer());
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            ...makeMcpServer(),
+            per_app_spend_per_action_cents: 1200,
+            per_app_daily_spend_cents: null,
+          },
+        ],
+        rowCount: 1,
+      });
+
+      const app = buildApp(USER_ID);
+      const res = await request(
+        app,
+        'PUT',
+        `/api/capabilities/${SERVER_ID}/policy`,
+        { perAppSpendPerActionCents: 1200, perAppDailySpendCents: null },
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE mcp_servers'),
+        [SERVER_ID, true, 1200, true, null, USER_ID],
+      );
+      const body = res.body as { policy: { perAppSpendPerActionCents: number; perAppDailySpendCents: null } };
+      expect(body.policy.perAppSpendPerActionCents).toBe(1200);
+      expect(body.policy.perAppDailySpendCents).toBeNull();
+    });
+  });
+
+  // =========================================================================
   // POST /:id/uninstall
   // =========================================================================
   describe('POST /:id/uninstall', () => {

--- a/apps/api/src/routes/about-me.ts
+++ b/apps/api/src/routes/about-me.ts
@@ -99,6 +99,53 @@ const PLACEHOLDER_PARAGRAPH: SelfPortraitParagraph = {
   citations: [],
 };
 
+function humanTier(tier: string): string {
+  const labels: Record<string, string> = {
+    observer: 'just watch',
+    suggest: 'ask first',
+    low_autonomy: 'handle small routine tasks',
+    moderate_autonomy: 'handle most familiar tasks',
+    high_autonomy: 'high autonomy',
+  };
+  return labels[tier] ?? tier.replace(/_/g, ' ');
+}
+
+function buildDeterministicPortrait(
+  facts: Awaited<ReturnType<typeof aggregateUserFacts>>,
+): SelfPortraitParagraph[] {
+  if (facts.installedCapabilities.length === 0 && facts.recentActions.length === 0) {
+    return [PLACEHOLDER_PARAGRAPH];
+  }
+
+  const capabilitySummary = facts.installedCapabilities.length > 0
+    ? facts.installedCapabilities
+        .slice(0, 4)
+        .map((c) => `${c.name} (${humanTier(c.trustTier)})`)
+        .join(', ')
+    : 'a small set of connected tools';
+
+  const actionCount = facts.recentActions.filter((a) => a.nodeType === 'action').length;
+  const installCount = facts.recentActions.filter((a) => a.nodeType === 'install').length;
+  const promotionCount = facts.tierPromotions.length;
+
+  return [
+    {
+      text: `You prefer useful autonomy with visible guardrails. Your active capabilities are ${capabilitySummary}, which means your twin can help across communication and work tools while still treating unfamiliar or higher-risk work as something that needs your review.`,
+      citations: [],
+    },
+    {
+      text: `The recent audit trail shows ${actionCount} capability action${actionCount === 1 ? '' : 's'} and ${installCount} install event${installCount === 1 ? '' : 's'}. That points to a twin that is already doing routine background work, while keeping an audit trail you can inspect and correct.`,
+      citations: [],
+    },
+    {
+      text: promotionCount > 0
+        ? `Your trust settings are changing gradually instead of jumping straight to autopilot. Recent promotion history shows the system waits for repeated approvals before widening what it can do on its own.`
+        : `Your trust settings are set up to grow gradually. The system should ask before spending money, sending sensitive messages, or taking actions that would be hard to undo.`,
+      citations: [],
+    },
+  ];
+}
+
 export function createAboutMeRouter(): Router {
   const router = Router();
 
@@ -120,11 +167,10 @@ export function createAboutMeRouter(): Router {
         return;
       }
 
+      const userFacts = await aggregateUserFacts(userId);
       const llmClient = getLlmClientFromConfig();
       if (llmClient) {
         try {
-          const userFacts = await aggregateUserFacts(userId);
-
           // Only call the LLM if we have meaningful facts to portrait
           const hasFacts =
             userFacts.installedCapabilities.length > 0 ||
@@ -160,11 +206,12 @@ export function createAboutMeRouter(): Router {
         }
       }
 
-      // Deterministic fallback: placeholder paragraph
       res.json({
-        paragraphs: [PLACEHOLDER_PARAGRAPH],
+        paragraphs: buildDeterministicPortrait(userFacts),
         generatedAt: new Date().toISOString(),
-        modelVersion: 'stub-v0',
+        modelVersion: userFacts.installedCapabilities.length > 0 || userFacts.recentActions.length > 0
+          ? 'deterministic-v1'
+          : 'stub-v0',
       });
     } catch (err) {
       next(err);

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -122,14 +122,14 @@ export function createActivityRouter(): Router {
       if (decisions.status === 'fulfilled') {
         for (const d of decisions.value) {
           const ts = (d.created_at ?? since).getTime();
+          const interpretedSummary = typeof d.interpreted_situation?.['summary'] === 'string'
+            ? d.interpreted_situation['summary']
+            : null;
           events.push({
             id: `dec:${d.id}`,
             kind: 'decision',
             at: new Date(ts).toISOString(),
-            // DecisionRow has no `summary` column — synthesise one from
-            // situation_type + domain. The future UI can fetch the
-            // ExplanationRecord via decisionId for the rich copy.
-            summary: `${d.situation_type ?? 'decision'} (${d.domain ?? 'unknown'})`,
+            summary: interpretedSummary ?? `${d.situation_type ?? 'decision'} (${d.domain ?? 'unknown'})`,
             domain: d.domain ?? null,
             decisionId: d.id,
             _ts: ts,

--- a/apps/api/src/routes/capabilities.ts
+++ b/apps/api/src/routes/capabilities.ts
@@ -140,6 +140,62 @@ export function buildEvidencePreview(signal: Record<string, unknown>): EvidenceP
 // RegistryClient reads curated.json on construction; constructing once
 // avoids re-parsing the file on every request.
 const registryClient = new RegistryClient();
+function getCapabilityUserId(req: Request): string | undefined {
+  return (req as unknown as { user?: { id?: string } }).user?.id
+    ?? (req.query['userId'] as string | undefined);
+}
+
+async function getOwnedCapabilityServer(
+  id: string,
+  userId: string,
+): Promise<{ status: 200; server: McpServerRow } | { status: 403 | 404; error: string }> {
+  const server = await mcpServerRepository.getById(id);
+  if (!server || server.status === 'uninstalled') {
+    return { status: 404, error: 'Capability server not found' };
+  }
+  if (server.user_id !== userId) {
+    return { status: 403, error: 'Forbidden: you do not own this capability server' };
+  }
+  return { status: 200, server };
+}
+
+function parseOptionalCents(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return undefined;
+  return Math.round(value);
+}
+
+function nullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function serializeCapabilityServer(server: McpServerRow): McpServerRow {
+  return {
+    ...server,
+    per_app_spend_per_action_cents: nullableNumber(server.per_app_spend_per_action_cents),
+    per_app_daily_spend_cents: nullableNumber(server.per_app_daily_spend_cents),
+    per_app_monthly_spend_cents: nullableNumber(server.per_app_monthly_spend_cents),
+  };
+}
+
+function serializeCapabilityPolicy(server: McpServerRow): Record<string, unknown> {
+  return {
+    perAppSpendPerActionCents: nullableNumber(server.per_app_spend_per_action_cents),
+    perAppDailySpendCents: nullableNumber(server.per_app_daily_spend_cents),
+    perAppMonthlySpendCents: nullableNumber(server.per_app_monthly_spend_cents),
+    perAppMonthlyRollover: server.per_app_monthly_rollover,
+    perAppIrreversibleRequiresApproval: server.per_app_irreversible_requires_approval,
+    zeroTrustMode: server.zero_trust_mode,
+    trustTier: server.trust_tier,
+  };
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Hardcoded recipes (v1). Each recipe bundles a set of registry IDs that a
@@ -277,6 +333,142 @@ async function writeProvenanceNode(opts: {
  */
 export function createCapabilitiesRouter(): Router {
   const router = Router();
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GET /:id/skills
+  // Returns cached MCP tool names and descriptions for the capability detail
+  // page. This is read-only and scoped by server ownership.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.get('/:id/skills', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      const userId = getCapabilityUserId(req);
+      if (!id || !UUID_REGEX.test(id)) {
+        res.status(400).json({ error: 'id path param must be a UUID' });
+        return;
+      }
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const owned = await getOwnedCapabilityServer(id, userId);
+      if (owned.status !== 200) {
+        res.status(owned.status).json({ error: owned.error });
+        return;
+      }
+
+      const result = await query<{
+        skill_name: string;
+        skill_description: string | null;
+        is_destructive: boolean;
+        is_irreversible: boolean;
+        estimated_cost_cents: number | null;
+      }>(
+        `SELECT skill_name, skill_description, is_destructive, is_irreversible, estimated_cost_cents
+         FROM mcp_server_skills
+         WHERE server_id = $1
+         ORDER BY skill_name`,
+        [id],
+      );
+
+      res.json({ skills: result.rows });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GET/PUT /:id/policy
+  // Per-capability spend caps live on mcp_servers. The detail page reads and
+  // writes only these local overrides; omitted fields preserve existing values.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.get('/:id/policy', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      const userId = getCapabilityUserId(req);
+      if (!id || !UUID_REGEX.test(id)) {
+        res.status(400).json({ error: 'id path param must be a UUID' });
+        return;
+      }
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const owned = await getOwnedCapabilityServer(id, userId);
+      if (owned.status !== 200) {
+        res.status(owned.status).json({ error: owned.error });
+        return;
+      }
+
+      res.json({ policy: serializeCapabilityPolicy(owned.server) });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.put('/:id/policy', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      const userId = getCapabilityUserId(req);
+      if (!id || !UUID_REGEX.test(id)) {
+        res.status(400).json({ error: 'id path param must be a UUID' });
+        return;
+      }
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const owned = await getOwnedCapabilityServer(id, userId);
+      if (owned.status !== 200) {
+        res.status(owned.status).json({ error: owned.error });
+        return;
+      }
+
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const perAction = parseOptionalCents(body['perAppSpendPerActionCents']);
+      const perDay = parseOptionalCents(body['perAppDailySpendCents']);
+      if (
+        (body['perAppSpendPerActionCents'] !== undefined && perAction === undefined) ||
+        (body['perAppDailySpendCents'] !== undefined && perDay === undefined)
+      ) {
+        res.status(400).json({ error: 'Spend caps must be non-negative cents or null' });
+        return;
+      }
+
+      const result = await query<McpServerRow>(
+        `UPDATE mcp_servers
+         SET per_app_spend_per_action_cents = CASE WHEN $2 THEN $3 ELSE per_app_spend_per_action_cents END,
+             per_app_daily_spend_cents      = CASE WHEN $4 THEN $5 ELSE per_app_daily_spend_cents END,
+             updated_at = now()
+         WHERE id = $1 AND user_id = $6
+         RETURNING *`,
+        [
+          id,
+          body['perAppSpendPerActionCents'] !== undefined,
+          perAction ?? null,
+          body['perAppDailySpendCents'] !== undefined,
+          perDay ?? null,
+          userId,
+        ],
+      );
+
+      const updated = result.rows[0];
+      if (!updated) {
+        res.status(404).json({ error: 'Capability server not found' });
+        return;
+      }
+
+      res.json({
+        ok: true,
+        policy: serializeCapabilityPolicy(updated),
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
 
   // ─────────────────────────────────────────────────────────────────────────
   // POST /:id/uninstall
@@ -2080,7 +2272,36 @@ export function createCapabilitiesRouter(): Router {
     }
   });
 
+  // ─────────────────────────────────────────────────────────────────────────
+  // GET /:id
+  // Base detail route lives last because Express 5 no longer supports inline
+  // regex params. Static routes above (/suggestions, /registry, etc.) get first
+  // chance; this handler still validates that :id is a UUID before reading.
+  // ─────────────────────────────────────────────────────────────────────────
+  router.get('/:id', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      const userId = getCapabilityUserId(req);
+      if (!id || !UUID_REGEX.test(id)) {
+        res.status(400).json({ error: 'id path param must be a UUID' });
+        return;
+      }
+      if (!userId) {
+        res.status(400).json({ error: 'userId is required' });
+        return;
+      }
+
+      const owned = await getOwnedCapabilityServer(id, userId);
+      if (owned.status !== 200) {
+        res.status(owned.status).json({ error: owned.error });
+        return;
+      }
+
+      res.json({ server: serializeCapabilityServer(owned.server) });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   return router;
 }
-
-

--- a/apps/api/src/routes/capabilities.ts
+++ b/apps/api/src/routes/capabilities.ts
@@ -176,9 +176,28 @@ function nullableNumber(value: unknown): number | null {
   return null;
 }
 
-function serializeCapabilityServer(server: McpServerRow): McpServerRow {
+/**
+ * Fields that must never reach the client: the raw process invocation
+ * (command/args), environment variables (may hold API keys / secrets), the raw
+ * server URL (may embed inline credentials or tokens), and the vault token
+ * reference. GET /:id previously spread the whole mcp_servers row (Copilot
+ * review), leaking all of these. The capability UI only consumes display
+ * metadata + spend limits, so redact the sensitive fields here.
+ */
+type RedactedCapabilityServer = Omit<
+  McpServerRow,
+  'command' | 'args' | 'env' | 'url' | 'oauth_token_id'
+>;
+
+function serializeCapabilityServer(server: McpServerRow): RedactedCapabilityServer {
+  const safe: Partial<McpServerRow> = { ...server };
+  delete safe.command;
+  delete safe.args;
+  delete safe.env;
+  delete safe.url;
+  delete safe.oauth_token_id;
   return {
-    ...server,
+    ...(safe as RedactedCapabilityServer),
     per_app_spend_per_action_cents: nullableNumber(server.per_app_spend_per_action_cents),
     per_app_daily_spend_cents: nullableNumber(server.per_app_daily_spend_cents),
     per_app_monthly_spend_cents: nullableNumber(server.per_app_monthly_spend_cents),

--- a/apps/api/src/routes/decisions.ts
+++ b/apps/api/src/routes/decisions.ts
@@ -79,6 +79,9 @@ export function createDecisionsRouter(): Router {
             situationType: d.situation_type,
             domain: d.domain,
             urgency: d.urgency,
+            summary: typeof d.interpreted_situation?.['summary'] === 'string'
+              ? d.interpreted_situation['summary']
+              : null,
             autoExecuted: outcome ? outcome.auto_executed : null,
             requiresApproval: outcome ? outcome.requires_approval === true : false,
             createdAt: d.created_at,

--- a/apps/web/public/js/pages/capability-detail.js
+++ b/apps/web/public/js/pages/capability-detail.js
@@ -484,7 +484,7 @@ async function loadMonthlyCostMeter(serverId, userId, server) {
     const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
     const spentCents = recent
       .filter(b => new Date(b.bucket_started_at) >= monthStart)
-      .reduce((sum, b) => sum + (b.spend_cents || 0), 0);
+      .reduce((sum, b) => sum + (Number(b.spend_cents) || 0), 0);
 
     const pct = perMonthCap > 0 ? Math.min(100, Math.round((spentCents / perMonthCap) * 100)) : 0;
     const barColor = pct >= 90 ? 'var(--danger)' : pct >= 70 ? 'var(--warning)' : 'var(--success)';

--- a/apps/web/public/js/pages/dashboard.js
+++ b/apps/web/public/js/pages/dashboard.js
@@ -666,7 +666,7 @@ export async function renderDashboard(container, userId) {
           const pending = d.autoExecuted == null;
           const verb = auto ? 'I handled' : pending ? 'I noticed' : 'You OK\'d';
           const verbColor = auto ? 'var(--success)' : pending ? 'var(--text-muted)' : 'var(--accent, #1976d2)';
-          const situation = situationLabel(d.situationType || d.situation_type);
+          const situation = d.summary || situationLabel(d.situationType || d.situation_type);
           const dom = escapeHtml(domainLabel(d.domain));
           return `
             <div class="activity-item">
@@ -783,4 +783,3 @@ export async function renderDashboard(container, userId) {
     window._skytwinFirstScanStartedAt = null;
   }
 }
-

--- a/apps/web/public/js/pages/decisions.js
+++ b/apps/web/public/js/pages/decisions.js
@@ -161,7 +161,7 @@ export async function renderDecisions(container, userId) {
                   <tr class="decision-row" style="cursor: pointer;" data-action="toggle-explanation" data-decision-id="${escapeHtml(d.id)}">
                     <td>${formatTime(d.createdAt || d.created_at)}</td>
                     <td><span class="badge badge-info">${escapeHtml(domainLabel(d.domain))}</span></td>
-                    <td>${escapeHtml(situationLabel(d.situationType || d.situation_type))}</td>
+                    <td>${escapeHtml(d.summary || situationLabel(d.situationType || d.situation_type))}</td>
                     <td><span class="badge badge-${urgencyBadge(d.urgency)}">${escapeHtml(d.urgency || '--')}</span></td>
                     <td>${d.autoExecuted === true
                       ? '<span class="badge badge-accent" title="Your twin handled this automatically">Auto</span>'

--- a/packages/db/src/seeds/demo-showcase.ts
+++ b/packages/db/src/seeds/demo-showcase.ts
@@ -425,6 +425,29 @@ async function seedAlexProfileSurfaces(client: Db): Promise<void> {
      ON CONFLICT (id) DO UPDATE SET reason = EXCLUDED.reason, offered_at = EXCLUDED.offered_at, responded_at = NULL, response = NULL`,
     [id('db', 1), DEMO_ALEX_ID, github],
   );
+
+  await client.query(
+    `INSERT INTO user_risk_profiles (user_id, profile_text, interpreted_caps, last_interpreted_at, last_model_version)
+     VALUES ($1, $2, $3::jsonb, now() - INTERVAL '1 hour', 'demo-seed-v1')
+     ON CONFLICT (user_id) DO UPDATE SET
+       profile_text = EXCLUDED.profile_text,
+       interpreted_caps = EXCLUDED.interpreted_caps,
+       last_interpreted_at = EXCLUDED.last_interpreted_at,
+       last_model_version = EXCLUDED.last_model_version,
+       updated_at = now()`,
+    [
+      DEMO_ALEX_ID,
+      'I like my twin to handle boring, reversible work without interrupting me: archive newsletters, file receipts, summarize routine threads, and accept obvious calendar updates. Ask before sending external email, spending more than $50, changing security settings, paying invoices, or touching anything irreversible. Keep sensitive work local when possible.',
+      JSON.stringify({
+        spend_limit_per_action_cents: 5000,
+        daily_spend_limit_cents: 15000,
+        auto_approve_domains: ['email_triage', 'document_management', 'calendar_low_risk'],
+        escalate_domains: ['finance', 'security', 'external_email_send', 'irreversible_actions'],
+        boldness: 'moderate',
+        raw_notes: 'Demo-seeded from Alex autonomy preferences.',
+      }),
+    ],
+  );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds capability detail, skills, and policy endpoints with ownership checks so the Capability Details page loads real data.
- Adds a deterministic About Me fallback portrait for demo profiles when no LLM is configured.
- Uses decision summaries across Decisions, Dashboard, and Activity instead of generic labels.
- Fixes Capability Details monthly-spend math and seeds a richer demo risk profile.

## Verification
- `pnpm --filter @skytwin/api test -- src/__tests__/capabilities-routes.test.ts` (30 tests passed)
- `pnpm --filter @skytwin/api build`
- `pnpm --filter @skytwin/web build`
- `pnpm --filter @skytwin/db build`
- `pnpm build --concurrency=1`
- `git diff --check`
- Manual browser QA: Capability Details, About Me, Decisions, Activity, and Capability spend all render the intended demo content.

## Notes
- Branch was recreated from current `origin/main` so this PR contains only the demo QA followups.
- Release metadata is unchanged because the version helper reports pre-existing `VERSION` / root `package.json` drift on `main`.
